### PR TITLE
fix: add error handling and authorization logging in privacy callbacks

### DIFF
--- a/src/bot/privacyHandler.ts
+++ b/src/bot/privacyHandler.ts
@@ -111,7 +111,11 @@ export function registerPrivacyHandler(bot: Bot): void {
     log('info', 'Privacy', `User ${ctx.chat?.id} toggled default ${field} → ${updated[field]}`);
 
     const { text, keyboard } = buildDefaultsMessage(updated);
-    await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    try {
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('warn', 'Privacy', `editMessageText failed (message likely deleted): ${err}`);
+    }
   });
 
   // Per-contact permission view (from contacts list)
@@ -122,13 +126,20 @@ export function registerPrivacyHandler(bot: Bot): void {
     if (!contact) return;
 
     const chatId = ctx.chat?.id;
-    if (chatId !== contact.user_id && chatId !== contact.contact_id) return;
+    if (chatId !== contact.user_id && chatId !== contact.contact_id) {
+      log('warn', 'Privacy', `Unauthorized access attempt by ${chatId ?? 'unknown'} on contact ${contactId}`);
+      return;
+    }
 
     const perms = getPermissions(contactId);
     if (!perms) return;
 
     const { text, keyboard } = buildContactPermissionsMessage(contactId, perms);
-    await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    try {
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('warn', 'Privacy', `editMessageText failed (message likely deleted): ${err}`);
+    }
   });
 
   // Toggle per-contact permission
@@ -142,19 +153,32 @@ export function registerPrivacyHandler(bot: Bot): void {
     if (!contact) return;
 
     const chatId = ctx.chat?.id;
-    if (chatId !== contact.user_id && chatId !== contact.contact_id) return;
+    if (chatId !== contact.user_id && chatId !== contact.contact_id) {
+      log('warn', 'Privacy', `Unauthorized access attempt by ${chatId ?? 'unknown'} on contact ${contactId}`);
+      return;
+    }
 
     const perms = getPermissions(contactId);
     if (!perms) return;
 
     const updated: Partial<ContactPermissions> = { [field]: !perms[field] };
-    updatePermissions(contactId, updated);
+    try {
+      updatePermissions(contactId, updated);
+    } catch (err) {
+      log('error', 'Privacy', `updatePermissions failed for contact ${contactId}: ${err}`);
+      await ctx.answerCallbackQuery({ text: 'שגיאה בעדכון הגדרות', show_alert: true });
+      return;
+    }
     log('info', 'Privacy', `User ${chatId} toggled contact ${contactId} ${field} → ${!perms[field]}`);
 
     const newPerms = getPermissions(contactId);
     if (!newPerms) return;
 
     const { text, keyboard } = buildContactPermissionsMessage(contactId, newPerms);
-    await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    try {
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('warn', 'Privacy', `editMessageText failed (message likely deleted): ${err}`);
+    }
   });
 }


### PR DESCRIPTION
## Problems Fixed

### 1. Uncaught updatePermissions() exception (HIGH)

\`updatePermissions()\` throws \`Error\` when the \`contact_permissions\` row is missing. The exception propagated uncaught through grammy's callback handler, crashing the bot for that user.

Fix: wrapped in try-catch with user-facing error reply via \`answerCallbackQuery({ show_alert: true })\`.

### 2. Uncaught ctx.editMessageText() exception (HIGH)

If the Telegram message was deleted before a callback fires, \`editMessageText\` throws a Telegram API error. Also uncaught.

Fix: wrapped all \`editMessageText\` calls in try-catch with a silent warn log and return.

### 3. Silent authorization failures (HIGH)

When the auth guard fires (\`chatId !== contact.user_id && ...\`), no log was emitted — unauthorized access attempts were invisible.

Fix: added \`log('warn', 'Privacy', ...)\` at each auth guard in both \`cx:perm\` and \`cp:toggle\` handlers.

## Related issues

Related to #77 (per-contact permission editing robustness)
Related to #80 (default privacy template editing robustness)

## Test plan

- [x] \`npm test\` — 738 tests pass, 0 failures
- [ ] DB corruption → user sees \`שגיאה בעדכון הגדרות\` alert; bot stays up
- [ ] Deleted message → no crash, silent warn log
- [ ] Unauthorized access attempt → appears in server logs as warn