### PR TITLE
fix: phone number masking in logs, cookie secure flag, SQL parameterization

### DIFF
--- a/src/dashboard/auth.ts
+++ b/src/dashboard/auth.ts
@@ -85,13 +85,14 @@ export function createSessionStore(db: Database.Database, secret: string) {
       clearLoginAttempts(ip);
       const token = randomUUID();
       db.prepare(
-        `INSERT INTO sessions (token, expires_at) VALUES (?, datetime('now', '+${SESSION_TTL_DAYS} days'))`
-      ).run(token);
+        "INSERT INTO sessions (token, expires_at) VALUES (?, datetime('now', '+' || cast(? as text) || ' days'))"
+      ).run(token, SESSION_TTL_DAYS);
+      const secureCookie = process.env['DASHBOARD_SECURE_COOKIE'] === 'true' || process.env.NODE_ENV === 'production';
       res.cookie(COOKIE_NAME, token, {
         httpOnly: true,
         sameSite: 'strict',
         maxAge: SESSION_TTL_DAYS * 24 * 60 * 60 * 1000,
-        secure: process.env.NODE_ENV === 'production',
+        secure: secureCookie,
       });
       res.json({ ok: true });
     } catch (err) {

--- a/src/dashboard/routes/telegramListeners.ts
+++ b/src/dashboard/routes/telegramListeners.ts
@@ -81,7 +81,8 @@ export function createTelegramListenerRouter(
 
     try {
       const { phoneCodeHash } = await clientDeps.startPhoneAuth(db, phone);
-      log('info', 'TG Listener', `OTP נשלח ל-${phone}`);
+      const maskedPhone = phone.length > 6 ? `${phone.slice(0, 4)}****${phone.slice(-2)}` : '****';
+      log('info', 'TG Listener', `OTP נשלח ל-${maskedPhone}`);
       res.json({ phoneCodeHash });
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

- **Phone masking** — `POST /api/telegram/connect` now logs `+972****67` instead of the full phone number; raw phone numbers in log files are a PII leak if logs are shipped to an external service
- **`DASHBOARD_SECURE_COOKIE`** — new explicit env var for the cookie `Secure` flag; the previous `NODE_ENV === 'production'` check is unreliable (developers often forget to set NODE_ENV, and the cookie is silently insecure over HTTP in staging); `DASHBOARD_SECURE_COOKIE=true` works independently of NODE_ENV
- **SQL parameterization** — `SESSION_TTL_DAYS` was interpolated directly into the SQL string via a template literal; replaced with SQLite `cast(? as text) || ' days'` parameterized form; SESSION_TTL_DAYS is a constant (not user input) but leaving string interpolation in SQL trains bad habits
- `.env.example` — documents `WHATSAPP_INVITE_LINK` (was missing entirely) and `DASHBOARD_SECURE_COOKIE`

## Test plan
- [x] `tsc --noEmit` passes
- [x] 17/17 auth tests pass
- [ ] CI gate passes

Part of the full codebase audit plan — PR 6 of 11.