### PR TITLE
feat: seed default all_clear message template in schema

### DIFF
--- a/src/__tests__/templateCache.test.ts
+++ b/src/__tests__/templateCache.test.ts
@@ -82,11 +82,18 @@ function makeDb(): Database.Database {
   return db;
 }
 
+// Helper — excludes the seeded all_clear row so repository tests stay focused on
+// user-managed templates (initSchema seeds all_clear via INSERT OR IGNORE).
+function userTemplates(db: Database.Database) {
+  return getAllTemplates(db).filter((r) => r.alert_type !== 'all_clear');
+}
+
 describe('messageTemplateRepository', () => {
-  it('getAllTemplates on empty DB returns []', () => {
+  it('getAllTemplates on empty DB returns only the seeded all_clear row', () => {
     const db = makeDb();
     const rows = getAllTemplates(db);
-    assert.deepEqual(rows, []);
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].alert_type, 'all_clear');
     db.close();
   });
 
@@ -98,7 +105,7 @@ describe('messageTemplateRepository', () => {
       title_he: 'בדיקה',
       instructions_prefix: '📌',
     });
-    const rows = getAllTemplates(db);
+    const rows = userTemplates(db);
     assert.equal(rows.length, 1);
     assert.equal(rows[0].alert_type, 'missiles');
     assert.equal(rows[0].emoji, '🚀');
@@ -121,7 +128,7 @@ describe('messageTemplateRepository', () => {
       title_he: 'עדכני',
       instructions_prefix: '🛡',
     });
-    const rows = getAllTemplates(db);
+    const rows = userTemplates(db);
     assert.equal(rows.length, 1);
     assert.equal(rows[0].emoji, '🔴');
     assert.equal(rows[0].title_he, 'עדכני');
@@ -143,7 +150,7 @@ describe('messageTemplateRepository', () => {
       instructions_prefix: '🛡',
     });
     deleteTemplate(db, 'missiles');
-    const rows = getAllTemplates(db);
+    const rows = userTemplates(db);
     assert.equal(rows.length, 1);
     assert.equal(rows[0].alert_type, 'earthQuake');
     db.close();

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -219,6 +219,14 @@ export function initSchema(database: Database.Database): void {
   addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN is_dm_active INTEGER NOT NULL DEFAULT 1');
 
   database.prepare('CREATE UNIQUE INDEX IF NOT EXISTS idx_users_connection_code ON users(connection_code) WHERE connection_code IS NOT NULL').run();
+
+  // Seed the all-clear template so it appears in the dashboard Messages page on first run.
+  // INSERT OR IGNORE — never overwrites admin customisations.
+  // instructions_prefix holds the editable closing text shown after the zone/alert-type line.
+  database.prepare(`
+    INSERT OR IGNORE INTO message_templates (alert_type, emoji, title_he, instructions_prefix)
+    VALUES ('all_clear', '✅', 'שקט חזר', 'נשמו. אתם בטוחים. 🕊')
+  `).run();
 }
 
 export function initDb(): void {


### PR DESCRIPTION
## Summary
- Adds `INSERT OR IGNORE INTO message_templates` for `all_clear` at the end of `initSchema()` so the template appears in the dashboard Messages page on first run
- `INSERT OR IGNORE` — never overwrites admin customisations made after initial setup
- Updates `templateCache.test.ts` with a `userTemplates()` helper that filters the seeded row so repository tests remain focused on user-managed templates

## Test plan
- [ ] Run `npx tsx --test src/__tests__/templateCache.test.ts` — all 16 tests pass
- [ ] Fresh DB: confirm `all_clear` row visible in dashboard Messages page without any manual SQL
- [ ] Existing DB: confirm existing `all_clear` customisation is NOT overwritten after restart

## Dependencies
Builds on #133 (tracker), #134 (subscriptions), #135 (renderTemplate), #136 (service). Precedes index.ts wiring PR.