### PR TITLE
fix: pass update_time from privacy defaults when creating new contacts

### DIFF
--- a/src/bot/connectHandler.ts
+++ b/src/bot/connectHandler.ts
@@ -62,6 +62,7 @@ interface PendingPermissionState {
   targetName: string;
   safety_status: boolean;
   home_city: boolean;
+  update_time: boolean;
   expiresAt: number;
 }
 const pendingPermissions = new Map<number, PendingPermissionState>();
@@ -315,6 +316,7 @@ export function registerConnectHandler(bot: Bot): void {
       targetName,
       safety_status: defaults.safety_status ?? true,
       home_city: defaults.home_city ?? false,
+      update_time: (defaults.update_time as boolean | undefined) ?? true,
       expiresAt: Date.now() + PENDING_PERMISSIONS_TTL_MS,
     });
 
@@ -415,6 +417,7 @@ export function registerConnectHandler(bot: Bot): void {
     const contact = createContactWithPermissions(chatId, state.targetId, {
       safety_status: state.safety_status,
       home_city: state.home_city,
+      update_time: state.update_time,
     });
 
     log('info', 'Connect', `User ${chatId} sent connection request to ${state.targetId} with permissions: safety=${state.safety_status}, city=${state.home_city}`);


### PR DESCRIPTION
## Problem

\`createContactWithPermissions\` was called without \`update_time\`, so it always defaulted to \`true\` regardless of the operator's \`/privacy\` settings.

\`PendingPermissionState\` only tracked \`safety_status\` and \`home_city\` — \`update_time\` was never stored in the pending state nor passed through to contact creation.

## Fix

1. Added \`update_time: boolean\` to \`PendingPermissionState\` interface
2. Read \`update_time\` from \`parsePrivacyDefaults()\` when initializing pending state
3. Pass \`update_time: state.update_time\` to \`createContactWithPermissions\`

\`\`\`diff
  interface PendingPermissionState {
    ...
+   update_time: boolean;
    expiresAt: number;
  }

  pendingPermissions.set(chatId, {
    ...
+   update_time: defaults.update_time ?? true,
  });

  createContactWithPermissions(chatId, state.targetId, {
    safety_status: state.safety_status,
    home_city: state.home_city,
+   update_time: state.update_time,
  });
\`\`\`

## Issues closed

Fixes #81

## Test plan

- [x] \`npm test\` — 738 tests pass, 0 failures
- [ ] \`/privacy\` → set \`update_time = ❌\` → \`/connect <code>\` → new contact has \`update_time = false\`