### PR TITLE
fix: replace empty .catch(() => {}) with error logging in fire-and-forget paths

### DIFF
--- a/src/telegram-listener/telegramListenerClient.ts
+++ b/src/telegram-listener/telegramListenerClient.ts
@@ -355,7 +355,9 @@ function attachMessageListener(db: Database.Database): void {
   }, new NewMessage({}));
 
   // Refresh known chats in background (non-blocking)
-  void refreshKnownChats(db);
+  refreshKnownChats(db).catch((err: unknown) => {
+    log('error', 'TG Listener', `refreshKnownChats background נכשל: ${err instanceof Error ? err.message : String(err)}`);
+  });
 }
 
 export async function initialize(db: Database.Database): Promise<void> {

--- a/src/telegram-listener/telegramListenerService.ts
+++ b/src/telegram-listener/telegramListenerService.ts
@@ -128,7 +128,9 @@ export function createMessageHandler(
               })
               .catch((err: unknown) => {
                 log('error', 'TG→TG', `שגיאה בשליחת תמונה מ-${msg.chatId}: ${err instanceof Error ? err.message : String(err)}`);
-                bot.api.sendMessage(targetChatId, caption, { parse_mode: 'HTML', ...sendOpts }).catch(() => {});
+                bot.api.sendMessage(targetChatId, caption, { parse_mode: 'HTML', ...sendOpts }).catch((fallbackErr: unknown) => {
+                  log('error', 'TG→TG', `fallback sendMessage נכשל מ-${msg.chatId}: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`);
+                });
               });
           } else {
             bot.api
@@ -137,7 +139,9 @@ export function createMessageHandler(
               })
               .catch((err: unknown) => {
                 log('error', 'TG→TG', `שגיאה בשליחת קובץ מ-${msg.chatId}: ${err instanceof Error ? err.message : String(err)}`);
-                bot.api.sendMessage(targetChatId, caption, { parse_mode: 'HTML', ...sendOpts }).catch(() => {});
+                bot.api.sendMessage(targetChatId, caption, { parse_mode: 'HTML', ...sendOpts }).catch((fallbackErr: unknown) => {
+                  log('error', 'TG→TG', `fallback sendMessage נכשל מ-${msg.chatId}: ${fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr)}`);
+                });
               });
           }
         } else {

--- a/src/whatsapp/whatsappService.ts
+++ b/src/whatsapp/whatsappService.ts
@@ -227,7 +227,9 @@ export function initialize(): void {
 
   if (client !== null) {
     log('info', 'WhatsApp', 'כבר מחובר — מרענן קבוצות');
-    refreshGroups().catch(() => {});
+    refreshGroups().catch((err: unknown) => {
+      log('warn', 'WhatsApp', `refreshGroups retry נכשל: ${err instanceof Error ? err.message : String(err)}`);
+    });
     return;
   }
 
@@ -257,7 +259,10 @@ export function initialize(): void {
     initTimeoutHandle = null;
     if (status === 'connecting') {
       log('warn', 'WhatsApp', 'אתחול פג זמן (90s) — מנתק ומאפס');
-      disconnect().catch(() => {});
+      disconnect().catch((err: unknown) => {
+        isInitializing = false;
+        log('error', 'WhatsApp', `ניתוק אחרי timeout נכשל: ${err instanceof Error ? err.message : String(err)}`);
+      });
     }
   }, 90_000);
 
@@ -294,7 +299,11 @@ export function initialize(): void {
     await refreshGroups();
     if (cachedGroups.length === 0) {
       log('info', 'WhatsApp', 'לא נמצאו קבוצות — מנסה שוב בעוד 3 שניות');
-      setTimeout(() => { refreshGroups().catch(() => {}); }, 3000);
+      setTimeout(() => {
+        refreshGroups().catch((err: unknown) => {
+          log('warn', 'WhatsApp', `refreshGroups retry נכשל: ${err instanceof Error ? err.message : String(err)}`);
+        });
+      }, 3000);
     }
   });
 


### PR DESCRIPTION
## Summary
- **telegramListenerService** (lines 131, 140): fallback `sendMessage` after photo/doc send failure was silently swallowed — forwarded messages dropped with zero log trail
- **whatsappService** (lines 230, 261, 297): three empty `.catch(() => {})` — disconnect-after-timeout and refreshGroups retries failed invisibly; `isInitializing` could get stuck `true` permanently  
- **telegramListenerClient** (line 358): `void refreshKnownChats(db)` — unhandled promise rejection risk; in Node.js 15+ this terminates the process

All three now log the error at the appropriate level (`error`/`warn`) using the existing `err instanceof Error ? err.message : String(err)` pattern already established in the codebase.

## Test plan
- [ ] `npx tsc --noEmit` — passes with 0 errors ✅
- [ ] `npx tsx --test src/__tests__/telegramListenerService.test.ts src/__tests__/whatsappService.test.ts` — 48/48 pass ✅
- [ ] Manual: trigger a WhatsApp init timeout and verify the disconnect error is now logged