### PR TITLE
feat(dashboard): collapsible RTL sidebar with Hebrew nav hierarchy

### DIFF
--- a/dashboard-ui/src/index.css
+++ b/dashboard-ui/src/index.css
@@ -27,6 +27,9 @@
   --color-glow-green: rgba(34, 197, 94, 0.08);
   --color-border-glow-blue: rgba(59, 130, 246, 0.35);
   --color-border-glow-green: rgba(34, 197, 94, 0.35);
+  --color-tg:          #229ED9;
+  --color-glow-tg:     rgba(34, 158, 217, 0.07);
+  --color-border-tg:   rgba(34, 158, 217, 0.4);
 }
 
 * {

--- a/dashboard-ui/src/layout/Sidebar.tsx
+++ b/dashboard-ui/src/layout/Sidebar.tsx
@@ -1,15 +1,68 @@
 import { NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
-import { LayoutDashboard, Bell, Users, Radio, Settings, Globe, MessageSquare, Phone, Rss, MessageCircle, ChevronRight, ChevronLeft } from 'lucide-react';
+import {
+  Activity, Bell, Users, Radio, SlidersHorizontal,
+  Globe, MessageSquare, Phone, Rss, MessageCircle,
+  LayoutDashboard, Settings, ChevronLeft, ChevronDown,
+} from 'lucide-react';
 import { LiveDot } from '../components/ui';
 
-const GROUPS = [
-  { label: 'מידע', items: [{ to: '/overview', icon: LayoutDashboard, label: 'לוח בקרה' }, { to: '/alerts', icon: Bell, label: 'התראות' }] },
-  { label: 'פעולות', items: [{ to: '/subscribers', icon: Users, label: 'מנויים' }, { to: '/operations', icon: Radio, label: 'מרכז פיקוד' }] },
-  { label: 'ניהול', items: [{ to: '/settings', icon: Settings, label: 'הגדרות' }, { to: '/landing', icon: Globe, label: 'אתר נחיתה' }, { to: '/messages', icon: MessageSquare, label: 'תבניות' }, { to: '/whatsapp', icon: Phone, label: 'WhatsApp' }, { to: '/whatsapp-listeners', icon: Rss, label: 'WA Listeners' }, { to: '/telegram-listeners', icon: MessageCircle, label: 'TG Listeners' }] },
+// ─── nav shape ────────────────────────────────────────────────
+type IconComponent = React.ComponentType<{ size?: number; className?: string }>;
+interface NavItem { to: string; icon: IconComponent; label: string }
+interface NavGroup { key: string; icon: IconComponent; label: string; items: NavItem[]; defaultOpen?: boolean }
+type SidebarEntry =
+  | { kind: 'group'; group: NavGroup; dividerAfter?: boolean }
+  | { kind: 'item';  item: NavItem & { icon: IconComponent }; dividerAfter?: boolean };
+
+const NAV: SidebarEntry[] = [
+  {
+    kind: 'group',
+    group: {
+      key: 'monitoring',
+      icon: Activity,
+      label: 'ניטור',
+      defaultOpen: true,
+      items: [
+        { to: '/overview', icon: LayoutDashboard, label: 'לוח בקרה' },
+        { to: '/alerts',   icon: Bell,            label: 'היסטוריית התראות' },
+      ],
+    },
+  },
+  { kind: 'item', item: { to: '/subscribers', icon: Users, label: 'מנויים' } },
+  { kind: 'item', item: { to: '/operations',  icon: Radio, label: 'מרכז פיקוד' }, dividerAfter: true },
+  {
+    kind: 'group',
+    group: {
+      key: 'listeners',
+      icon: Rss,
+      label: 'מאזינים',
+      defaultOpen: false,
+      items: [
+        { to: '/whatsapp',           icon: Phone,          label: 'WhatsApp' },
+        { to: '/whatsapp-listeners', icon: Rss,            label: 'מאזיני WhatsApp' },
+        { to: '/telegram-listeners', icon: MessageCircle,  label: 'מאזיני Telegram' },
+      ],
+    },
+  },
+  {
+    kind: 'group',
+    group: {
+      key: 'system',
+      icon: SlidersHorizontal,
+      label: 'מערכת',
+      defaultOpen: false,
+      items: [
+        { to: '/settings', icon: Settings,      label: 'הגדרות' },
+        { to: '/messages', icon: MessageSquare, label: 'תבניות הודעות' },
+        { to: '/landing',  icon: Globe,         label: 'אתר נחיתה' },
+      ],
+    },
+  },
 ];
 
+// ─── helpers ──────────────────────────────────────────────────
 function formatUptime(s: number): string {
   const d = Math.floor(s / 86400);
   const h = Math.floor((s % 86400) / 3600);
@@ -19,6 +72,124 @@ function formatUptime(s: number): string {
   return `${m}m`;
 }
 
+function useLocalOpen(key: string, defaultValue: boolean): [boolean, () => void] {
+  const [open, setOpen] = useState<boolean>(() => {
+    const stored = localStorage.getItem(`sidebar_open_${key}`);
+    return stored !== null ? stored === 'true' : defaultValue;
+  });
+  const toggle = () => {
+    setOpen(prev => {
+      const next = !prev;
+      localStorage.setItem(`sidebar_open_${key}`, String(next));
+      return next;
+    });
+  };
+  return [open, toggle];
+}
+
+// ─── sub-components ───────────────────────────────────────────
+function NavItemLink({ item, collapsed }: { item: NavItem; collapsed: boolean }) {
+  const prefersReduced = useReducedMotion();
+  return (
+    <NavLink
+      to={item.to}
+      aria-label={item.label}
+      className={({ isActive }) =>
+        `flex items-center gap-3 px-4 py-2 text-sm transition-colors ${
+          isActive
+            ? 'border-l-2 border-[var(--color-tg)] text-[var(--color-tg)] bg-[var(--color-glow-tg)]'
+            : 'text-text-secondary hover:bg-white/5 hover:text-text-primary'
+        }`
+      }
+    >
+      <motion.div
+        whileHover={prefersReduced ? {} : { x: -2 }}
+        className="flex items-center gap-3 w-full"
+      >
+        <item.icon size={16} className="flex-shrink-0" />
+        <AnimatePresence mode="wait">
+          {!collapsed && (
+            <motion.span
+              key={item.to}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              className="whitespace-nowrap"
+            >
+              {item.label}
+            </motion.span>
+          )}
+        </AnimatePresence>
+      </motion.div>
+    </NavLink>
+  );
+}
+
+function CollapsibleGroup({ group, collapsed }: { group: NavGroup; collapsed: boolean }) {
+  const [open, toggle] = useLocalOpen(group.key, group.defaultOpen ?? false);
+  const prefersReduced = useReducedMotion();
+
+  return (
+    <div>
+      {/* Group header — clickable when sidebar is expanded */}
+      <button
+        onClick={collapsed ? undefined : toggle}
+        disabled={collapsed}
+        aria-expanded={open}
+        aria-label={group.label}
+        className="w-full flex items-center gap-3 px-4 py-2 text-sm text-text-muted hover:text-text-secondary transition-colors"
+      >
+        <group.icon size={16} className="flex-shrink-0" />
+        <AnimatePresence mode="wait">
+          {!collapsed && (
+            <motion.span
+              key={`${group.key}-label`}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.12 }}
+              className="flex-1 text-right whitespace-nowrap font-medium"
+            >
+              {group.label}
+            </motion.span>
+          )}
+        </AnimatePresence>
+        {!collapsed && (
+          <motion.div
+            animate={prefersReduced ? {} : { rotate: open ? 0 : -90 }}
+            transition={{ duration: 0.18 }}
+            className="flex-shrink-0"
+          >
+            <ChevronDown size={14} />
+          </motion.div>
+        )}
+      </button>
+
+      {/* Items */}
+      <AnimatePresence initial={false}>
+        {(open || collapsed) && (
+          <motion.div
+            key={`${group.key}-items`}
+            initial={prefersReduced ? false : { height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={prefersReduced ? {} : { height: 0, opacity: 0 }}
+            transition={{ duration: 0.18, ease: 'easeInOut' }}
+            className="overflow-hidden"
+          >
+            {group.items.map(item => (
+              <div key={item.to} className={collapsed ? '' : 'pr-2'}>
+                <NavItemLink item={item} collapsed={collapsed} />
+              </div>
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ─── main component ───────────────────────────────────────────
 export function Sidebar({ uptime }: { uptime: number }) {
   const [collapsed, setCollapsed] = useState(false);
   const prefersReduced = useReducedMotion();
@@ -29,6 +200,7 @@ export function Sidebar({ uptime }: { uptime: number }) {
       transition={prefersReduced ? { duration: 0 } : { duration: 0.2, ease: 'easeInOut' }}
       className="flex flex-col h-screen backdrop-blur-md bg-[var(--color-glass)] border-l border-border overflow-hidden flex-shrink-0"
     >
+      {/* Header */}
       <div className="flex items-center gap-2 p-4 border-b border-border">
         <Bell className="text-amber flex-shrink-0" size={20} />
         <AnimatePresence mode="wait">
@@ -49,57 +221,31 @@ export function Sidebar({ uptime }: { uptime: number }) {
           aria-expanded={!collapsed}
           className="mr-auto text-text-muted hover:text-text-secondary flex-shrink-0"
         >
-          {collapsed ? <ChevronLeft size={16} /> : <ChevronRight size={16} />}
+          <ChevronLeft
+            size={16}
+            style={{ transform: collapsed ? 'rotate(180deg)' : 'none', transition: 'transform 0.2s' }}
+          />
         </button>
       </div>
 
-      <nav aria-label="ניווט ראשי" className="flex-1 overflow-y-auto py-3 space-y-1">
-        {GROUPS.map((group, index) => (
-          <div key={group.label}>
-            <AnimatePresence mode="wait">
-              {!collapsed && (
-                <motion.p
-                  key={`label-${group.label}`}
-                  initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-                  transition={{ duration: 0.15 }}
-                  className="text-text-muted text-xs px-4 py-1 uppercase tracking-wider"
-                >
-                  {group.label}
-                </motion.p>
-              )}
-            </AnimatePresence>
-            {group.items.map(item => (
-              <NavLink
-                key={item.to}
-                to={item.to}
-                className={({ isActive }) =>
-                  `flex items-center gap-3 px-4 py-2 text-sm transition-colors ${isActive
-                    ? 'border-r-2 border-amber text-amber bg-[var(--color-glow-amber)]'
-                    : 'text-text-secondary hover:bg-white/5 hover:text-text-primary'}`
-                }
-              >
-                <motion.div whileHover={{ x: 2 }} className="flex items-center gap-3 w-full">
-                  <item.icon size={16} className="flex-shrink-0" />
-                  <AnimatePresence mode="wait">
-                    {!collapsed && (
-                      <motion.span
-                        key={`item-${item.to}`}
-                        initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-                        transition={{ duration: 0.15 }}
-                        className="whitespace-nowrap"
-                      >
-                        {item.label}
-                      </motion.span>
-                    )}
-                  </AnimatePresence>
-                </motion.div>
-              </NavLink>
-            ))}
-            {!collapsed && index < GROUPS.length - 1 && <div className="border-t border-border mx-4 my-1" />}
-          </div>
-        ))}
+      {/* Nav */}
+      <nav aria-label="ניווט ראשי" className="flex-1 overflow-y-auto py-2 space-y-0.5">
+        {NAV.map((entry) => {
+          const key = entry.kind === 'item' ? entry.item.to : entry.group.key;
+          const showDivider = !!entry.dividerAfter && !collapsed;
+          return (
+            <div key={key}>
+              {entry.kind === 'item'
+                ? <NavItemLink item={entry.item} collapsed={collapsed} />
+                : <CollapsibleGroup group={entry.group} collapsed={collapsed} />
+              }
+              {showDivider && <div className="border-t border-border mx-4 my-1" />}
+            </div>
+          );
+        })}
       </nav>
 
+      {/* Footer */}
       <div className="p-4 border-t border-border">
         <div className="flex items-center gap-2">
           <LiveDot color="green" />


### PR DESCRIPTION
## Summary
- Replaces flat 11-item sidebar with collapsible 5-entry hierarchy (Approach B from design spec)
- 3 collapsible groups: **ניטור** (overview+alerts), **מאזינים** (WhatsApp+listeners), **מערכת** (settings+messages+landing)
- 2 standalones: **מנויים**, **מרכז פיקוד**
- Fixes RTL active indicator bug: `border-l-2` (was incorrectly `border-r-2`)
- localStorage persists open/closed state per group
- All labels fully Hebrew — no "WA Listeners" / "TG Listeners"
- Adds Telegram blue CSS vars (`--color-tg`, `--color-glow-tg`, `--color-border-tg`)
- Accessible: `aria-label` on all nav links + group buttons (works in collapsed icon-only mode)
- Divider placement driven by `dividerAfter` data field — no magic index numbers

## Test plan
- [ ] Navigate all 11 pages — routing unchanged
- [ ] Collapse/expand each group, reload page — state persists via localStorage
- [ ] Active item shows blue left border (`border-l-2`)
- [ ] Sidebar collapses to icon-only mode
- [ ] `npm run build:dashboard` passes clean

Spec: `docs/superpowers/specs/2026-04-05-dashboard-ux-overhaul-design.md`