### PR TITLE
fix: all-clear DM uses home_city with quiet-hours/snooze

### DIFF
--- a/src/__tests__/allClearIntegration.test.ts
+++ b/src/__tests__/allClearIntegration.test.ts
@@ -10,6 +10,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createAllClearTracker } from '../services/allClearTracker.js';
 import { createAllClearService } from '../services/allClearService.js';
+import type { SubscriberInfo } from '../db/subscriptionRepository.js';
 import type Database from 'better-sqlite3';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -59,6 +60,17 @@ function fakeDb(settings: Record<string, string>): Database.Database {
  * @param topicId - all_clear_topic_id (optional)
  * @param getUserIdsByZone - spy for subscriber lookup
  */
+function makeSubscriber(chatId: number): SubscriberInfo {
+  return {
+    chat_id: chatId,
+    format: 'short',
+    quiet_hours_enabled: false,
+    muted_until: null,
+    home_city: null,
+    matchedCities: [],
+  };
+}
+
 function makeStack(
   mode: string,
   topicId?: number,
@@ -71,11 +83,17 @@ function makeStack(
   const telegramCalls: Array<{ chatId: string; topicId: number | undefined; text: string }> = [];
   const renderCalls: Array<{ zone: string; alertType: string }> = [];
 
+  // Bridge getUserIdsByZone to getUsersByHomeCityInCities for integration tests
+  const getUsersByHomeCityInCities = (_cities: string[]) =>
+    getUserIdsByZone([]).map((id) => makeSubscriber(id));
+
   const service = createAllClearService({
     db: fakeDb(settings),
     chatId: 'chan-test',
     sendTelegram: async (chatId, tid, text) => { telegramCalls.push({ chatId, topicId: tid, text }); },
     getUserIdsByZone,
+    getUsersByHomeCityInCities,
+    shouldSkipForQuietHours: () => false,
     sendDm: async (userId, text) => { dmCalls.push({ userId, text }); },
     renderTemplate: (zone, alertType) => {
       renderCalls.push({ zone, alertType });
@@ -190,6 +208,8 @@ describe('allClearIntegration — duplicate suppression', () => {
       chatId: 'c',
       sendTelegram: async () => {},
       getUserIdsByZone: () => [1],
+      getUsersByHomeCityInCities: () => [makeSubscriber(1)],
+      shouldSkipForQuietHours: () => false,
       sendDm: async () => { firedCount++; },
       renderTemplate: () => 'text',
     });

--- a/src/__tests__/allClearService.test.ts
+++ b/src/__tests__/allClearService.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createAllClearService } from '../services/allClearService.js';
+import type { AllClearEvent } from '../services/allClearService.js';
+import type { SubscriberInfo } from '../db/subscriptionRepository.js';
 import type Database from 'better-sqlite3';
 
 // Builds a fake better-sqlite3 DB that returns settings from an in-memory map.
@@ -16,14 +18,27 @@ function fakeDb(settings: Record<string, string>): Database.Database {
   } as unknown as Database.Database;
 }
 
+function makeSubscriber(overrides: Partial<SubscriberInfo> & { chat_id: number }): SubscriberInfo {
+  return {
+    format: 'short',
+    quiet_hours_enabled: false,
+    muted_until: null,
+    home_city: null,
+    matchedCities: [],
+    ...overrides,
+  };
+}
+
 // Builds a service instance with controllable spies.
-function makeService(
-  mode: string,
-  topicId?: number,
-  getUserIdsByZone: (zones: string[]) => number[] = () => []
-) {
-  const settings: Record<string, string> = { all_clear_mode: mode };
-  if (topicId !== undefined) settings['all_clear_topic_id'] = String(topicId);
+function makeService(opts: {
+  mode: string;
+  topicId?: number;
+  getUserIdsByZone?: (zones: string[]) => number[];
+  getUsersByHomeCityInCities?: (cityNames: string[]) => SubscriberInfo[];
+  shouldSkipForQuietHours?: (alertType: string, quietEnabled: boolean, now: Date) => boolean;
+}) {
+  const settings: Record<string, string> = { all_clear_mode: opts.mode };
+  if (opts.topicId !== undefined) settings['all_clear_topic_id'] = String(opts.topicId);
 
   const dmCalls: Array<{ userId: number; text: string }> = [];
   const telegramCalls: Array<{ chatId: string; topicId: number | undefined; text: string }> = [];
@@ -32,7 +47,9 @@ function makeService(
     db: fakeDb(settings),
     chatId: 'chan-123',
     sendTelegram: async (chatId, tid, text) => { telegramCalls.push({ chatId, topicId: tid, text }); },
-    getUserIdsByZone,
+    getUserIdsByZone: opts.getUserIdsByZone ?? (() => []),
+    getUsersByHomeCityInCities: opts.getUsersByHomeCityInCities ?? (() => []),
+    shouldSkipForQuietHours: opts.shouldSkipForQuietHours ?? (() => false),
     sendDm: async (userId, text) => { dmCalls.push({ userId, text }); },
     renderTemplate: (zone, alertType) => `[${alertType}] ${zone}`,
   });
@@ -41,21 +58,30 @@ function makeService(
 }
 
 describe('allClearService — dm mode', () => {
-  it('sends DM to all subscribers of the zone', async () => {
-    const { service, dmCalls, telegramCalls } = makeService('dm', undefined, () => [10, 20]);
+  it('sends DM to subscribers whose home_city is in alertCities', async () => {
+    const { service, dmCalls, telegramCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: (cities) =>
+        cities.includes('תל אביב')
+          ? [makeSubscriber({ chat_id: 10, home_city: 'תל אביב' }), makeSubscriber({ chat_id: 20, home_city: 'תל אביב' })]
+          : [],
+    });
 
-    await service.handleAllClear([{ zone: 'גליל עליון', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב', 'רמת גן'] }]);
 
     assert.equal(dmCalls.length, 2);
     assert.equal(dmCalls[0].userId, 10);
     assert.equal(dmCalls[1].userId, 20);
-    assert.ok(dmCalls[0].text.includes('גליל עליון'), 'Rendered text passed to DM');
+    assert.ok(dmCalls[0].text.includes('דן'), 'Rendered text passed to DM');
     assert.equal(telegramCalls.length, 0, 'No channel message in dm mode');
   });
 
-  it('sends no DM when zone has no subscribers', async () => {
-    const { service, dmCalls } = makeService('dm', undefined, () => []);
-    await service.handleAllClear([{ zone: 'גולן', alertType: 'missiles' }]);
+  it('sends no DM when no subscribers have home_city in alertCities', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [],
+    });
+    await service.handleAllClear([{ zone: 'גולן', alertType: 'missiles', alertCities: ['קצרין'] }]);
     assert.equal(dmCalls.length, 0);
   });
 
@@ -66,10 +92,12 @@ describe('allClearService — dm mode', () => {
       chatId: 'c',
       sendTelegram: async () => { throw new Error('should not be called'); },
       getUserIdsByZone: () => [99],
+      getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 99, home_city: 'חיפה' })],
+      shouldSkipForQuietHours: () => false,
       sendDm: async (userId) => { dmCalls.push({ userId }); },
       renderTemplate: () => 'text',
     });
-    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['חיפה'] }]);
     assert.equal(dmCalls.length, 1);
     assert.equal(dmCalls[0].userId, 99);
   });
@@ -77,9 +105,14 @@ describe('allClearService — dm mode', () => {
 
 describe('allClearService — channel mode', () => {
   it('sends to channel with configured topicId, no DMs', async () => {
-    const { service, dmCalls, telegramCalls } = makeService('channel', 555, () => [1, 2]);
+    const { service, dmCalls, telegramCalls } = makeService({
+      mode: 'channel',
+      topicId: 555,
+      getUserIdsByZone: () => [1, 2],
+      getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 1 }), makeSubscriber({ chat_id: 2 })],
+    });
 
-    await service.handleAllClear([{ zone: 'שרון', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'שרון', alertType: 'missiles', alertCities: ['נתניה'] }]);
 
     assert.equal(telegramCalls.length, 1);
     assert.equal(telegramCalls[0].chatId, 'chan-123');
@@ -89,17 +122,21 @@ describe('allClearService — channel mode', () => {
   });
 
   it('sends with undefined topicId when not configured', async () => {
-    const { service, telegramCalls } = makeService('channel'); // no topicId
-    await service.handleAllClear([{ zone: 'חיפה', alertType: 'missiles' }]);
+    const { service, telegramCalls } = makeService({ mode: 'channel' }); // no topicId
+    await service.handleAllClear([{ zone: 'חיפה', alertType: 'missiles', alertCities: ['חיפה'] }]);
     assert.equal(telegramCalls[0].topicId, undefined);
   });
 });
 
 describe('allClearService — both mode', () => {
   it('sends DM and channel message', async () => {
-    const { service, dmCalls, telegramCalls } = makeService('both', 777, () => [99]);
+    const { service, dmCalls, telegramCalls } = makeService({
+      mode: 'both',
+      topicId: 777,
+      getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 99, home_city: 'ירושלים' })],
+    });
 
-    await service.handleAllClear([{ zone: 'ירושלים', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'ירושלים', alertType: 'missiles', alertCities: ['ירושלים'] }]);
 
     assert.equal(dmCalls.length, 1);
     assert.equal(dmCalls[0].userId, 99);
@@ -110,13 +147,19 @@ describe('allClearService — both mode', () => {
 
 describe('allClearService — multiple events', () => {
   it('processes each zone event independently', async () => {
-    const { service, dmCalls } = makeService('dm', undefined, (zones) =>
-      zones.includes('דן') ? [1] : zones.includes('שרון') ? [2] : []
-    );
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: (cities) =>
+        cities.includes('תל אביב')
+          ? [makeSubscriber({ chat_id: 1, home_city: 'תל אביב' })]
+          : cities.includes('נתניה')
+            ? [makeSubscriber({ chat_id: 2, home_city: 'נתניה' })]
+            : [],
+    });
 
     await service.handleAllClear([
-      { zone: 'דן', alertType: 'missiles' },
-      { zone: 'שרון', alertType: 'missiles' },
+      { zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] },
+      { zone: 'שרון', alertType: 'missiles', alertCities: ['נתניה'] },
     ]);
 
     const userIds = dmCalls.map((c) => c.userId).sort();
@@ -131,7 +174,13 @@ describe('allClearService — error resilience', () => {
       db: fakeDb({ all_clear_mode: 'dm' }),
       chatId: 'c',
       sendTelegram: async () => {},
-      getUserIdsByZone: () => [1, 2, 3],
+      getUserIdsByZone: () => [],
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 1 }),
+        makeSubscriber({ chat_id: 2 }),
+        makeSubscriber({ chat_id: 3 }),
+      ],
+      shouldSkipForQuietHours: () => false,
       sendDm: async (userId) => {
         if (userId === 2) throw new Error('Telegram 429');
         successfulIds.push(userId);
@@ -139,7 +188,7 @@ describe('allClearService — error resilience', () => {
       renderTemplate: () => 'text',
     });
 
-    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
 
     assert.deepEqual(successfulIds.sort(), [1, 3], 'Users 1 and 3 received DM despite failure for user 2');
   });
@@ -151,16 +200,110 @@ describe('allClearService — error resilience', () => {
       chatId: 'c',
       sendTelegram: async () => { callCount++; throw new Error('network error'); },
       getUserIdsByZone: () => [],
+      getUsersByHomeCityInCities: () => [],
+      shouldSkipForQuietHours: () => false,
       sendDm: async () => {},
       renderTemplate: () => 'text',
     });
 
     // Two events — both should be attempted even though the first throws
     await service.handleAllClear([
-      { zone: 'דן', alertType: 'missiles' },
-      { zone: 'שרון', alertType: 'missiles' },
+      { zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] },
+      { zone: 'שרון', alertType: 'missiles', alertCities: ['נתניה'] },
     ]);
 
     assert.equal(callCount, 2, 'Both channel sends attempted despite first failure');
+  });
+});
+
+describe('allClearService — home_city filtering', () => {
+  it('user with home_city in alertCities receives all-clear', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: (cities) =>
+        cities.includes('חיפה')
+          ? [makeSubscriber({ chat_id: 42, home_city: 'חיפה' })]
+          : [],
+    });
+
+    await service.handleAllClear([{ zone: 'חיפה', alertType: 'missiles', alertCities: ['חיפה', 'קריית אתא'] }]);
+
+    assert.equal(dmCalls.length, 1);
+    assert.equal(dmCalls[0].userId, 42);
+  });
+
+  it('user with home_city NOT in alertCities does NOT receive all-clear', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      // getUsersByHomeCityInCities correctly returns empty when home_city not in list
+      getUsersByHomeCityInCities: () => [],
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 0, 'No DM sent when home_city not in alertCities');
+  });
+});
+
+describe('allClearService — quiet hours and snooze', () => {
+  it('user in quiet hours does NOT receive all-clear for drills', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 50, home_city: 'תל אביב', quiet_hours_enabled: true }),
+      ],
+      shouldSkipForQuietHours: (_alertType, quietEnabled) => quietEnabled,
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'drill', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 0, 'DM skipped for quiet-hours user');
+  });
+
+  it('user in quiet hours DOES receive all-clear for security alerts', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 51, home_city: 'תל אביב', quiet_hours_enabled: true }),
+      ],
+      // shouldSkipForQuietHours returns false for security alerts even when quiet is enabled
+      shouldSkipForQuietHours: () => false,
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 1, 'DM sent for security alert despite quiet hours');
+    assert.equal(dmCalls[0].userId, 51);
+  });
+
+  it('snoozed user does NOT receive all-clear for general alerts', async () => {
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 60, home_city: 'תל אביב', muted_until: futureDate }),
+      ],
+    });
+
+    // 'general' category is suppressible by snooze
+    await service.handleAllClear([{ zone: 'דן', alertType: 'newsFlash', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 0, 'DM skipped for snoozed user');
+  });
+
+  it('snoozed user DOES receive all-clear for security alerts', async () => {
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 61, home_city: 'תל אביב', muted_until: futureDate }),
+      ],
+    });
+
+    // 'missiles' maps to 'security' category — snooze does NOT apply
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 1, 'DM sent for security alert despite snooze');
+    assert.equal(dmCalls[0].userId, 61);
   });
 });

