### PR TITLE
feat: extend allClearTracker to carry alertType and add cancelAlert

### DIFF
--- a/src/__tests__/allClearTracker.test.ts
+++ b/src/__tests__/allClearTracker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { createAllClearTracker } from '../services/allClearTracker.js';
+import { createAllClearTracker, type AllClearEvent } from '../services/allClearTracker.js';
 
 /** Builds injectable timer fakes that fire callbacks synchronously on demand. */
 function createFakeTimers() {
@@ -26,118 +26,118 @@ function createFakeTimers() {
 }
 
 describe('allClearTracker', () => {
-  it('fires onAllClear with zone name after quiet window', () => {
-    const firedZones: string[][] = [];
+  it('fires onAllClear with zone and alertType after quiet window', () => {
+    const fired: AllClearEvent[][] = [];
     const timers = createFakeTimers();
     const tracker = createAllClearTracker({
       scheduleFn: timers.scheduleFn,
       cancelScheduleFn: timers.cancelScheduleFn,
-      onAllClear: (zones) => firedZones.push(zones),
+      onAllClear: (events) => fired.push(events),
     });
 
-    tracker.recordAlert(['גליל עליון']);
-    assert.equal(firedZones.length, 0, 'Should not fire immediately');
+    tracker.recordAlert(['גליל עליון'], 'missiles');
+    assert.equal(fired.length, 0, 'Should not fire immediately');
 
     timers.fireAll();
-    assert.equal(firedZones.length, 1);
-    assert.deepEqual(firedZones[0], ['גליל עליון']);
+    assert.equal(fired.length, 1);
+    assert.deepEqual(fired[0], [{ zone: 'גליל עליון', alertType: 'missiles' }]);
   });
 
   it('resets the timer when a new alert arrives for the same zone', () => {
-    const firedZones: string[][] = [];
+    const fired: AllClearEvent[][] = [];
     const timers = createFakeTimers();
     const tracker = createAllClearTracker({
       scheduleFn: timers.scheduleFn,
       cancelScheduleFn: timers.cancelScheduleFn,
-      onAllClear: (zones) => firedZones.push(zones),
+      onAllClear: (events) => fired.push(events),
     });
 
-    tracker.recordAlert(['דן']);
+    tracker.recordAlert(['דן'], 'missiles');
     assert.equal(timers.pendingCount(), 1);
 
     // New alert for same zone should cancel old timer and create new one
-    tracker.recordAlert(['דן']);
+    tracker.recordAlert(['דן'], 'missiles');
     assert.equal(timers.pendingCount(), 1, 'Old timer should be cancelled, new one scheduled');
 
     timers.fireAll();
-    assert.equal(firedZones.length, 1, 'Should fire exactly once');
-    assert.deepEqual(firedZones[0], ['דן']);
+    assert.equal(fired.length, 1, 'Should fire exactly once');
+    assert.deepEqual(fired[0], [{ zone: 'דן', alertType: 'missiles' }]);
   });
 
   it('deduplicates — does not fire twice for same zone without new alert', () => {
-    const firedZones: string[][] = [];
+    const fired: AllClearEvent[][] = [];
     const timers = createFakeTimers();
     const tracker = createAllClearTracker({
       scheduleFn: timers.scheduleFn,
       cancelScheduleFn: timers.cancelScheduleFn,
-      onAllClear: (zones) => firedZones.push(zones),
+      onAllClear: (events) => fired.push(events),
     });
 
-    tracker.recordAlert(['חיפה']);
+    tracker.recordAlert(['חיפה'], 'missiles');
     timers.fireAll();
-    assert.equal(firedZones.length, 1);
+    assert.equal(fired.length, 1);
 
-    // Record the same zone again without new alert — but the timer was already consumed
-    // The firedZones set still has 'חיפה', so no second fire
-    // Simulate a stale scenario: nothing to fire
-    assert.equal(firedZones.length, 1, 'Should not fire again without a new alert');
+    // Timer was consumed — firedZones still has 'חיפה', no second fire possible
+    assert.equal(fired.length, 1, 'Should not fire again without a new alert');
   });
 
   it('allows re-firing after a new alert clears dedupe', () => {
-    const firedZones: string[][] = [];
+    const fired: AllClearEvent[][] = [];
     const timers = createFakeTimers();
     const tracker = createAllClearTracker({
       scheduleFn: timers.scheduleFn,
       cancelScheduleFn: timers.cancelScheduleFn,
-      onAllClear: (zones) => firedZones.push(zones),
+      onAllClear: (events) => fired.push(events),
     });
 
-    tracker.recordAlert(['שרון']);
+    tracker.recordAlert(['שרון'], 'missiles');
     timers.fireAll();
-    assert.equal(firedZones.length, 1);
+    assert.equal(fired.length, 1);
 
     // New alert resets dedupe
-    tracker.recordAlert(['שרון']);
+    tracker.recordAlert(['שרון'], 'earthQuake');
     timers.fireAll();
-    assert.equal(firedZones.length, 2, 'Should fire again after new alert');
+    assert.equal(fired.length, 2, 'Should fire again after new alert');
+    assert.equal(fired[1][0].alertType, 'earthQuake', 'New alertType should be carried');
   });
 
   it('clearAll cancels all pending timers', () => {
-    const firedZones: string[][] = [];
+    const fired: AllClearEvent[][] = [];
     const timers = createFakeTimers();
     const tracker = createAllClearTracker({
       scheduleFn: timers.scheduleFn,
       cancelScheduleFn: timers.cancelScheduleFn,
-      onAllClear: (zones) => firedZones.push(zones),
+      onAllClear: (events) => fired.push(events),
     });
 
-    tracker.recordAlert(['גולן', 'קריות']);
+    tracker.recordAlert(['גולן', 'קריות'], 'missiles');
     assert.equal(timers.pendingCount(), 2);
 
     tracker.clearAll();
     // Timers were cancelled by clearAll, so fireAll should do nothing
     timers.fireAll();
-    assert.equal(firedZones.length, 0, 'No all-clear should fire after clearAll');
+    assert.equal(fired.length, 0, 'No all-clear should fire after clearAll');
   });
 
   it('tracks multiple zones independently', () => {
-    const firedZones: string[][] = [];
+    const fired: AllClearEvent[][] = [];
     const timers = createFakeTimers();
     const tracker = createAllClearTracker({
       scheduleFn: timers.scheduleFn,
       cancelScheduleFn: timers.cancelScheduleFn,
-      onAllClear: (zones) => firedZones.push(zones),
+      onAllClear: (events) => fired.push(events),
     });
 
-    tracker.recordAlert(['דן', 'שרון']);
+    tracker.recordAlert(['דן', 'שרון'], 'missiles');
     assert.equal(timers.pendingCount(), 2);
 
     timers.fireAll();
-    assert.equal(firedZones.length, 2);
-    // Each zone fires independently
-    const allZones = firedZones.flat();
+    assert.equal(fired.length, 2);
+    // Each zone fires independently with its alertType
+    const allZones = fired.flat().map((e) => e.zone);
     assert.ok(allZones.includes('דן'));
     assert.ok(allZones.includes('שרון'));
+    assert.ok(fired.flat().every((e) => e.alertType === 'missiles'));
   });
 
   it('uses custom quietWindowMs', () => {
@@ -149,7 +149,49 @@ describe('allClearTracker', () => {
       quietWindowMs: 300_000,
     });
 
-    tracker.recordAlert(['ירושלים']);
+    tracker.recordAlert(['ירושלים'], 'missiles');
     assert.equal(scheduledMs, 300_000);
+  });
+
+  it('cancelAlert suppresses the all-clear without resetting dedupe', () => {
+    const fired: AllClearEvent[][] = [];
+    const timers = createFakeTimers();
+    const tracker = createAllClearTracker({
+      scheduleFn: timers.scheduleFn,
+      cancelScheduleFn: timers.cancelScheduleFn,
+      onAllClear: (events) => fired.push(events),
+    });
+
+    tracker.recordAlert(['תל אביב'], 'missiles');
+    assert.equal(timers.pendingCount(), 1);
+
+    tracker.cancelAlert(['תל אביב']);
+    assert.equal(timers.pendingCount(), 0, 'Timer should be cancelled');
+
+    timers.fireAll();
+    assert.equal(fired.length, 0, 'No all-clear should fire after cancelAlert');
+  });
+
+  it('cancelAlert does not reset firedZones — new alert re-opens the cycle', () => {
+    const fired: AllClearEvent[][] = [];
+    const timers = createFakeTimers();
+    const tracker = createAllClearTracker({
+      scheduleFn: timers.scheduleFn,
+      cancelScheduleFn: timers.cancelScheduleFn,
+      onAllClear: (events) => fired.push(events),
+    });
+
+    // First cycle fires normally
+    tracker.recordAlert(['ירושלים'], 'missiles');
+    timers.fireAll();
+    assert.equal(fired.length, 1);
+
+    // cancelAlert on a zone that has no pending timer is a no-op
+    tracker.cancelAlert(['ירושלים']);
+
+    // A new alert must re-open the cycle
+    tracker.recordAlert(['ירושלים'], 'missiles');
+    timers.fireAll();
+    assert.equal(fired.length, 2, 'New alert should re-open cycle after cancelAlert');
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -158,8 +158,8 @@ for (const envVar of REQUIRED_ENV_VARS) {
 
   const allClearChatId = process.env.TELEGRAM_CHAT_ID!;
   const allClearTracker = createAllClearTracker({
-    onAllClear: async (zones) => {
-      for (const zone of zones) {
+    onAllClear: async (events) => {
+      for (const { zone } of events) {
         try {
           const message = formatAllClearMessage(zone);
           await bot.api.sendMessage(allClearChatId, message, { parse_mode: 'HTML' });
@@ -213,7 +213,7 @@ for (const envVar of REQUIRED_ENV_VARS) {
         .filter((z): z is string => z != null)
     )];
     if (alertZones.length > 0) {
-      allClearTracker.recordAlert(alertZones);
+      allClearTracker.recordAlert(alertZones, alert.type);
     }
 
     await handleNewAlert(alert, {

--- a/src/services/allClearTracker.ts
+++ b/src/services/allClearTracker.ts
@@ -1,43 +1,64 @@
+export interface AllClearEvent {
+  zone: string;
+  alertType: string;
+}
+
 export interface AllClearDeps {
   scheduleFn?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
   cancelScheduleFn?: (id: ReturnType<typeof setTimeout>) => void;
-  onAllClear: (zones: string[]) => void;
+  onAllClear: (events: AllClearEvent[]) => void;
   quietWindowMs?: number;
+}
+
+interface ZoneTimer {
+  id: ReturnType<typeof setTimeout>;
+  alertType: string;
 }
 
 const DEFAULT_QUIET_WINDOW_MS = 600_000; // 10 minutes
 
 export function createAllClearTracker(deps: AllClearDeps) {
-  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  const timers = new Map<string, ZoneTimer>();
   const firedZones = new Set<string>();
   const schedule = deps.scheduleFn ?? setTimeout;
   const cancel = deps.cancelScheduleFn ?? clearTimeout;
   const windowMs = deps.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS;
 
-  function recordAlert(zones: string[]): void {
+  function recordAlert(zones: string[], alertType: string): void {
     for (const zone of zones) {
       const existing = timers.get(zone);
-      if (existing) cancel(existing);
+      if (existing) cancel(existing.id);
 
       // New alert resets dedupe — a fresh all-clear should fire later
       firedZones.delete(zone);
 
-      const timer = schedule(() => {
+      const id = schedule(() => {
         if (!firedZones.has(zone)) {
           firedZones.add(zone);
-          deps.onAllClear([zone]);
+          deps.onAllClear([{ zone, alertType }]);
         }
         timers.delete(zone);
       }, windowMs);
-      timers.set(zone, timer);
+      timers.set(zone, { id, alertType });
+    }
+  }
+
+  // Cancels the pending all-clear timer for the given zones without firing it.
+  // Does NOT reset firedZones — a new alert will re-open the cycle correctly.
+  // Use when an official "האירוע הסתיים" newsFlash has already notified the user.
+  function cancelAlert(zones: string[]): void {
+    for (const zone of zones) {
+      const existing = timers.get(zone);
+      if (existing) cancel(existing.id);
+      timers.delete(zone);
     }
   }
 
   function clearAll(): void {
-    for (const timer of timers.values()) cancel(timer);
+    for (const { id } of timers.values()) cancel(id);
     timers.clear();
     firedZones.clear();
   }
 
-  return { recordAlert, clearAll };
+  return { recordAlert, cancelAlert, clearAll };
 }


### PR DESCRIPTION
## Summary

- `recordAlert(zones, alertType)` — tracker now stores the alert type per zone so the all-clear callback carries context for grounding closure messages (needed for users with PTSD)
- `onAllClear` callback receives `AllClearEvent[]` (`{ zone, alertType }[]`) instead of `string[]`
- `cancelAlert(zones)` — new method that cancels a pending timer **without** resetting `firedZones`, used when Pikud HaOref sends an official `"האירוע הסתיים"` newsFlash (prevents double DM notification)
- 7 existing tests updated for new signatures; 2 new tests cover `cancelAlert` behaviour
- `index.ts` call sites updated to pass `alert.type` and destructure `events`

## Test plan

- [x] `npx tsx --test src/__tests__/allClearTracker.test.ts` — 9/9 pass
- [x] `npm test` — 946/946 pass
- [x] `npx tsc --noEmit` — 0 errors

Part of #94 #95 — epic #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #94