### PR TITLE
feat: /today timeline + density indicator (#97, #99)

### DIFF
--- a/src/__tests__/todayHandler.test.ts
+++ b/src/__tests__/todayHandler.test.ts
@@ -1,10 +1,16 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
-import { buildTodayMessage } from '../bot/todayHandler.js';
+import { buildTodayMessage, buildTodayTimeline } from '../bot/todayHandler.js';
 import type { AlertHistoryRow } from '../db/alertHistoryRepository.js';
 
-function makeAlert(type: string, cities: string[] = []): AlertHistoryRow {
-  return { id: 1, type, cities, instructions: undefined, fired_at: new Date().toISOString() };
+function makeAlert(type: string, cities: string[] = [], fired_at?: string): AlertHistoryRow {
+  return {
+    id: 1,
+    type,
+    cities,
+    instructions: undefined,
+    fired_at: fired_at ?? new Date().toISOString(),
+  };
 }
 
 describe('buildTodayMessage', () => {
@@ -44,5 +50,74 @@ describe('buildTodayMessage', () => {
     const alerts = [makeAlert('missiles', ['תל אביב'])];
     const msg = buildTodayMessage(alerts, []);
     assert.ok(!msg.includes('באזורך'), `Should not show personal section: ${msg}`);
+  });
+
+  // Density indicator in summary
+  it('shows density "חריג" label when monthlyCounts indicates unusual day', () => {
+    // 10 counts all=1 → sorted p90=1; today=2 alerts → 2 > 1 → חריג
+    const alerts = [makeAlert('missiles'), makeAlert('rockets')];
+    const monthlyCounts = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1];
+    const msg = buildTodayMessage(alerts, [], monthlyCounts);
+    assert.ok(msg.includes('חריג'), `Expected חריג label: ${msg}`);
+  });
+
+  it('shows density "רגיל" label when monthlyCounts indicates normal day', () => {
+    const alerts = [makeAlert('missiles')];
+    const monthlyCounts = [5, 5, 5, 5, 5, 5, 5, 5, 5, 5]; // all same → today=1 is רגיל
+    const msg = buildTodayMessage(alerts, [], monthlyCounts);
+    assert.ok(msg.includes('רגיל'), `Expected רגיל label: ${msg}`);
+  });
+
+  it('omits density label when fewer than 5 data points', () => {
+    const alerts = [makeAlert('missiles')];
+    const msg = buildTodayMessage(alerts, [], [1, 2]);
+    assert.ok(!msg.includes('חריג') && !msg.includes('רגיל'), `Should omit density: ${msg}`);
+  });
+
+  // Timeline section
+  it('includes timeline section when there are alerts', () => {
+    const alerts = [makeAlert('missiles', ['תל אביב'])];
+    const msg = buildTodayMessage(alerts, []);
+    assert.ok(msg.includes('ציר'), `Expected timeline header: ${msg}`);
+  });
+
+  it('omits timeline section when no alerts', () => {
+    const msg = buildTodayMessage([], []);
+    assert.ok(!msg.includes('ציר'), `Should omit timeline when no alerts: ${msg}`);
+  });
+
+  it('shows at most 15 events in timeline, with overflow prefix', () => {
+    const alerts = Array.from({ length: 20 }, (_, i) =>
+      makeAlert('missiles', [`עיר ${i}`])
+    );
+    const msg = buildTodayMessage(alerts, []);
+    // Should show overflow prefix (ועוד N אירועים)
+    assert.ok(msg.includes('ועוד'), `Expected overflow prefix for >15 events: ${msg}`);
+  });
+});
+
+describe('buildTodayTimeline', () => {
+  it('returns empty string when no alerts', () => {
+    assert.equal(buildTodayTimeline([]), '');
+  });
+
+  it('formats a single alert as one compact line with time and emoji', () => {
+    const alert = makeAlert('missiles', ['תל אביב'], '2026-04-05T12:32:00.000Z');
+    const line = buildTodayTimeline([alert]);
+    assert.ok(line.includes('תל אביב'), `Expected city in line: ${line}`);
+    assert.ok(line.includes('🔴'), `Expected security emoji: ${line}`);
+  });
+
+  it('truncates city list to 3 cities with overflow count', () => {
+    const alert = makeAlert('missiles', ['א', 'ב', 'ג', 'ד', 'ה']);
+    const line = buildTodayTimeline([alert]);
+    assert.ok(line.includes('+2'), `Expected +2 overflow for 5 cities (3 shown): ${line}`);
+  });
+
+  it('shows all cities when 3 or fewer', () => {
+    const alert = makeAlert('missiles', ['א', 'ב', 'ג']);
+    const line = buildTodayTimeline([alert]);
+    assert.ok(!line.includes('+'), `Should not show overflow for 3 cities: ${line}`);
+    assert.ok(line.includes('א') && line.includes('ב') && line.includes('ג'));
   });
 });

--- a/src/bot/todayHandler.ts
+++ b/src/bot/todayHandler.ts
@@ -1,8 +1,14 @@
 import { Bot } from 'grammy';
 import type { Context } from 'grammy';
-import { getRecentAlerts, type AlertHistoryRow } from '../db/alertHistoryRepository.js';
+import {
+  getAlertsToday,
+  getDailyCountsForMonth,
+  type AlertHistoryRow,
+} from '../db/alertHistoryRepository.js';
 import { getUserCities } from '../db/subscriptionRepository.js';
 import { ALERT_TYPE_CATEGORY, type AlertCategory } from '../config/alertCategories.js';
+import { ALERT_TYPE_EMOJI } from '../telegramBot.js';
+import { getDensityLabel } from '../config/alertDensity.js';
 
 const CATEGORY_LABEL: Readonly<Record<AlertCategory, string>> = {
   security: '🔴 ביטחוני',
@@ -13,10 +19,55 @@ const CATEGORY_LABEL: Readonly<Record<AlertCategory, string>> = {
   whatsapp: '📲 WhatsApp',
 };
 
-export function buildTodayMessage(alerts: AlertHistoryRow[], userCities: string[]): string {
+const MAX_TIMELINE_EVENTS = 15;
+const MAX_CITIES_PER_LINE = 3;
+
+/** Formats today's alerts as a compact chronological timeline string. */
+export function buildTodayTimeline(alerts: AlertHistoryRow[]): string {
+  if (alerts.length === 0) return '';
+
+  const displayed = alerts.length > MAX_TIMELINE_EVENTS
+    ? alerts.slice(alerts.length - MAX_TIMELINE_EVENTS)
+    : alerts;
+
+  const overflowCount = alerts.length - displayed.length;
+  const lines: string[] = [];
+
+  if (overflowCount > 0) {
+    lines.push(`<i>...ועוד ${overflowCount} אירועים קודמים</i>`);
+  }
+
+  for (const alert of displayed) {
+    const emoji = ALERT_TYPE_EMOJI[alert.type] ?? '⚠️';
+    const timeStr = new Date(alert.fired_at).toLocaleTimeString('he-IL', {
+      timeZone: 'Asia/Jerusalem',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    });
+
+    let cityPart = '';
+    if (alert.cities.length > 0) {
+      const shown = alert.cities.slice(0, MAX_CITIES_PER_LINE).join(', ');
+      const overflow = alert.cities.length > MAX_CITIES_PER_LINE
+        ? ` (+${alert.cities.length - MAX_CITIES_PER_LINE})`
+        : '';
+      cityPart = ` · ${shown}${overflow}`;
+    }
+
+    lines.push(`${timeStr} · ${emoji}${cityPart}`);
+  }
+
+  return lines.join('\n');
+}
+
+export function buildTodayMessage(
+  alerts: AlertHistoryRow[],
+  userCities: string[],
+  monthlyCounts: number[] = [],
+): string {
   const total = alerts.length;
 
-  // Count by category
   const byCat = new Map<AlertCategory, number>();
   let userMatchCount = 0;
 
@@ -36,8 +87,11 @@ export function buildTodayMessage(alerts: AlertHistoryRow[], userCities: string[
     return lines.join('\n');
   }
 
+  const density = getDensityLabel(total, monthlyCounts);
+  const densitySuffix = density === 'חריג' ? ' · ⚠️ יום חריג' : density === 'רגיל' ? ' · 📊 יום רגיל' : '';
+
   lines.push('');
-  lines.push(`סה"כ היום: <b>${total}</b> התראות`);
+  lines.push(`סה"כ היום: <b>${total}</b> התראות${densitySuffix}`);
   lines.push('');
 
   const sortedCats = [...byCat.entries()].sort((a, b) => b[1] - a[1]);
@@ -54,6 +108,15 @@ export function buildTodayMessage(alerts: AlertHistoryRow[], userCities: string[
     }
   }
 
+  const timeline = buildTodayTimeline(alerts);
+  if (timeline) {
+    lines.push('');
+    lines.push('──────────────');
+    lines.push('📋 <b>ציר זמן</b>');
+    lines.push('');
+    lines.push(timeline);
+  }
+
   return lines.join('\n');
 }
 
@@ -61,8 +124,9 @@ export function registerTodayHandler(bot: Bot): void {
   bot.command('today', async (ctx: Context) => {
     if (ctx.chat?.type !== 'private') return;
     const chatId = ctx.chat.id;
-    const alerts = getRecentAlerts(24);
+    const alerts = getAlertsToday();
     const userCities = getUserCities(chatId);
-    await ctx.reply(buildTodayMessage(alerts, userCities), { parse_mode: 'HTML' });
+    const monthlyCounts = getDailyCountsForMonth();
+    await ctx.reply(buildTodayMessage(alerts, userCities, monthlyCounts), { parse_mode: 'HTML' });
   });
 }


### PR DESCRIPTION
## Summary
- `buildTodayMessage()`: adds density label to summary line + compact chronological timeline section
- `buildTodayTimeline()`: new exported helper — max 15 events, one compact line each (HH:MM · emoji · cities +N)
- Handler switched to `getAlertsToday()` + `getDailyCountsForMonth()` (Israel-TZ aware, from PR #137)

**Stacked on:** #137 (density infrastructure)

## Sample output
```
📅 סיכום יומי

סה"כ היום: 12 התראות · ⚠️ יום חריג

🔴 ביטחוני: 8
📢 כללי: 4

🏠 5 התראות באזורך

──────────────
📋 ציר זמן

14:32 · 🔴 חיפה, עכו (+3)
14:45 · 📢 האירוע הסתיים
16:15 · 🔴 תל אביב
```

## Test plan
- [ ] `npx tsx --test src/__tests__/todayHandler.test.ts` — 16 tests pass (10 new)
- [ ] `npm test` — 968 tests, 0 failures
- [ ] Manual `/today` in DM — verify layout on mobile

Closes #97. Part of #99 and epic #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)