--- a/src/__tests__/allClearTracker.test.ts
+++ b/src/__tests__/allClearTracker.test.ts
@@ -40,7 +40,22 @@ describe('allClearTracker', () => {
 
     timers.fireAll();
     assert.equal(fired.length, 1);
-    assert.deepEqual(fired[0], [{ zone: 'גליל עליון', alertType: 'missiles' }]);
+    assert.deepEqual(fired[0], [{ zone: 'גליל עליון', alertType: 'missiles', alertCities: [] }]);
+  });
+
+  it('fires onAllClear with alertCities when provided', () => {
+    const fired: AllClearEvent[][] = [];
+    const timers = createFakeTimers();
+    const tracker = createAllClearTracker({
+      scheduleFn: timers.scheduleFn,
+      cancelScheduleFn: timers.cancelScheduleFn,
+      onAllClear: (events) => fired.push(events),
+    });
+
+    tracker.recordAlert(['דן'], 'missiles', ['תל אביב', 'רמת גן']);
+    timers.fireAll();
+    assert.equal(fired.length, 1);
+    assert.deepEqual(fired[0][0].alertCities, ['תל אביב', 'רמת גן']);
   });
 
   it('resets the timer when a new alert arrives for the same zone', () => {
@@ -61,7 +76,7 @@ describe('allClearTracker', () => {
 
     timers.fireAll();
     assert.equal(fired.length, 1, 'Should fire exactly once');
-    assert.deepEqual(fired[0], [{ zone: 'דן', alertType: 'missiles' }]);
+    assert.deepEqual(fired[0], [{ zone: 'דן', alertType: 'missiles', alertCities: [] }]);
   });
 
   it('deduplicates — does not fire twice for same zone without new alert', () => {

--- a/src/__tests__/subscriptionRepository.test.ts
+++ b/src/__tests__/subscriptionRepository.test.ts
@@ -13,6 +13,7 @@ import {
   removeAllSubscriptions,
   getUsersForCities,
   getUserIdsByZone,
+  getUsersByHomeCityInCities,
   initSubscriptionCache,
   updateSubscriberData,
 } from '../db/subscriptionRepository';
@@ -298,5 +299,75 @@ describe('subscriptionRepository — getUserIdsByZone', () => {
 
     const ids = getUserIdsByZone(['דן']);
     assert.ok(!ids.includes(1006), 'Inactive DM user should be excluded');
+  });
+});
+
+describe('subscriptionRepository — getUsersByHomeCityInCities', () => {
+  before(() => { initDb(); });
+  after(() => { closeDb(); });
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM subscriptions').run();
+    getDb().prepare('DELETE FROM users').run();
+    initSubscriptionCache();
+  });
+
+  it('returns users whose home_city is in the provided list', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2001, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2001, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2002, 'חיפה');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2002, 'חיפה');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב', 'חיפה']);
+    const ids = results.map((r) => r.chat_id).sort();
+    assert.deepEqual(ids, [2001, 2002]);
+  });
+
+  it('excludes users whose home_city is NOT in the list', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2003, 'באר שבע');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2003, 'באר שבע');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב', 'חיפה']);
+    assert.equal(results.length, 0, 'User with home_city not in list should be excluded');
+  });
+
+  it('excludes users with is_dm_active = false', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city, is_dm_active) VALUES (?, ?, 0)').run(2004, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2004, 'תל אביב');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב']);
+    assert.equal(results.length, 0, 'Inactive DM user should be excluded');
+  });
+
+  it('returns empty array when no home_city matches', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2005, 'אילת');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2005, 'אילת');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב', 'ירושלים']);
+    assert.deepEqual(results, []);
+  });
+
+  it('returns empty array for empty city list', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2006, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2006, 'תל אביב');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities([]);
+    assert.deepEqual(results, []);
+  });
+
+  it('includes quiet_hours_enabled and muted_until in returned data', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city, quiet_hours_enabled, muted_until) VALUES (?, ?, 1, ?)').run(2007, 'תל אביב', '2099-01-01T00:00:00Z');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2007, 'תל אביב');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב']);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].quiet_hours_enabled, true);
+    assert.equal(results[0].muted_until, '2099-01-01T00:00:00Z');
+    assert.equal(results[0].home_city, 'תל אביב');
   });
 });

