### PR TITLE
fix: guard against missing TELEGRAM_CHAT_ID in telegram listener service

### DIFF
--- a/src/telegram-listener/telegramListenerService.ts
+++ b/src/telegram-listener/telegramListenerService.ts
@@ -68,7 +68,11 @@ export function createMessageHandler(
       if (listeners.length === 0) return;
 
       const targetChatId =
-        process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID']!;
+        process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID'];
+      if (!targetChatId) {
+        log('error', 'TG Listener', 'TELEGRAM_FORWARD_GROUP_ID or TELEGRAM_CHAT_ID not configured');
+        return;
+      }
 
       const truncatedBody =
         msg.body.length > MESSAGE_BODY_MAX


### PR DESCRIPTION
## Problem

\`telegramListenerService.ts\` used a non-null assertion on \`TELEGRAM_CHAT_ID\`:

\`\`\`typescript
const targetChatId = process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID']!;
\`\`\`

If both env vars are unset, \`targetChatId\` is \`undefined\` and \`bot.api.sendMessage(undefined, ...)\` throws a runtime error.

## Fix

\`\`\`diff
- const targetChatId =
-   process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID']!;
+ const targetChatId =
+   process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID'];
+ if (!targetChatId) {
+   log('error', 'TG Listener', 'TELEGRAM_FORWARD_GROUP_ID or TELEGRAM_CHAT_ID not configured');
+   return;
+ }
\`\`\`

## Test plan

- [x] \`npm test\` — 762 tests pass, 0 failures
- [ ] Missing env vars → logs error and returns, no throw