### PR TITLE
fix: add isInitializing guard to startPhoneAuth and validate env vars at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,12 @@ for (const envVar of REQUIRED_ENV_VARS) {
   const bot = getBot();
   await setupBotHandlers(bot);
 
+  if (process.env.TELEGRAM_LISTENER_ENABLED === 'true') {
+    for (const key of ['TELEGRAM_API_ID', 'TELEGRAM_API_HASH']) {
+      if (!process.env[key]) throw new Error(`${key} is required when TELEGRAM_LISTENER_ENABLED=true`);
+    }
+  }
+
   try {
     if (process.env.TELEGRAM_LISTENER_ENABLED === 'true') {
       await initializeTelegramListener(getDb(), bot);

--- a/src/telegram-listener/telegramListenerClient.ts
+++ b/src/telegram-listener/telegramListenerClient.ts
@@ -203,6 +203,7 @@ export async function startPhoneAuth(
   phone: string
 ): Promise<{ phoneCodeHash: string }> {
   if (isDisconnecting) throw new Error('מתנתק כרגע — נסה שוב בעוד רגע');
+  if (isInitializing) throw new Error('אתחול מתבצע כרגע — נסה שוב בעוד רגע');
 
   const { apiId, apiHash } = getApiCredentials();
   const session = new StringSession('');


### PR DESCRIPTION
## Problems Fixed

### 1. Race condition in startPhoneAuth() (CRITICAL)

\`startPhoneAuth()\` had no guard against concurrent calls with \`initialize()\`.
If both ran simultaneously, two \`TelegramClient\` instances would fight over
the shared module-level \`client\` variable.

Fix: throw early if \`isInitializing\` is \`true\`.

\`\`\`diff
  if (isDisconnecting) throw new Error('מתנתק כרגע — נסה שוב בעוד רגע');
+ if (isInitializing) throw new Error('אתחול מתבצע כרגע — נסה שוב בעוד רגע');
\`\`\`

### 2. Silent startup failure when env vars missing (MEDIUM)

When \`TELEGRAM_LISTENER_ENABLED=true\` but \`TELEGRAM_API_ID\` or \`TELEGRAM_API_HASH\` were missing, the app started normally and only failed later — making the error hard to diagnose.

Fix: validate both vars at startup, throw a clear error immediately.

## Test plan

- [x] \`npm test\` — 762 tests pass, 0 failures
- [ ] Starting with \`TELEGRAM_LISTENER_ENABLED=true\` and missing vars → immediate clear error