### PR TITLE
fix: correct supergroup/channel/group chat type classification

### DIFF
--- a/src/telegram-listener/telegramListenerClient.ts
+++ b/src/telegram-listener/telegramListenerClient.ts
@@ -72,8 +72,8 @@ async function refreshKnownChats(db: Database.Database): Promise<void> {
         if (entityType !== 'Chat' && entityType !== 'Channel') continue;
 
         const isChannel = entityType === 'Channel';
-        const isGroup = !isChannel || (entity as { megagroup?: boolean }).megagroup;
-        const chatType = isChannel && !isGroup ? 'channel' : isGroup ? 'group' : 'supergroup';
+        const megagroup = !!(entity as { megagroup?: boolean }).megagroup;
+        const chatType = isChannel ? (megagroup ? 'supergroup' : 'channel') : 'group';
 
         const rawId = entity.id;
         // Convert to signed 64-bit Telegram chat ID format


### PR DESCRIPTION
## Problem

The ternary for chat type classification had an unreachable \`'supergroup'\` case.

For a megagroup channel (\`isChannel=true\`, \`megagroup=true\`):
- \`isGroup = !isChannel || megagroup = !true || true = true\`
- \`isChannel && !isGroup = false\` → skip first branch
- \`isGroup ? 'group' : ...\` → returns **\`'group'\`** incorrectly

Supergroups were stored as \`'group'\` in \`telegram_known_chats\`, showing the wrong badge in the dashboard.

## Fix

\`\`\`diff
- const isGroup = !isChannel || (entity as { megagroup?: boolean }).megagroup;
- const chatType = isChannel && !isGroup ? 'channel' : isGroup ? 'group' : 'supergroup';
+ const megagroup = !!(entity as { megagroup?: boolean }).megagroup;
+ const chatType = isChannel ? (megagroup ? 'supergroup' : 'channel') : 'group';
\`\`\`

## Test plan

- [x] \`npm test\` — 762 tests pass, 0 failures
- [ ] Supergroup entities now correctly stored with \`chat_type = 'supergroup'\`