--- a/src/db/subscriptionRepository.ts
+++ b/src/db/subscriptionRepository.ts
@@ -250,6 +250,58 @@ export function getUserIdsByZone(zones: string[]): number[] {
   return Array.from(chatIds);
 }
 
+// Returns DM-active subscribers whose home_city is in the provided city list.
+// Used by allClearService to dispatch "שקט חזר" messages only to users
+// whose home city was actually in the alert (not just any city in the zone).
+export function getUsersByHomeCityInCities(cityNames: string[]): SubscriberInfo[] {
+  if (cityNames.length === 0) return [];
+
+  if (!cacheInitialized) {
+    // DB fallback
+    const placeholders = cityNames.map(() => '?').join(', ');
+    const rows = getDb()
+      .prepare(
+        `SELECT DISTINCT u.chat_id, u.format, u.quiet_hours_enabled, u.muted_until, u.home_city
+         FROM users u
+         WHERE u.home_city IN (${placeholders}) AND u.is_dm_active = 1`
+      )
+      .all(...cityNames) as {
+        chat_id: number;
+        format: NotificationFormat;
+        quiet_hours_enabled: number;
+        muted_until: string | null;
+        home_city: string | null;
+      }[];
+
+    return rows.map((row) => ({
+      chat_id: row.chat_id,
+      format: row.format,
+      quiet_hours_enabled: row.quiet_hours_enabled === 1,
+      muted_until: row.muted_until ?? null,
+      home_city: row.home_city ?? null,
+      matchedCities: row.home_city ? [row.home_city] : [],
+    }));
+  }
+
+  const citySet = new Set(cityNames);
+  const results: SubscriberInfo[] = [];
+
+  for (const [chatId, data] of subscriberData) {
+    if (!data.is_dm_active) continue;
+    if (!data.home_city || !citySet.has(data.home_city)) continue;
+    results.push({
+      chat_id: chatId,
+      format: data.format,
+      quiet_hours_enabled: data.quiet_hours_enabled,
+      muted_until: data.muted_until,
+      home_city: data.home_city,
+      matchedCities: [data.home_city],
+    });
+  }
+
+  return results;
+}
+
 export function evictSubscriberFromCache(chatId: number, cityName?: string): void {
   if (!cacheInitialized) return;
   if (cityName !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import { Alert } from './types';
 import { initDb, closeDb } from './db/schema';
 import { initializeCache } from './mapService';
 import { setupBotHandlers } from './bot/botSetup';
-import { notifySubscribers } from './services/dmDispatcher';
+import { notifySubscribers, shouldSkipForQuietHours } from './services/dmDispatcher';
+import { dmQueue } from './services/dmQueue.js';
 import { shouldSkipMap } from './alertHelpers';
 import { handleNewAlert } from './alertHandler';
 import { insertAlert as insertAlertHistory, countAlertsToday, getDailyCountsForMonth } from './db/alertHistoryRepository.js';
@@ -27,7 +28,7 @@ import { createMessageHandler } from './whatsapp/whatsappListenerService.js';
 import { initializeTelegramListener } from './telegram-listener/telegramListenerService.js';
 import { disconnect as disconnectTelegramListener } from './telegram-listener/telegramListenerClient.js';
 import { InputFile } from 'grammy';
-import { initSubscriptionCache, getUserIdsByZone } from './db/subscriptionRepository.js';
+import { initSubscriptionCache, getUserIdsByZone, getUsersByHomeCityInCities } from './db/subscriptionRepository.js';
 import { initUsageCache } from './db/mapboxUsageRepository.js';
 import { createAllClearTracker } from './services/allClearTracker.js';
 import { createAllClearService } from './services/allClearService.js';
@@ -168,8 +169,10 @@ for (const envVar of REQUIRED_ENV_VARS) {
       });
     },
     getUserIdsByZone,
