### PR TITLE
test: clear-session route, alertSerial timezone rollover, routingCache coverage

### DIFF
--- a/src/__tests__/alertSerial.test.ts
+++ b/src/__tests__/alertSerial.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  initAlertSerial,
+  getNextAlertSerial,
+  _resetSerial,
+} from '../config/alertSerial.js';
+
+describe('alertSerial', () => {
+  beforeEach(() => {
+    _resetSerial();
+  });
+
+  it('getNextAlertSerial() starts at 1 after _resetSerial()', () => {
+    assert.equal(getNextAlertSerial(), 1);
+  });
+
+  it('getNextAlertSerial() increments monotonically', () => {
+    assert.equal(getNextAlertSerial(), 1);
+    assert.equal(getNextAlertSerial(), 2);
+    assert.equal(getNextAlertSerial(), 3);
+  });
+
+  it('initAlertSerial(n) seeds counter so next call returns n+1', () => {
+    initAlertSerial(5);
+    assert.equal(getNextAlertSerial(), 6);
+    assert.equal(getNextAlertSerial(), 7);
+  });
+
+  it('initAlertSerial(0) behaves the same as _resetSerial — next call returns 1', () => {
+    initAlertSerial(0);
+    assert.equal(getNextAlertSerial(), 1);
+  });
+
+  it('date rollover: counter resets when Israel date changes', () => {
+    // Seed with a past date string via _resetSerial + initAlertSerial so
+    // lastCounterDate is set to "today".  Then fast-forward Date.now by 24h so
+    // Intl.DateTimeFormat returns a different date — getNextAlertSerial() must
+    // detect the mismatch and reset to 1.
+    initAlertSerial(42);
+    assert.equal(getNextAlertSerial(), 43, 'increments normally before rollover');
+
+    const origDate = globalThis.Date;
+    // Advance time by 25 hours to guarantee a new calendar day in any timezone.
+    const fakeNow = Date.now() + 25 * 60 * 60 * 1000;
+    // Minimal Date shim — only intercepts the zero-arg constructor that
+    // Intl.DateTimeFormat.format() uses internally.
+    class FakeDate extends origDate {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(...args: any[]) {
+        if (args.length === 0) {
+          super(fakeNow);
+        } else {
+          super(...args as []);
+        }
+      }
+      static now() { return fakeNow; }
+    }
+    // @ts-expect-error replacing global Date for test
+    globalThis.Date = FakeDate;
+    try {
+      const serial = getNextAlertSerial();
+      assert.equal(serial, 1, 'counter must reset to 1 on date rollover');
+    } finally {
+      globalThis.Date = origDate;
+    }
+  });
+
+  it('no rollover when same day is called twice', () => {
+    initAlertSerial(10);
+    assert.equal(getNextAlertSerial(), 11);
+    assert.equal(getNextAlertSerial(), 12);
+  });
+});

--- a/src/__tests__/dashboard/routes/whatsapp.test.ts
+++ b/src/__tests__/dashboard/routes/whatsapp.test.ts
@@ -220,6 +220,47 @@ describe('PATCH /api/whatsapp/groups/:id', () => {
   });
 });
 
+describe('POST /api/whatsapp/clear-session', () => {
+  before(() => { process.env['WHATSAPP_ENABLED'] = 'true'; });
+  after(() => { delete process.env['WHATSAPP_ENABLED']; });
+
+  it('returns { ok: true } and calls clearSession() + initialize()', async () => {
+    let clearSessionCalled = false;
+    initializeCalled = false;
+    const origClearSession = mockSvc.clearSession;
+    (mockSvc as any).clearSession = async () => {
+      clearSessionCalled = true;
+      mockStatus = 'disconnected';
+      mockPhone = null;
+      mockCachedGroups = [];
+    };
+    const res = await request(app).post('/api/whatsapp/clear-session');
+    (mockSvc as any).clearSession = origClearSession;
+    assert.equal(res.status, 200);
+    assert.deepEqual(res.body, { ok: true });
+    assert.equal(clearSessionCalled, true, 'clearSession() must be called');
+    assert.equal(initializeCalled, true, 'initialize() must be called after clearSession');
+  });
+
+  it('returns 400 when WHATSAPP_ENABLED is not true', async () => {
+    const prev = process.env['WHATSAPP_ENABLED'];
+    delete process.env['WHATSAPP_ENABLED'];
+    const res = await request(app).post('/api/whatsapp/clear-session');
+    process.env['WHATSAPP_ENABLED'] = prev!;
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error);
+  });
+
+  it('returns 500 when clearSession() throws', async () => {
+    const origClearSession = mockSvc.clearSession;
+    (mockSvc as any).clearSession = async () => { throw new Error('disk full'); };
+    const res = await request(app).post('/api/whatsapp/clear-session');
+    (mockSvc as any).clearSession = origClearSession;
+    assert.equal(res.status, 500);
+    assert.ok(res.body.error);
+  });
+});
+
 describe('POST /api/whatsapp/reconnect', () => {
   before(() => { process.env['WHATSAPP_ENABLED'] = 'true'; });
   after(() => { delete process.env['WHATSAPP_ENABLED']; });


### PR DESCRIPTION
## Summary
- **POST /api/whatsapp/clear-session**: 3 tests covering happy path (calls `clearSession()` + `initialize()`), WHATSAPP_ENABLED=false guard (400), and clearSession() throw (500)
- **alertSerial.test.ts** (new file — 6 tests): init seeding from DB count, monotonic increment, `initAlertSerial(0)` reset, timezone rollover via `globalThis.Date` shim (advances 25h, verifies counter resets to 1), same-day no-reset invariant
- **routingCache.test.ts**: hot-reload and topic ID `1` rejection were already covered in a prior PR — no changes needed

## Test plan
- [x] `DB_PATH=:memory: npx tsx --test src/__tests__/dashboard/routes/whatsapp.test.ts` — 25 pass
- [x] `npx tsx --test src/__tests__/alertSerial.test.ts` — 6 pass
- [x] `npx tsx --test src/__tests__/routingCache.test.ts` — 11 pass
- [x] `npm test` — 920/920 pass
- [x] `npx tsc --noEmit` — 0 errors