### PR TITLE
feat(dashboard): ensure Hebrew toast feedback on all mutations

### DIFF
--- a/dashboard-ui/src/components/messages/RoutingSection.tsx
+++ b/dashboard-ui/src/components/messages/RoutingSection.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
+import toast from 'react-hot-toast';
 import { GlassCard } from '../ui/GlassCard';
 import { api } from '../../api/client';
 import { ORDERED_CATEGORIES, CATEGORY_META } from '../../utils/categoryConfig';
@@ -58,7 +59,9 @@ export function RoutingSection() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['settings'] });
       setDirty(false);
+      toast.success('ניתוב עודכן');
     },
+    onError: (err) => toast.error(`שגיאה בשמירת ניתוב: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   const updateValue = (cat: AlertCategory, val: string) => {

--- a/dashboard-ui/src/components/messages/SimulationPanel.tsx
+++ b/dashboard-ui/src/components/messages/SimulationPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
+import toast from 'react-hot-toast';
 import { GlassCard } from '../ui/GlassCard';
 import { CityMultiSelect } from './CityMultiSelect';
 import { TelegramBubblePreview } from './TelegramBubblePreview';
@@ -113,6 +114,7 @@ export function SimulationPanel({ targetEntry }: SimulationPanelProps) {
         alertHistoryId,
         templateOverride: mergedTemplate ?? undefined,
       }),
+    onError: (err) => toast.error(`שגיאה בטעינת תצוגה מקדימה: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   // Telegram test-fire mutation
@@ -125,6 +127,7 @@ export function SimulationPanel({ targetEntry }: SimulationPanelProps) {
         templateOverride: mergedTemplate ?? undefined,
         platform: 'telegram',
       }),
+    onError: (err) => toast.error(`שגיאה בשליחת בדיקה: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   // WhatsApp test-fire mutation
@@ -137,6 +140,7 @@ export function SimulationPanel({ targetEntry }: SimulationPanelProps) {
         templateOverride: mergedTemplate ?? undefined,
         platform: 'whatsapp',
       }),
+    onError: (err) => toast.error(`שגיאה בשליחת בדיקה: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   const handleReplaySelect = (replayId: string) => {

--- a/dashboard-ui/src/components/messages/SystemMessagePanel.tsx
+++ b/dashboard-ui/src/components/messages/SystemMessagePanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
+import toast from 'react-hot-toast';
 import { GlassCard } from '../ui/GlassCard';
 import { TelegramBubblePreview } from './TelegramBubblePreview';
 import { ConfirmModal } from '../ConfirmModal';
@@ -43,6 +44,7 @@ export function SystemMessagePanel() {
       setText('');
       setConfirmOpen(false);
     },
+    onError: (err) => toast.error(`שגיאה בשליחה: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   const handleTopicChange = (value: string) => {

--- a/dashboard-ui/src/components/messages/VersionHistoryPanel.tsx
+++ b/dashboard-ui/src/components/messages/VersionHistoryPanel.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { api } from '../../api/client';
 
 interface HistoryRow {
@@ -58,10 +59,12 @@ export function VersionHistoryPanel({
     mutationFn: (versionId: number) =>
       api.post<{ ok: boolean }>(`/api/messages/${alertType}/rollback`, { versionId }),
     onSuccess: () => {
+      toast.success('גרסה שוחזרה');
       queryClient.invalidateQueries({ queryKey: ['messages'] });
       queryClient.invalidateQueries({ queryKey: ['template-history', alertType] });
       onClose();
     },
+    onError: (err) => toast.error(`שגיאה בשחזור: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   return (

--- a/dashboard-ui/src/pages/Messages.tsx
+++ b/dashboard-ui/src/pages/Messages.tsx
@@ -62,13 +62,14 @@ export default function Messages() {
       queryClient.invalidateQueries({ queryKey: ['messages'] });
       toast.success('תבניות נשמרו');
     },
-    onError: (err) => toast.error(`שגיאה: ${String(err)}`),
+    onError: (err) => toast.error(`שגיאה בשמירה: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   // Reset single type
   const resetMutation = useMutation({
     mutationFn: (alertType: string) => api.delete(`/api/messages/${alertType}`),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ['messages'] }),
+    onError: (err) => toast.error(`שגיאה באיפוס: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   // Reset all customized
@@ -82,6 +83,7 @@ export default function Messages() {
       queryClient.invalidateQueries({ queryKey: ['messages'] });
       toast.success('כל התבניות אופסו');
     },
+    onError: (err) => toast.error(`שגיאה באיפוס: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   // Import mutation
@@ -94,7 +96,7 @@ export default function Messages() {
       setImportModalOpen(false);
       toast.success(`יובאו ${data.count} תבניות`);
     },
-    onError: (err) => toast.error(`שגיאה בייבוא: ${String(err)}`),
+    onError: (err) => toast.error(`שגיאה בייבוא: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`),
   });
 
   // Field change handler
@@ -162,7 +164,7 @@ export default function Messages() {
       URL.revokeObjectURL(url);
       toast.success('ייצוא הושלם');
     } catch (err) {
-      toast.error(`שגיאה בייצוא: ${String(err)}`);
+      toast.error(`שגיאה בייצוא: ${err instanceof Error ? err.message : 'פעולה נכשלה'}`);
     }
   }, []);
 


### PR DESCRIPTION
## Summary

- Audited all `useMutation` calls across all 10 dashboard pages and sub-components
- Added missing `onError` Hebrew toast calls to 5 files
- Normalized pre-existing `String(err)` error formatting to consistent `err instanceof Error ? err.message : 'פעולה נכשלה'` pattern

## Files Changed

| File | What Was Added |
|------|----------------|
| `pages/Messages.tsx` | `onError` for `resetMutation`, `resetAllMutation`; normalized 3 pre-existing `String(err)` handlers |
| `components/messages/RoutingSection.tsx` | `onSuccess` + `onError` for `saveMutation` |
| `components/messages/VersionHistoryPanel.tsx` | `onSuccess` + `onError` for `rollbackMutation` |
| `components/messages/SystemMessagePanel.tsx` | `onError` for `sendMutation` |
| `components/messages/SimulationPanel.tsx` | `onError` for `replayPreviewMutation`, `testFireMutation`, `testFireWAMutation` |

All other pages (Settings, Subscribers, Operations, WhatsApp, WhatsAppListeners, TelegramListeners, LandingPage) were already fully covered.

## Test Plan

- [ ] `npm run build:dashboard` passes (✅ verified)
- [ ] Trigger a mutation failure on Messages page — confirm Hebrew error toast appears
- [ ] Trigger rollback in VersionHistoryPanel — confirm success toast appears
- [ ] Confirm no duplicate `<Toaster />` instances in any page

Part of Dashboard UX Overhaul Phase 1 — stacks on #147