+    getUsersByHomeCityInCities,
+    shouldSkipForQuietHours,
     sendDm: async (userId, text) => {
-      await bot.api.sendMessage(String(userId), text, { parse_mode: 'HTML' });
+      dmQueue.enqueueAll([{ chatId: String(userId), text }]);
     },
     renderTemplate: renderAllClearTemplate,
   });
@@ -234,7 +237,7 @@ for (const envVar of REQUIRED_ENV_VARS) {
       if (isOfficialAllClear) {
         allClearTracker.cancelAlert(alertZones);
       } else {
-        allClearTracker.recordAlert(alertZones, alert.type);
+        allClearTracker.recordAlert(alertZones, alert.type, alert.cities);
       }
     }
 

--- a/src/services/allClearService.ts
+++ b/src/services/allClearService.ts
@@ -1,13 +1,10 @@
 import type Database from 'better-sqlite3';
 import { getSetting } from '../dashboard/settingsRepository.js';
 import { log } from '../logger.js';
-
-// Mirrors AllClearEvent from allClearTracker.ts (PR #133).
-// Import from there once that PR is merged.
-export interface AllClearEvent {
-  zone: string;
-  alertType: string;
-}
+import { ALERT_TYPE_CATEGORY } from '../topicRouter.js';
+import type { AllClearEvent } from './allClearTracker.js';
+import type { SubscriberInfo } from '../db/subscriptionRepository.js';
+export type { AllClearEvent };
 
 export type AllClearMode = 'dm' | 'channel' | 'both';
 
