### PR TITLE
ci: smart path filtering + CI Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  filter:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      bot: ${{ steps.changes.outputs.bot }}
+      dashboard: ${{ steps.changes.outputs.dashboard }}
+      docker: ${{ steps.changes.outputs.docker }}
+      wizard: ${{ steps.changes.outputs.wizard }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            bot:
+              - 'src/**'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+              - 'tsconfig.*.json'
+            dashboard:
+              - 'dashboard-ui/**'
+            docker:
+              - 'src/**'
+              - 'dashboard-ui/**'
+              - 'Dockerfile'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'tsconfig.json'
+            wizard:
+              - 'wizard/**'
+
   test:
     name: Type-check & Test
+    needs: filter
+    if: needs.filter.outputs.bot == 'true'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -43,6 +77,9 @@ jobs:
         run: npx tsx --test 'src/__tests__/dashboard/**/*.test.ts'
 
   dashboard-build:
+    name: dashboard-build
+    needs: filter
+    if: needs.filter.outputs.dashboard == 'true'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -60,6 +97,8 @@ jobs:
 
   docker-build:
     name: Docker Build Validation
+    needs: filter
+    if: needs.filter.outputs.docker == 'true'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -82,6 +121,8 @@ jobs:
 
   wizard-check:
     name: Wizard Type-check & Test
+    needs: filter
+    if: needs.filter.outputs.wizard == 'true'
     runs-on: ubuntu-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
@@ -118,3 +159,23 @@ jobs:
       - name: Run wizard tests
         if: steps.check.outputs.exists == 'true'
         run: cd wizard && npm test
+
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    needs: [test, dashboard-build, docker-build, wizard-check]
+    if: always()
+    steps:
+      - name: All checks passed or skipped
+        env:
+          NEEDS_RESULTS: ${{ toJson(needs) }}
+        run: |
+          echo "$NEEDS_RESULTS" | jq -e '
+            to_entries | all(
+              .value.result == "success" or
+              .value.result == "skipped"
+            )
+          ' && echo "All CI jobs passed or were skipped." || {
+            echo "One or more required CI jobs failed or were cancelled."
+            exit 1
+          }

--- a/.github/workflows/deploy-landing.yml
+++ b/.github/workflows/deploy-landing.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'landing/**'
+      - 'README.md'
+      - 'package.json'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

- Adds `dorny/paths-filter` as a first job to detect which artifact-related paths changed
- Each CI job now runs conditionally — only when its relevant files change
- Adds a `ci-gate` job (always runs) that becomes the **single required status check**
- Adds `paths:` filter to `deploy-landing.yml` so landing deploys only trigger on relevant changes

## Path → Job mapping

| Files changed | Jobs that run |
|---|---|
| `src/**`, `package.json`, `tsconfig.json` | test, docker-build |
| `dashboard-ui/**` | dashboard-build, docker-build |
| `wizard/**` | wizard-check |
| `Dockerfile` | docker-build |
| `README.md`, `landing/**` | (none — only deploy-landing) |
| Everything else (docs, `.claude/`, etc.) | (none — ci-gate passes in ~30s) |

## After merging

Update branch protection to require only `CI Gate` instead of the 4 individual checks:

```bash
gh api repos/yonatan2021/pikud-haoref-bot/branches/main/protection/required_status_checks \
  --method PATCH \
  --field strict=true \
  --field 'checks[][context]=CI Gate' \
  --field 'checks[][app_id]=15368'
```

## Test plan

- [ ] Merge this PR → verify CI Gate appears as a check in GitHub
- [ ] Update branch protection to require only `CI Gate`
- [ ] Push a docs-only commit directly to `main` → only filter + ci-gate run (~30s)
- [ ] Push a `src/` change → test + docker-build run, dashboard-build skipped
- [ ] Introduce a TypeScript error → test fails → ci-gate fails → merge blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)