### PR TITLE
feat: enhance /health with pollStuck, memoryMb, dmQueueDepth and 503 on stuck poller

### DIFF
--- a/src/__tests__/healthServer.test.ts
+++ b/src/__tests__/healthServer.test.ts
@@ -13,6 +13,16 @@ async function getHealth(port: number): Promise<Record<string, unknown>> {
   });
 }
 
+async function getHealthWithStatus(port: number): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve, reject) => {
+    http.get(`http://localhost:${port}/health`, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) }));
+    }).on('error', reject);
+  });
+}
+
 describe('metrics', () => {
   it('returns null lastAlertAt before any update', async () => {
     const { getMetrics } = await import('../metrics.js');
@@ -39,6 +49,41 @@ describe('healthServer', () => {
     assert.ok('lastAlertAt' in body);
     assert.ok('lastPollAt' in body);
     assert.ok(typeof body.alertsToday === 'number');
+    assert.ok('pollStuck' in body, 'pollStuck must be present');
+    assert.ok(typeof body.memoryMb === 'number', 'memoryMb must be a number');
+    assert.ok(typeof body.dmQueueDepth === 'number', 'dmQueueDepth must be a number');
+    server.close();
+  });
+
+  it('GET /health returns 200 when poll is not stuck', async () => {
+    const { updateLastPollAt } = await import('../metrics.js');
+    updateLastPollAt(); // mark poll as recent
+    const { startHealthServer } = await import('../healthServer.js');
+    const server = startHealthServer(0);
+    const port = (server.address() as { port: number }).port;
+    const { status, body } = await getHealthWithStatus(port);
+    assert.equal(status, 200);
+    assert.equal(body.pollStuck, false);
+    server.close();
+  });
+
+  it('GET /health returns 503 when lastPollAt is older than 30s', async () => {
+    const { startHealthServer } = await import('../healthServer.js');
+    const { getMetrics } = await import('../metrics.js');
+    const server = startHealthServer(0);
+    const port = (server.address() as { port: number }).port;
+    // Verify the stuck path by fast-forwarding Date.now past the 30s threshold.
+    // lastPollAt was set in the previous test — advance time by 35 seconds.
+    const metrics = getMetrics();
+    const origNow = Date.now;
+    Date.now = () => (metrics.lastPollAt ? metrics.lastPollAt.getTime() + 35_000 : origNow());
+    try {
+      const { status, body } = await getHealthWithStatus(port);
+      assert.equal(status, 503);
+      assert.equal(body.pollStuck, true);
+    } finally {
+      Date.now = origNow;
+    }
     server.close();
   });
 

--- a/src/healthServer.ts
+++ b/src/healthServer.ts
@@ -3,6 +3,13 @@ import { getMetrics } from './metrics.js';
 import { getDb } from './db/schema.js';
 import { log } from './logger.js';
 import { israelMidnight } from './dashboard/israelDate.js';
+import { getQueueStats } from './services/dmQueue.js';
+
+// A poll cycle is considered "stuck" if more than 30 seconds have elapsed
+// since the last successful poll. Both poll sources (library + direct fetch)
+// must have failed for this to trigger — a single-source failure still updates
+// lastPollAt via Promise.allSettled's anySucceeded check in alertPoller.ts.
+const POLL_STUCK_THRESHOLD_MS = 30_000;
 
 function alertsToday(): { count: number; error: boolean } {
   try {
@@ -25,14 +32,23 @@ export function startHealthServer(port: number): http.Server {
       }
       const { lastAlertAt, lastPollAt } = getMetrics();
       const today = alertsToday();
+      const pollStuck = lastPollAt
+        ? Date.now() - lastPollAt.getTime() > POLL_STUCK_THRESHOLD_MS
+        : false;
+      const memoryMb = Math.round(process.memoryUsage().rss / 1_048_576);
+      const dmQueueDepth = getQueueStats().pending;
+      const statusCode = pollStuck ? 503 : 200;
       const body = JSON.stringify({
         uptime: process.uptime(),
         lastAlertAt: lastAlertAt?.toISOString() ?? null,
         lastPollAt: lastPollAt?.toISOString() ?? null,
         alertsToday: today.count,
+        pollStuck,
+        memoryMb,
+        dmQueueDepth,
         ...(today.error ? { alertsTodayError: true } : {}),
       });
-      res.writeHead(200, { 'Content-Type': 'application/json' }).end(body);
+      res.writeHead(statusCode, { 'Content-Type': 'application/json' }).end(body);
     } catch (err) {
       log('error', 'Health', `שגיאה בטיפול בבקשה: ${err}`);
       if (!res.headersSent) res.writeHead(500).end('Internal Server Error');


### PR DESCRIPTION
## Summary
- `/health` now exposes `pollStuck` (bool), `memoryMb` (int), `dmQueueDepth` (int)
- Returns HTTP **503** when `lastPollAt` is older than 30 seconds — monitoring tools can page on status code alone without parsing JSON
- `pollStuck` is false when `lastPollAt` is null (bot just started, not yet polled once) — avoids false alerts on startup
- Queue depth sourced from existing `getQueueStats()` in `dmQueue.ts` (no new exports needed)
- 2 new tests: 200 + `pollStuck=false` when poll is recent; 503 + `pollStuck=true` when `Date.now` is advanced 35s past `lastPollAt`

## Test plan
- [x] `DB_PATH=:memory: npx tsx --test src/__tests__/healthServer.test.ts` — 7 pass
- [x] `npm test` — 916/916 pass
- [x] `npx tsc --noEmit` — 0 errors
- [ ] Manual: `curl http://localhost:3000/health` — verify new fields present

## Example response
```json
{
  "uptime": 142.3,
  "lastAlertAt": null,
  "lastPollAt": "2026-04-04T15:30:00.000Z",
  "alertsToday": 3,
  "pollStuck": false,
  "memoryMb": 87,
  "dmQueueDepth": 0
}
```