@@ -16,6 +13,8 @@ export interface AllClearServiceDeps {
   chatId: string;
   sendTelegram: (chatId: string, topicId: number | undefined, text: string) => Promise<void>;
   getUserIdsByZone: (zones: string[]) => number[];
+  getUsersByHomeCityInCities: (cityNames: string[]) => SubscriberInfo[];
+  shouldSkipForQuietHours: (alertType: string, quietEnabled: boolean, now: Date) => boolean;
   sendDm: (userId: number, text: string) => Promise<void>;
   renderTemplate: (zone: string, alertType: string) => string;
 }
@@ -26,7 +25,7 @@ export function createAllClearService(deps: AllClearServiceDeps) {
     const topicIdStr = getSetting(deps.db, 'all_clear_topic_id');
     const topicId = topicIdStr ? Number(topicIdStr) : undefined;
 
-    for (const { zone, alertType } of events) {
+    for (const { zone, alertType, alertCities } of events) {
       let text: string;
       try {
         text = deps.renderTemplate(zone, alertType);
@@ -36,12 +35,27 @@ export function createAllClearService(deps: AllClearServiceDeps) {
       }
 
       if (mode === 'dm' || mode === 'both') {
-        const userIds = deps.getUserIdsByZone([zone]);
-        for (const userId of userIds) {
+        const subscribers = deps.getUsersByHomeCityInCities(alertCities);
+        const now = new Date();
+
+        // Quiet-hours and snooze: only suppress drills/general categories.
+        // Security, nature, and environmental alerts always pass through.
+        const category = ALERT_TYPE_CATEGORY[alertType] ?? 'general';
+        const muteApplies = category === 'drills' || category === 'general';
+
+        for (const subscriber of subscribers) {
+          // Quiet-hours filter
+          if (deps.shouldSkipForQuietHours(alertType, subscriber.quiet_hours_enabled, now)) {
+            continue;
+          }
+          // Snooze filter
+          if (muteApplies && subscriber.muted_until && new Date(subscriber.muted_until) > now) {
+            continue;
+          }
           try {
-            await deps.sendDm(userId, text);
+            await deps.sendDm(subscriber.chat_id, text);
           } catch (err) {
-            log('error', 'AllClear', `DM נכשל למשתמש ${userId} (אזור "${zone}"): ${String(err)}`);
+            log('error', 'AllClear', `DM נכשל למשתמש ${subscriber.chat_id} (אזור "${zone}"): ${String(err)}`);
           }
         }
       }

--- a/src/services/allClearTracker.ts
+++ b/src/services/allClearTracker.ts
@@ -1,6 +1,7 @@
 export interface AllClearEvent {
   zone: string;
   alertType: string;
+  alertCities: string[];
 }
 
 export interface AllClearDeps {
@@ -13,6 +14,7 @@ export interface AllClearDeps {
 interface ZoneTimer {
   id: ReturnType<typeof setTimeout>;
   alertType: string;
+  alertCities: string[];
 }
 
 const DEFAULT_QUIET_WINDOW_MS = 600_000; // 10 minutes
@@ -24,7 +26,7 @@ export function createAllClearTracker(deps: AllClearDeps) {
   const cancel = deps.cancelScheduleFn ?? clearTimeout;
   const windowMs = deps.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS;
 
-  function recordAlert(zones: string[], alertType: string): void {
+  function recordAlert(zones: string[], alertType: string, alertCities: string[] = []): void {
     for (const zone of zones) {
       const existing = timers.get(zone);
       if (existing) cancel(existing.id);
@@ -35,11 +37,11 @@ export function createAllClearTracker(deps: AllClearDeps) {
       const id = schedule(() => {
         if (!firedZones.has(zone)) {
           firedZones.add(zone);
-          deps.onAllClear([{ zone, alertType }]);
+          deps.onAllClear([{ zone, alertType, alertCities }]);
         }
         timers.delete(zone);
       }, windowMs);
-      timers.set(zone, { id, alertType });
+      timers.set(zone, { id, alertType, alertCities });
     }
   }
 


### PR DESCRIPTION
## Summary
- All-clear ("נשמו") DM now only sent when user's `home_city` was in the original alert cities (was: zone-level matching)
- Quiet-hours and snooze filters applied to all-clear DMs (was: bypassed entirely)
- All-clear DMs routed through `dmQueue` for Telegram 429 rate limiting (was: direct `bot.api.sendMessage`)

## Changes
- `src/services/allClearTracker.ts` — `AllClearEvent` extended with `alertCities: string[]`
- `src/db/subscriptionRepository.ts` — new `getUsersByHomeCityInCities()` function
- `src/services/allClearService.ts` — rewritten DM path: home_city matching + quiet-hours + snooze
- `src/index.ts` — threads `alert.cities` to tracker, wires `sendDm` through `dmQueue`
- 4 test files updated/added with 13 new tests

## Test plan
- [x] allClearService: 15 tests pass
- [x] subscriptionRepository: 28 tests pass (was 22, +6 new)
- [x] allClearTracker: 10 tests pass
- [x] Full suite: 1016/1016 pass
- [ ] Manual: subscribe to city A, trigger alert for city B (same zone), verify "נשמו" NOT received
- [ ] Manual: subscribe to city A, trigger alert for city A, verify "נשמו" IS received after quiet window