### PR TITLE
test: safeMassDeleteGuard unit tests + General-topic normalization

### DIFF
--- a/src/__tests__/dmQueue.test.ts
+++ b/src/__tests__/dmQueue.test.ts
@@ -1,6 +1,6 @@
-import { describe, it } from 'node:test';
+import { describe, it, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
-import { DmQueue, extractRetryAfter, validateChatId } from '../services/dmQueue.js';
+import { DmQueue, extractRetryAfter, validateChatId, _resetMassDeleteGuard, _safeMassDeleteGuard } from '../services/dmQueue.js';
 
 describe('DmQueue', () => {
   it('calls send for every enqueued task', async () => {
@@ -243,5 +243,44 @@ describe('validateChatId', () => {
 
   it('returns null for "-Infinity"', () => {
     assert.equal(validateChatId('-Infinity'), null);
+  });
+});
+
+// ─── safeMassDeleteGuard ──────────────────────────────────────────────────────
+
+describe('safeMassDeleteGuard', () => {
+  beforeEach(() => {
+    _resetMassDeleteGuard();
+  });
+
+  it('returns true for first MAX_MASS_DELETES (5) calls within the window', () => {
+    for (let i = 0; i < 5; i++) {
+      assert.equal(_safeMassDeleteGuard(), true, `call ${i + 1} should be allowed`);
+    }
+  });
+
+  it('returns false on the 6th call within the same window', () => {
+    for (let i = 0; i < 5; i++) _safeMassDeleteGuard();
+    assert.equal(_safeMassDeleteGuard(), false, '6th call within window should be blocked');
+  });
+
+  it('resets and returns true again after _resetMassDeleteGuard()', () => {
+    for (let i = 0; i < 6; i++) _safeMassDeleteGuard(); // exhaust
+    _resetMassDeleteGuard();
+    assert.equal(_safeMassDeleteGuard(), true, 'first call after reset should be allowed');
+  });
+
+  it('resets automatically when window expires (simulated via Date.now override)', () => {
+    for (let i = 0; i < 6; i++) _safeMassDeleteGuard(); // exhaust and block
+    assert.equal(_safeMassDeleteGuard(), false, 'should be blocked before time travel');
+
+    // Fast-forward time by 61 seconds — guard window should reset
+    const orig = Date.now;
+    Date.now = () => orig() + 61_000;
+    try {
+      assert.equal(_safeMassDeleteGuard(), true, 'should be allowed after window expires');
+    } finally {
+      Date.now = orig;
+    }
   });
 });

--- a/src/__tests__/telegramListenerService.test.ts
+++ b/src/__tests__/telegramListenerService.test.ts
@@ -2,7 +2,7 @@ import { describe, it, before, after, beforeEach, afterEach, mock } from 'node:t
 import assert from 'node:assert/strict';
 import Database from 'better-sqlite3';
 import { initSchema } from '../db/schema.js';
-import { createListener } from '../db/telegramListenerRepository.js';
+import { createListener, upsertKnownChat } from '../db/telegramListenerRepository.js';
 import { createMessageHandler } from '../telegram-listener/telegramListenerService.js';
 
 process.env['TELEGRAM_CHAT_ID'] = '-1001234567890';
@@ -471,5 +471,59 @@ describe('createMessageHandler — diagnostic logging (no-listener warn)', () =>
     const h = createMessageHandler(db, bot);
     // Should resolve cleanly (the warning log is side-effect, hard to assert without mocking logger)
     await assert.doesNotReject(() => h(makeMsg('-100unknown', 'hello') as any));
+  });
+});
+
+// ─── General-topic (forum topic id=1) normalization ──────────────────────────
+// In Telegram forum supergroups, the "General" topic (id=1) sends messages
+// WITHOUT replyToTopId — they arrive with topicId=null. The service must
+// normalise null → 1 for forum groups so rules with sourceTopicId=1 match.
+
+describe('createMessageHandler — General-topic normalization', () => {
+  const FORUM_CHAT_ID = '-100forum';
+
+  beforeEach(() => {
+    db.prepare('DELETE FROM telegram_listeners').run();
+    db.prepare('DELETE FROM telegram_known_chats').run();
+  });
+
+  it('isForum=true, sourceTopicId=1, topicId=null → message IS forwarded (null normalised to 1)', async () => {
+    upsertKnownChat(db, { chatId: FORUM_CHAT_ID, chatName: 'Forum', chatType: 'supergroup', isForum: true });
+    createListener(db, { ...BASE, chatId: FORUM_CHAT_ID, sourceTopicId: 1 });
+    const { bot, calls } = makeBot();
+    const h = createMessageHandler(db, bot);
+    await h(makeMsg(FORUM_CHAT_ID, 'general topic msg', { topicId: null }) as any);
+    await new Promise<void>((r) => setTimeout(r, 10));
+    assert.equal(calls.length, 1, 'should forward because null is treated as topic 1 in forum groups');
+  });
+
+  it('isForum=true, sourceTopicId=1, topicId=2 → message is NOT forwarded (different topic)', async () => {
+    upsertKnownChat(db, { chatId: FORUM_CHAT_ID, chatName: 'Forum', chatType: 'supergroup', isForum: true });
+    createListener(db, { ...BASE, chatId: FORUM_CHAT_ID, sourceTopicId: 1 });
+    const { bot, calls } = makeBot();
+    const h = createMessageHandler(db, bot);
+    await h(makeMsg(FORUM_CHAT_ID, 'topic 2 msg', { topicId: 2 }) as any);
+    await new Promise<void>((r) => setTimeout(r, 10));
+    assert.equal(calls.length, 0, 'should NOT forward — topic 2 does not match sourceTopicId 1');
+  });
+
+  it('isForum=false, sourceTopicId=1, topicId=null → message is NOT forwarded (not a forum)', async () => {
+    upsertKnownChat(db, { chatId: FORUM_CHAT_ID, chatName: 'Non-Forum', chatType: 'supergroup', isForum: false });
+    createListener(db, { ...BASE, chatId: FORUM_CHAT_ID, sourceTopicId: 1 });
+    const { bot, calls } = makeBot();
+    const h = createMessageHandler(db, bot);
+    await h(makeMsg(FORUM_CHAT_ID, 'regular group msg', { topicId: null }) as any);
+    await new Promise<void>((r) => setTimeout(r, 10));
+    assert.equal(calls.length, 0, 'should NOT forward — not a forum group so null is not normalised to 1');
+  });
+
+  it('isForum=true, sourceTopicId=null (forward all), topicId=null → message IS forwarded', async () => {
+    upsertKnownChat(db, { chatId: FORUM_CHAT_ID, chatName: 'Forum', chatType: 'supergroup', isForum: true });
+    createListener(db, { ...BASE, chatId: FORUM_CHAT_ID, sourceTopicId: null });
+    const { bot, calls } = makeBot();
+    const h = createMessageHandler(db, bot);
+    await h(makeMsg(FORUM_CHAT_ID, 'any topic msg', { topicId: null }) as any);
+    await new Promise<void>((r) => setTimeout(r, 10));
+    assert.equal(calls.length, 1, 'sourceTopicId=null means forward all topics');
   });
 });

--- a/src/services/dmQueue.ts
+++ b/src/services/dmQueue.ts
@@ -152,6 +152,15 @@ function safeMassDeleteGuard(): boolean {
   return massDeleteCount <= MAX_MASS_DELETES;
 }
 
+/** Exported for test isolation only — resets the mass-delete guard counters. */
+export function _resetMassDeleteGuard(): void {
+  massDeleteCount = 0;
+  massDeleteWindowStart = 0;
+}
+
+/** Exported for tests only — call the guard directly. */
+export { safeMassDeleteGuard as _safeMassDeleteGuard };
+
 const MAX_PAUSE_SECONDS = 300;
 
 export function extractRetryAfter(err: unknown): number | null {


### PR DESCRIPTION
## Summary

### `safeMassDeleteGuard` tests (dmQueue.ts)
Exports `_safeMassDeleteGuard` and `_resetMassDeleteGuard` (test-only, `_` prefix) to enable direct testing of the mass-delete circuit breaker:
- Allows up to 5 deletions within the 60s window
- Blocks the 6th deletion in the same window
- Resets after explicit `_resetMassDeleteGuard()` call
- Resets automatically when time window expires (simulated via `Date.now` override)

### General-topic normalization tests (telegramListenerService.ts)
The "General" topic in Telegram forum groups sends messages without `replyToTopId`, arriving as `topicId=null`. The service normalises `null → 1` for forum groups. 4 tests:
- `isForum=true + sourceTopicId=1 + topicId=null` → forwarded (null treated as General/1)
- `isForum=true + sourceTopicId=1 + topicId=2` → not forwarded (wrong topic)
- `isForum=false + sourceTopicId=1 + topicId=null` → not forwarded (not a forum)
- `isForum=true + sourceTopicId=null + topicId=null` → forwarded (forward-all mode)

## Test plan
- [x] `tsc --noEmit` passes
- [x] 65/65 tests pass in dmQueue + telegramListenerService suites
- [ ] CI gate passes

Part of the full codebase audit plan — PR 9 of 11.