### PR TITLE
fix: improve error visibility for HIGH-severity silent failures

### DIFF
--- a/src/alertHandler.ts
+++ b/src/alertHandler.ts
@@ -174,6 +174,9 @@ export async function handleNewAlert(alert: Alert, deps: AlertHandlerDeps): Prom
     // Spread original `alert` (not `finalAlert`): DM subscribers receive the incoming
     // alert's type/instructions with only the NEW cities (dmCities). `finalAlert` is
     // the merged channel state used for Telegram channel edits only.
+    if (!sentToGroup) {
+      log('warn', 'AlertHandler', `DM נשלח למרות כישלון ערוץ — type=${alert.type}, ${dmCities.length} ערים`);
+    }
     notifySubscribers({ ...alert, cities: dmCities });
   }
 

--- a/src/alertPoller.ts
+++ b/src/alertPoller.ts
@@ -58,12 +58,15 @@ export class AlertPoller extends EventEmitter {
   }
 
   private async poll(): Promise<void> {
-    await Promise.all([this.pollViaLibrary(), this.pollCitylessNewsFlash()]);
-    updateLastPollAt();
+    const results = await Promise.allSettled([this.pollViaLibrary(), this.pollCitylessNewsFlash()]);
+    const anySucceeded = results.some((r) => r.status === 'fulfilled');
+    if (anySucceeded) {
+      updateLastPollAt();
+    }
   }
 
   private pollViaLibrary(): Promise<void> {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const options: Record<string, string> = {};
       if (process.env.PROXY_URL) {
         options.proxy = process.env.PROXY_URL;
@@ -72,8 +75,8 @@ export class AlertPoller extends EventEmitter {
       pikudHaoref.getActiveAlerts(
         (err: Error | null, alerts: Alert[]) => {
           if (err) {
-            log('error', 'Poller', `שגיאה בשליפת התראות: ${err}`);
-            return resolve();
+            log('error', 'Poller', `שגיאה בשליפת התראות: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+            return reject(err);
           }
 
           const groupedAlerts = groupAlertsByType(alerts ?? []);
@@ -205,7 +208,8 @@ export class AlertPoller extends EventEmitter {
         this.emit('newAlert', { ...alert, receivedAt: Date.now() });
       }
     } catch (err) {
-      log('error', 'Poller', `שגיאה בבדיקת newsFlash ארצי: ${err}`);
+      log('error', 'Poller', `שגיאה בבדיקת newsFlash ארצי: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+      throw err;
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ for (const envVar of REQUIRED_ENV_VARS) {
       await initializeTelegramListener(getDb(), bot);
     }
   } catch (err) {
-    log('warn', 'Init', `Telegram Listener אתחול נכשל — ממשיך ללא: ${err}`);
+    log('warn', 'Init', `Telegram Listener אתחול נכשל — ממשיך ללא: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
   }
 
   // Wire WhatsApp→Telegram listener. setMessageCallback is safe to call even when

--- a/src/telegram-listener/telegramListenerClient.ts
+++ b/src/telegram-listener/telegramListenerClient.ts
@@ -279,8 +279,9 @@ function attachMessageListener(db: Database.Database): void {
       try {
         const entity = await client!.getEntity(message.peerId!);
         chatName = (entity as { title?: string }).title ?? chatId;
-      } catch {
-        // non-fatal — use chatId as fallback name
+      } catch (entityErr: unknown) {
+        // non-fatal — chatId used as fallback name
+        log('info', 'TG Listener', `getEntity נכשל עבור ${chatId}: ${entityErr instanceof Error ? entityErr.message : String(entityErr)}`);
       }
 
       // Build sender info
@@ -294,8 +295,9 @@ function attachMessageListener(db: Database.Database): void {
           const sender = await client!.getEntity(fromId);
           const s = sender as { firstName?: string; lastName?: string; username?: string };
           senderName = [s.firstName, s.lastName].filter(Boolean).join(' ') || s.username || senderId;
-        } catch {
-          // non-fatal
+        } catch (senderErr: unknown) {
+          // non-fatal — senderId used as fallback name
+          log('info', 'TG Listener', `getEntity (sender) נכשל עבור ${senderId}: ${senderErr instanceof Error ? senderErr.message : String(senderErr)}`);
         }
       }
 

--- a/src/whatsapp/whatsappBroadcaster.ts
+++ b/src/whatsapp/whatsappBroadcaster.ts
@@ -208,8 +208,8 @@ export function createBroadcaster(
                 updatedMessage = await sendFreshText(chat, text);
                 sendCount++;
               }
-            } catch {
-              // Edit failed — send fresh text as fallback
+            } catch (editErr: unknown) {
+              log('warn', 'WhatsApp', `עריכת הודעה נכשלה בקבוצה ${groupId} — שולח הודעה חדשה: ${editErr instanceof Error ? editErr.message : String(editErr)}`);
               updatedMessage = await sendFreshText(chat, text);
               sendCount++;
             }


### PR DESCRIPTION
## Summary

- **`alertPoller`** — use `err.stack ?? err.message` in error logs (template literals produce truncated "Error: message" strings, losing the stack trace); `pollViaLibrary` now rejects on callback error; `pollCitylessNewsFlash` re-throws after logging — `Promise.allSettled` only calls `updateLastPollAt()` when at least one poll source completed successfully
- **`whatsappBroadcaster`** — log edit failures (`editErr.message`) before falling back to a fresh send (previously invisible)
- **`telegramListenerClient`** — log `getEntity()` fallback failures for chat name and sender name lookup (both non-fatal but now traceable)
- **`alertHandler`** — log a warning when a DM is dispatched to subscribers despite the channel broadcast failing

## Test plan
- [x] `tsc --noEmit` passes
- [x] 57/57 tests pass in alertPoller, alertHandler, whatsappBroadcaster
- [ ] CI gate passes

Part of the full codebase audit plan — PR 4 of 11.