### PR TITLE
fix: add RTL markers to Telegram alert messages

### DIFF
--- a/src/__tests__/telegramBot.test.ts
+++ b/src/__tests__/telegramBot.test.ts
@@ -661,6 +661,57 @@ describe('editAlert degraded chain (_editAlertChain)', () => {
   });
 });
 
+describe('RTL marks on zone headers', () => {
+  it('zone headers in buildZonedCityList start with RTL mark', () => {
+    // אור יהודה and בני ברק are both in zone דן
+    const result = buildZonedCityList(['אור יהודה', 'בני ברק']);
+    const lines = result.split('\n');
+    const headerLines = lines.filter(l => l.includes('▸'));
+    assert.ok(headerLines.length > 0, 'should have at least one zone header');
+    for (const line of headerLines) {
+      assert.ok(line.startsWith('\u200F'), `Zone header missing RTL mark: ${line}`);
+    }
+  });
+
+  it('noZone header in buildZonedCityList starts with RTL mark', () => {
+    const result = buildZonedCityList(['עיר לא קיימת בכלל']);
+    const lines = result.split('\n');
+    const headerLines = lines.filter(l => l.includes('▸'));
+    for (const line of headerLines) {
+      assert.ok(line.startsWith('\u200F'), `noZone header missing RTL mark: ${line}`);
+    }
+  });
+
+  it('zone headers in buildZoneOnlyList start with RTL mark', () => {
+    const result = buildZoneOnlyList(['אור יהודה', 'החותרים']);
+    const lines = result.split('\n');
+    const headerLines = lines.filter(l => l.includes('▸'));
+    assert.ok(headerLines.length > 0, 'should have at least one zone header');
+    for (const line of headerLines) {
+      assert.ok(line.startsWith('\u200F'), `Zone-only header missing RTL mark: ${line}`);
+    }
+  });
+
+  it('formatAlertMessage header line starts with RTL mark', () => {
+    const alert = { type: 'missiles', cities: ['תל אביב'] };
+    const result = formatAlertMessage(alert);
+    const lines = result.split('\n');
+    // Find the emoji+title header line (contains <b> and the alert title)
+    const emojiHeaderLine = lines.find(l => l.includes('<b>') && l.includes('</b>') && !l.includes('▸') && !l.includes('⏰') && !l.includes('⏱'));
+    assert.ok(emojiHeaderLine, 'should find the emoji header line');
+    assert.ok(emojiHeaderLine!.startsWith('\u200F'), `Header line missing RTL mark: ${emojiHeaderLine}`);
+  });
+
+  it('formatAlertMessage action card starts with RTL mark', () => {
+    const alert = { type: 'missiles', cities: ['תל אביב'] };
+    const result = formatAlertMessage(alert);
+    const lines = result.split('\n');
+    const actionLine = lines.find(l => l.includes('🛡'));
+    assert.ok(actionLine, 'missiles alert should have action card');
+    assert.ok(actionLine!.startsWith('\u200F'), `Action card missing RTL mark: ${actionLine}`);
+  });
+});
+
 describe('renderAllClearTemplate', () => {
   it('renders default template when cache has no all_clear entry', () => {
     const result = renderAllClearTemplate('גליל עליון', 'missiles');

--- a/src/telegramBot.ts
+++ b/src/telegramBot.ts
@@ -25,7 +25,7 @@ const SHELTER_TYPES = new Set([
 export function buildActionCard(alertType: string): string | null {
   if (!SHELTER_TYPES.has(alertType)) return null;
   const prefix = getInstructionsPrefix(alertType);
-  return `🛡 <b>${prefix ? escapeHtml(prefix) + ' ' : ''}היכנסו למרחב מוגן!</b>`;
+  return `\u200F🛡 <b>${prefix ? escapeHtml(prefix) + ' ' : ''}היכנסו למרחב מוגן!</b>`;
 }
 
 /** Telegram's hard caption limit for photo messages (sendPhoto / editMessageCaption). */
@@ -103,12 +103,12 @@ export function buildZonedCityList(cities: string[]): string {
     const zoneCount = ` (${sorted.length})`;
     const srEmoji = getSuperRegionByZone(zone)?.name.split(' ')[0] ?? '';
     const srPrefix = srEmoji ? `${srEmoji} ` : '';
-    sections.push(`▸ ${srPrefix}${urgencyPrefix}<b>${escapeHtml(zone)}</b>${zoneCount}${countdownSuffix}\n${buildCityList(sorted)}`);
+    sections.push(`\u200F▸ ${srPrefix}${urgencyPrefix}<b>${escapeHtml(zone)}</b>${zoneCount}${countdownSuffix}\n${buildCityList(sorted)}`);
   }
 
   if (noZone.length > 0) {
     const sortedNoZone = [...noZone].sort((a, b) => a.localeCompare(b, 'he'));
-    sections.push(`▸ <i>ערים נוספות</i>\n${buildCityList(sortedNoZone)}`);
+    sections.push(`\u200F▸ <i>ערים נוספות</i>\n${buildCityList(sortedNoZone)}`);
   }
 
   return sections.join('\n\n');
@@ -141,7 +141,7 @@ export function buildZoneOnlyList(cities: string[]): string {
       minCountdown > 0 && isFinite(minCountdown) ? `  ⏱ <b>${minCountdown} שנ׳</b>` : '';
     const srEmoji = getSuperRegionByZone(zone)?.name.split(' ')[0] ?? '';
     const srPrefix = srEmoji ? `${srEmoji} ` : '';
-    sections.push(`▸ ${srPrefix}<b>${escapeHtml(zone)}</b> (${count})${countdownSuffix}`);
+    sections.push(`\u200F▸ ${srPrefix}<b>${escapeHtml(zone)}</b> (${count})${countdownSuffix}`);
   }
 
   return sections.join('\n');
@@ -165,7 +165,7 @@ export function formatAlertMessage(alert: Alert, serial?: number, density?: 'ח�
 
   if (actionCard) parts.push(actionCard);
 
-  const headerLines = [`${emoji} <b>${escapeHtml(title)}</b>`, `⏰ ${escapeHtml(timeStr)}`];
+  const headerLines = [`\u200F${emoji} <b>${escapeHtml(title)}</b>`, `⏰ ${escapeHtml(timeStr)}`];
   if (summaryLine) headerLines.push(summaryLine);
   parts.push(headerLines.join('\n'));
 


### PR DESCRIPTION
## Summary
- Add `\u200F` (Right-to-Left Mark) at the start of zone headers, action card, and title line in `telegramBot.ts`
- Fixes misalignment where `▸` bullet appeared on the left side and Hebrew text was not properly RTL-anchored
- Zero existing tests broken (all use `.includes()` substring matchers)

## Changes
- `src/telegramBot.ts` — 5 lines changed: `buildActionCard()`, `buildZonedCityList()` (2 locations), `buildZoneOnlyList()`, `formatAlertMessage()`
- `src/__tests__/telegramBot.test.ts` — 5 new tests in `RTL marks on zone headers` block

## Test plan
- [x] All 83 telegramBot tests pass (was 78, +5 new)
- [x] Full suite: 1008/1008 pass
- [ ] Visual verification: send test alert via `npx tsx test-alert.ts` and verify RTL alignment in Telegram