### PR TITLE
feat: add getUserIdsByZone to subscriptionRepository

### DIFF
--- a/src/__tests__/subscriptionRepository.test.ts
+++ b/src/__tests__/subscriptionRepository.test.ts
@@ -12,10 +12,12 @@ import {
   removeSubscription,
   removeAllSubscriptions,
   getUsersForCities,
+  getUserIdsByZone,
   initSubscriptionCache,
   updateSubscriberData,
 } from '../db/subscriptionRepository';
 import { setFormat, setQuietHours, setMutedUntil } from '../db/userRepository';
+import { getCitiesByZone } from '../cityLookup';
 
 describe('subscriptionRepository — in-memory cache', () => {
   before(() => {
@@ -225,5 +227,76 @@ describe('subscriptionRepository — cache invalidation via userRepository sette
     const results = getUsersForCities(['חיפה']);
     assert.equal(results.length, 1);
     assert.equal(results[0].home_city, null);
+  });
+});
+
+describe('subscriptionRepository — getUserIdsByZone', () => {
+  before(() => { initDb(); });
+  after(() => { closeDb(); });
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM subscriptions').run();
+    getDb().prepare('DELETE FROM users').run();
+    initSubscriptionCache();
+  });
+
+  it('returns user IDs subscribed to cities in the given zone', () => {
+    // Use the first city in the 'דן' zone — resilient to data changes
+    const danCities = getCitiesByZone('דן');
+    assert.ok(danCities.length > 0, 'דן zone must have cities');
+    const firstCity = danCities[0].name;
+
+    addSubscription(1001, firstCity);
+
+    const ids = getUserIdsByZone(['דן']);
+    assert.ok(ids.includes(1001));
+  });
+
+  it('returns empty array when no users are subscribed to the zone', () => {
+    const ids = getUserIdsByZone(['גולן']);
+    assert.deepEqual(ids, []);
+  });
+
+  it('returns empty array for empty zones input', () => {
+    addSubscription(1002, 'תל אביב');
+    const ids = getUserIdsByZone([]);
+    assert.deepEqual(ids, []);
+  });
+
+  it('deduplicates users subscribed to multiple cities within the same zone', () => {
+    const danCities = getCitiesByZone('דן');
+    assert.ok(danCities.length >= 2, 'דן zone must have at least 2 cities for this test');
+
+    // Subscribe same user to 2 cities in the same zone
+    addSubscription(1003, danCities[0].name);
+    addSubscription(1003, danCities[1].name);
+
+    const ids = getUserIdsByZone(['דן']);
+    assert.equal(ids.filter((id) => id === 1003).length, 1, 'User should appear only once');
+  });
+
+  it('spans multiple zones — returns subscribers from all', () => {
+    const danCities = getCitiesByZone('דן');
+    const sharonCities = getCitiesByZone('שרון');
+    assert.ok(danCities.length > 0 && sharonCities.length > 0);
+
+    addSubscription(1004, danCities[0].name);
+    addSubscription(1005, sharonCities[0].name);
+
+    const ids = getUserIdsByZone(['דן', 'שרון']);
+    assert.ok(ids.includes(1004));
+    assert.ok(ids.includes(1005));
+  });
+
+  it('excludes users with is_dm_active = 0', () => {
+    const danCities = getCitiesByZone('דן');
+    assert.ok(danCities.length > 0);
+
+    // Insert user with is_dm_active = 0 directly
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, is_dm_active) VALUES (?, 0)').run(1006);
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(1006, danCities[0].name);
+    initSubscriptionCache();
+
+    const ids = getUserIdsByZone(['דן']);
+    assert.ok(!ids.includes(1006), 'Inactive DM user should be excluded');
   });
 });

--- a/src/db/subscriptionRepository.ts
+++ b/src/db/subscriptionRepository.ts
@@ -2,6 +2,7 @@ import { getDb } from './schema.js';
 import { upsertUser } from './userRepository.js';
 import type { NotificationFormat } from './userRepository.js';
 import { log } from '../logger.js';
+import { getCitiesByZone } from '../cityLookup.js';
 
 export interface SubscriberInfo {
   chat_id: number;
@@ -217,6 +218,36 @@ export function updateSubscriberData(chatId: number, patch: Partial<CachedSubscr
   if (!cacheInitialized) return;
   const current = subscriberData.get(chatId);
   if (current) subscriberData.set(chatId, { ...current, ...patch });
+}
+
+// Returns the chat IDs of all DM-active subscribers whose subscriptions
+// overlap with at least one city in the given zones. Used by allClearService
+// to dispatch "שקט חזר" messages to only the relevant zone subscribers.
+export function getUserIdsByZone(zones: string[]): number[] {
+  if (zones.length === 0) return [];
+
+  const cityNames = zones.flatMap((zone) => getCitiesByZone(zone).map((c) => c.name));
+  if (cityNames.length === 0) return [];
+
+  if (!cacheInitialized) {
+    const placeholders = cityNames.map(() => '?').join(', ');
+    const rows = getDb()
+      .prepare(
+        `SELECT DISTINCT s.chat_id FROM subscriptions s
+         JOIN users u ON u.chat_id = s.chat_id
+         WHERE s.city_name IN (${placeholders}) AND u.is_dm_active = 1`
+      )
+      .all(...cityNames) as { chat_id: number }[];
+    return rows.map((r) => r.chat_id);
+  }
+
+  const chatIds = new Set<number>();
+  for (const city of cityNames) {
+    cityToSubscribers.get(city)?.forEach((id) => {
+      if (subscriberData.get(id)?.is_dm_active) chatIds.add(id);
+    });
+  }
+  return Array.from(chatIds);
 }
 
 export function evictSubscriberFromCache(chatId: number, cityName?: string): void {


### PR DESCRIPTION
## Summary

- New `getUserIdsByZone(zones: string[]): number[]` exported from `subscriptionRepository.ts`
- Expands zone names → city list via existing `getCitiesByZone()` from `cityLookup.ts`
- Uses in-memory subscription cache when initialized; DB fallback otherwise (consistent with `getUsersForCities` pattern)
- Filters `is_dm_active = 0` users in both cache and DB paths
- Used by `allClearService` (upcoming PR) to send "שקט חזר" DMs only to subscribers of the affected zone

## Test plan

- [x] 6 new tests: basic lookup, empty inputs, dedup across cities in same zone, multi-zone span, inactive user exclusion
- [x] `npx tsx --test src/__tests__/subscriptionRepository.test.ts` — 22/22 pass
- [x] `npx tsc --noEmit` — 0 errors

Part of #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)