### PR TITLE
feat: add AES-256-GCM envelope encryption module for settings

### DIFF
--- a/src/__tests__/crypto.test.ts
+++ b/src/__tests__/crypto.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  initCrypto,
+  isCryptoReady,
+  encryptValue,
+  decryptValue,
+  rewrapDek,
+  _resetCryptoForTesting,
+} from '../dashboard/crypto.js';
+
+const TEST_SECRET = 'test-dashboard-secret-at-least-32-chars-long!!';
+const ALT_SECRET = 'another-secret-for-rotation-testing-32-chars!!';
+
+function createDb(): Database.Database {
+  const db = new Database(':memory:');
+  initSchema(db);
+  return db;
+}
+
+describe('crypto module', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    _resetCryptoForTesting();
+    db = createDb();
+  });
+
+  after(() => {
+    _resetCryptoForTesting();
+  });
+
+  // ── Initialization ──────────────────────────────────────────────────────
+
+  describe('initCrypto', () => {
+    it('throws when DASHBOARD_SECRET is empty', () => {
+      assert.throws(
+        () => initCrypto(db, ''),
+        /DASHBOARD_SECRET is required/
+      );
+    });
+
+    it('sets isCryptoReady() to true after init', () => {
+      assert.equal(isCryptoReady(), false);
+      initCrypto(db, TEST_SECRET);
+      assert.equal(isCryptoReady(), true);
+    });
+
+    it('creates _encryption_salt in settings on first run', () => {
+      initCrypto(db, TEST_SECRET);
+      const row = db.prepare("SELECT value FROM settings WHERE key = '_encryption_salt'").get() as { value: string } | undefined;
+      assert.ok(row, '_encryption_salt should be stored');
+      assert.equal(Buffer.from(row!.value, 'hex').length, 32, 'salt should be 32 bytes');
+    });
+
+    it('creates _wrapped_dek in settings on first run', () => {
+      initCrypto(db, TEST_SECRET);
+      const row = db.prepare("SELECT value FROM settings WHERE key = '_wrapped_dek'").get() as { value: string } | undefined;
+      assert.ok(row, '_wrapped_dek should be stored');
+      const parsed = JSON.parse(row!.value);
+      assert.ok(parsed.iv, 'wrapped DEK should have iv');
+      assert.ok(parsed.tag, 'wrapped DEK should have tag');
+      assert.ok(parsed.ciphertext, 'wrapped DEK should have ciphertext');
+    });
+
+    it('reuses existing salt and DEK on subsequent init', () => {
+      initCrypto(db, TEST_SECRET);
+      const plaintext = 'hello-world';
+      const encrypted = encryptValue(plaintext);
+
+      // Re-init with same secret — should unwrap the same DEK
+      _resetCryptoForTesting();
+      initCrypto(db, TEST_SECRET);
+      const decrypted = decryptValue(encrypted);
+      assert.equal(decrypted, plaintext);
+    });
+
+    it('fails to unwrap DEK with wrong secret', () => {
+      initCrypto(db, TEST_SECRET);
+      _resetCryptoForTesting();
+
+      assert.throws(
+        () => initCrypto(db, 'wrong-secret-that-is-definitely-not-correct'),
+        /Unsupported state or unable to authenticate data/
+      );
+    });
+  });
+
+  // ── Encrypt / Decrypt ───────────────────────────────────────────────────
+
+  describe('encryptValue / decryptValue', () => {
+    // Override parent beforeEach — we need crypto initialised for every test
+    beforeEach(() => {
+      _resetCryptoForTesting();
+      db = createDb();
+      initCrypto(db, TEST_SECRET);
+    });
+
+    it('throws when crypto is not initialised', () => {
+      _resetCryptoForTesting();
+      assert.throws(() => encryptValue('test'), /Crypto not initialised/);
+      assert.throws(() => decryptValue('{}'), /Crypto not initialised/);
+    });
+
+    it('roundtrips a simple string', () => {
+      const original = 'my-secret-telegram-bot-token-12345';
+      const encrypted = encryptValue(original);
+      const decrypted = decryptValue(encrypted);
+      assert.equal(decrypted, original);
+    });
+
+    it('roundtrips an empty string', () => {
+      const encrypted = encryptValue('');
+      assert.equal(decryptValue(encrypted), '');
+    });
+
+    it('roundtrips Hebrew text', () => {
+      const hebrew = 'סיסמה סודית מאוד';
+      const encrypted = encryptValue(hebrew);
+      assert.equal(decryptValue(encrypted), hebrew);
+    });
+
+    it('roundtrips a long value (API key length)', () => {
+      const long = 'sk-proj-' + 'a'.repeat(200);
+      const encrypted = encryptValue(long);
+      assert.equal(decryptValue(encrypted), long);
+    });
+
+    it('produces different ciphertext for the same plaintext (unique IV)', () => {
+      const plaintext = 'same-input-twice';
+      const enc1 = encryptValue(plaintext);
+      const enc2 = encryptValue(plaintext);
+      assert.notEqual(enc1, enc2, 'different IVs should produce different ciphertext');
+      // But both decrypt to the same value
+      assert.equal(decryptValue(enc1), plaintext);
+      assert.equal(decryptValue(enc2), plaintext);
+    });
+
+    it('detects tampered ciphertext (GCM auth tag)', () => {
+      const encrypted = encryptValue('secret');
+      const payload = JSON.parse(encrypted);
+      // Flip a byte in the ciphertext
+      const buf = Buffer.from(payload.ciphertext, 'base64');
+      buf[0] = buf[0]! ^ 0xff;
+      payload.ciphertext = buf.toString('base64');
+
+      assert.throws(
+        () => decryptValue(JSON.stringify(payload)),
+        /Unsupported state or unable to authenticate data/
+      );
+    });
+
+    it('detects tampered auth tag', () => {
+      const encrypted = encryptValue('secret');
+      const payload = JSON.parse(encrypted);
+      const tagBuf = Buffer.from(payload.tag, 'base64');
+      tagBuf[0] = tagBuf[0]! ^ 0xff;
+      payload.tag = tagBuf.toString('base64');
+
+      assert.throws(
+        () => decryptValue(JSON.stringify(payload)),
+        /Unsupported state or unable to authenticate data/
+      );
+    });
+
+    it('detects tampered IV', () => {
+      const encrypted = encryptValue('secret');
+      const payload = JSON.parse(encrypted);
+      const ivBuf = Buffer.from(payload.iv, 'base64');
+      ivBuf[0] = ivBuf[0]! ^ 0xff;
+      payload.iv = ivBuf.toString('base64');
+
+      assert.throws(
+        () => decryptValue(JSON.stringify(payload)),
+        /Unsupported state or unable to authenticate data/
+      );
+    });
+  });
+
+  // ── Schema Migration ────────────────────────────────────────────────────
+
+  describe('schema — encrypted column', () => {
+    it('settings table has encrypted column with default 0', () => {
+      const info = db.prepare('PRAGMA table_info(settings)').all() as {
+        name: string;
+        dflt_value: string | null;
+      }[];
+      const col = info.find(c => c.name === 'encrypted');
+      assert.ok(col, 'encrypted column should exist on settings table');
+      assert.equal(col!.dflt_value, '0');
+    });
+
+    it('encrypted column defaults to 0 for normal settings', () => {
+      db.prepare("INSERT INTO settings (key, value) VALUES ('test_key', 'test_value')").run();
+      const row = db.prepare("SELECT encrypted FROM settings WHERE key = 'test_key'").get() as { encrypted: number };
+      assert.equal(row.encrypted, 0);
+    });
+
+    it('encrypted column can be set to 1', () => {
+      db.prepare("INSERT INTO settings (key, value, encrypted) VALUES ('secret_key', 'encrypted_json', 1)").run();
+      const row = db.prepare("SELECT encrypted FROM settings WHERE key = 'secret_key'").get() as { encrypted: number };
+      assert.equal(row.encrypted, 1);
+    });
+  });
+
+  // ── DEK Rotation (rewrapDek) ────────────────────────────────────────────
+
+  describe('rewrapDek', () => {
+    it('re-wraps DEK so new secret can decrypt existing values', () => {
+      initCrypto(db, TEST_SECRET);
+      const plaintext = 'sensitive-token-value';
+      const encrypted = encryptValue(plaintext);
+
+      // Rotate
+      rewrapDek(db, TEST_SECRET, ALT_SECRET);
+
+      // Re-init with new secret — should succeed
+      _resetCryptoForTesting();
+      initCrypto(db, ALT_SECRET);
+
+      // Existing encrypted values still decrypt
+      assert.equal(decryptValue(encrypted), plaintext);
+    });
+
+    it('old secret no longer works after rotation', () => {
+      initCrypto(db, TEST_SECRET);
+      rewrapDek(db, TEST_SECRET, ALT_SECRET);
+
+      _resetCryptoForTesting();
+      assert.throws(
+        () => initCrypto(db, TEST_SECRET),
+        /Unsupported state or unable to authenticate data/
+      );
+    });
+
+    it('throws when salt is missing', () => {
+      assert.throws(
+        () => rewrapDek(db, TEST_SECRET, ALT_SECRET),
+        /No encryption salt found/
+      );
+    });
+
+    it('throws when wrapped DEK is missing', () => {
+      db.prepare("INSERT INTO settings (key, value) VALUES ('_encryption_salt', 'abcd1234')").run();
+      assert.throws(
+        () => rewrapDek(db, TEST_SECRET, ALT_SECRET),
+        /No wrapped DEK found/
+      );
+    });
+
+    it('generates a new salt on rotation (old salt invalidated)', () => {
+      initCrypto(db, TEST_SECRET);
+      const saltBefore = db.prepare("SELECT value FROM settings WHERE key = '_encryption_salt'").get() as { value: string };
+
+      rewrapDek(db, TEST_SECRET, ALT_SECRET);
+
+      const saltAfter = db.prepare("SELECT value FROM settings WHERE key = '_encryption_salt'").get() as { value: string };
+      assert.notEqual(saltBefore.value, saltAfter.value, 'salt should change on rotation');
+    });
+
+    it('preserves ability to encrypt new values after rotation', () => {
+      initCrypto(db, TEST_SECRET);
+      rewrapDek(db, TEST_SECRET, ALT_SECRET);
+
+      const newEncrypted = encryptValue('post-rotation-value');
+      assert.equal(decryptValue(newEncrypted), 'post-rotation-value');
+    });
+  });
+
+  // ── Persistence ─────────────────────────────────────────────────────────
+
+  describe('persistence across sessions', () => {
+    it('encrypts in one session, decrypts in another (same DB, same secret)', () => {
+      initCrypto(db, TEST_SECRET);
+      const encrypted = encryptValue('cross-session-secret');
+
+      // Simulate restart: reset module state, re-init with same DB
+      _resetCryptoForTesting();
+      assert.equal(isCryptoReady(), false);
+
+      initCrypto(db, TEST_SECRET);
+      assert.equal(isCryptoReady(), true);
+      assert.equal(decryptValue(encrypted), 'cross-session-secret');
+    });
+  });
+});

--- a/src/dashboard/crypto.ts
+++ b/src/dashboard/crypto.ts
@@ -1,0 +1,195 @@
+/**
+ * Envelope Encryption module (DEK/KEK pattern).
+ *
+ * KEK derived from DASHBOARD_SECRET via PBKDF2.
+ * DEK is a random 256-bit key wrapped by KEK and stored in the settings table.
+ * All secret values are encrypted with the DEK using AES-256-GCM.
+ */
+
+import { randomBytes, pbkdf2Sync, createCipheriv, createDecipheriv } from 'crypto';
+import type Database from 'better-sqlite3';
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const ALGORITHM = 'aes-256-gcm';
+const KEY_LENGTH = 32;        // 256 bits
+const IV_LENGTH = 12;         // 96 bits (GCM recommended)
+const TAG_LENGTH = 16;        // 128 bits
+const SALT_LENGTH = 32;       // 256 bits
+const PBKDF2_ITERATIONS = 100_000;
+const PBKDF2_DIGEST = 'sha512';
+
+const SETTINGS_KEY_SALT = '_encryption_salt';
+const SETTINGS_KEY_WRAPPED_DEK = '_wrapped_dek';
+
+// ── Module State ─────────────────────────────────────────────────────────────
+
+let cachedDek: Buffer | null = null;
+
+// ── Internal Helpers ─────────────────────────────────────────────────────────
+
+interface EncryptedPayload {
+  readonly iv: string;       // base64
+  readonly tag: string;      // base64
+  readonly ciphertext: string; // base64
+}
+
+function deriveKek(secret: string, salt: Buffer): Buffer {
+  return pbkdf2Sync(secret, salt, PBKDF2_ITERATIONS, KEY_LENGTH, PBKDF2_DIGEST);
+}
+
+function aesEncrypt(key: Buffer, plaintext: Buffer): EncryptedPayload {
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  const encrypted = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    iv: iv.toString('base64'),
+    tag: tag.toString('base64'),
+    ciphertext: encrypted.toString('base64'),
+  };
+}
+
+function aesDecrypt(key: Buffer, payload: EncryptedPayload): Buffer {
+  const iv = Buffer.from(payload.iv, 'base64');
+  const tag = Buffer.from(payload.tag, 'base64');
+  const ciphertext = Buffer.from(payload.ciphertext, 'base64');
+  const decipher = createDecipheriv(ALGORITHM, key, iv, { authTagLength: TAG_LENGTH });
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+}
+
+function getSettingRaw(db: Database.Database, key: string): string | null {
+  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
+  return row?.value ?? null;
+}
+
+function setSettingRaw(db: Database.Database, key: string, value: string): void {
+  db.prepare(`
+    INSERT INTO settings (key, value, updated_at)
+    VALUES (?, ?, datetime('now'))
+    ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+  `).run(key, value);
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Initialise the crypto subsystem. Must be called after initDb() and before
+ * any encrypt/decrypt operations.
+ *
+ * On first run: generates a random salt and DEK, stores both in the settings
+ * table (salt as hex, DEK wrapped by KEK as JSON).
+ *
+ * On subsequent runs: reads salt + wrapped DEK from DB, derives KEK, unwraps DEK.
+ */
+export function initCrypto(db: Database.Database, dashboardSecret: string): void {
+  if (!dashboardSecret) {
+    throw new Error('DASHBOARD_SECRET is required — cannot initialise encryption without it');
+  }
+
+  // 1. Resolve or create salt
+  let saltHex = getSettingRaw(db, SETTINGS_KEY_SALT);
+  if (!saltHex) {
+    const salt = randomBytes(SALT_LENGTH);
+    saltHex = salt.toString('hex');
+    setSettingRaw(db, SETTINGS_KEY_SALT, saltHex);
+  }
+  const salt = Buffer.from(saltHex, 'hex');
+
+  // 2. Derive KEK from DASHBOARD_SECRET + salt
+  const kek = deriveKek(dashboardSecret, salt);
+
+  // 3. Resolve or create DEK
+  const wrappedDekJson = getSettingRaw(db, SETTINGS_KEY_WRAPPED_DEK);
+  if (!wrappedDekJson) {
+    // First run — generate a random DEK and wrap it
+    const dek = randomBytes(KEY_LENGTH);
+    const wrapped = aesEncrypt(kek, dek);
+    setSettingRaw(db, SETTINGS_KEY_WRAPPED_DEK, JSON.stringify(wrapped));
+    cachedDek = dek;
+  } else {
+    // Subsequent run — unwrap existing DEK
+    const wrapped: EncryptedPayload = JSON.parse(wrappedDekJson);
+    cachedDek = aesDecrypt(kek, wrapped);
+  }
+}
+
+/** Returns true when initCrypto() has completed successfully. */
+export function isCryptoReady(): boolean {
+  return cachedDek !== null;
+}
+
+/**
+ * Encrypt a plaintext string with the DEK (AES-256-GCM).
+ * Returns a JSON string containing {iv, tag, ciphertext} — all base64.
+ */
+export function encryptValue(plaintext: string): string {
+  if (!cachedDek) {
+    throw new Error('Crypto not initialised — call initCrypto() first');
+  }
+  const payload = aesEncrypt(cachedDek, Buffer.from(plaintext, 'utf8'));
+  return JSON.stringify(payload);
+}
+
+/**
+ * Decrypt a value previously encrypted by encryptValue().
+ * Input: JSON string containing {iv, tag, ciphertext}.
+ */
+export function decryptValue(encrypted: string): string {
+  if (!cachedDek) {
+    throw new Error('Crypto not initialised — call initCrypto() first');
+  }
+  const payload: EncryptedPayload = JSON.parse(encrypted);
+  return aesDecrypt(cachedDek, payload).toString('utf8');
+}
+
+/**
+ * Re-wrap the DEK with a new DASHBOARD_SECRET (KEK rotation).
+ *
+ * Requires the old secret to unwrap the existing DEK, then wraps it
+ * with the new secret. All encrypted values remain valid — only the
+ * DEK wrapper changes.
+ */
+export function rewrapDek(
+  db: Database.Database,
+  oldSecret: string,
+  newSecret: string
+): void {
+  // 1. Read salt
+  const saltHex = getSettingRaw(db, SETTINGS_KEY_SALT);
+  if (!saltHex) {
+    throw new Error('No encryption salt found — has initCrypto() ever been called?');
+  }
+  const salt = Buffer.from(saltHex, 'hex');
+
+  // 2. Derive old KEK and unwrap DEK
+  const oldKek = deriveKek(oldSecret, salt);
+  const wrappedDekJson = getSettingRaw(db, SETTINGS_KEY_WRAPPED_DEK);
+  if (!wrappedDekJson) {
+    throw new Error('No wrapped DEK found — has initCrypto() ever been called?');
+  }
+  const dek = aesDecrypt(oldKek, JSON.parse(wrappedDekJson));
+
+  // 3. Generate new salt for the new KEK (so old KEK derivation params are fully invalidated)
+  const newSalt = randomBytes(SALT_LENGTH);
+  const newKek = deriveKek(newSecret, newSalt);
+
+  // 4. Wrap DEK with new KEK and persist
+  const newWrapped = aesEncrypt(newKek, dek);
+  db.transaction(() => {
+    setSettingRaw(db, SETTINGS_KEY_SALT, newSalt.toString('hex'));
+    setSettingRaw(db, SETTINGS_KEY_WRAPPED_DEK, JSON.stringify(newWrapped));
+  })();
+
+  // 5. Update cached DEK (same bytes, just re-wrapped)
+  cachedDek = dek;
+}
+
+/**
+ * Reset module state. Intended for test isolation only — production code
+ * should never need to call this.
+ */
+export function _resetCryptoForTesting(): void {
+  cachedDek = null;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -221,6 +221,9 @@ export function initSchema(database: Database.Database): void {
   // Template body: nullable TEXT column; NULL = use default assembled structure
   addColumnIfMissing(database, 'ALTER TABLE message_templates ADD COLUMN body_template TEXT DEFAULT NULL');
 
+  // v0.4.6 — encrypted secrets support: flag column for settings table
+  addColumnIfMissing(database, 'ALTER TABLE settings ADD COLUMN encrypted INTEGER NOT NULL DEFAULT 0');
+
   database.prepare('CREATE UNIQUE INDEX IF NOT EXISTS idx_users_connection_code ON users(connection_code) WHERE connection_code IS NOT NULL').run();
 
   // Seed the all-clear template so it appears in the dashboard Messages page on first run.


### PR DESCRIPTION
## Summary

- Add `src/dashboard/crypto.ts` — envelope encryption (DEK/KEK pattern) using Node.js built-in `crypto`
- KEK derived from `DASHBOARD_SECRET` via PBKDF2 (100K iterations, SHA-512)
- Random 256-bit DEK wrapped by KEK and stored in `settings` table
- Per-value AES-256-GCM encryption with unique 12-byte IVs
- `rewrapDek()` for DASHBOARD_SECRET rotation — re-wraps DEK only (O(1), no re-encryption of secrets)
- Schema migration: `ALTER TABLE settings ADD COLUMN encrypted INTEGER NOT NULL DEFAULT 0`

## Security

- No new dependencies — uses Node.js `crypto` only
- GCM auth tag detects any tampering (ciphertext, IV, or tag)
- Salt + wrapped DEK stored in settings table; actual encryption key never persisted in plaintext
- Wrong DASHBOARD_SECRET → immediate failure (cannot unwrap DEK)

## Test plan

- [x] 25 unit tests in `src/__tests__/crypto.test.ts`
- [x] Full test suite passes (1028 tests, 0 failures)
- [ ] Verify schema migration is idempotent on existing DB (restart bot twice)

## Part of

DB-backed secrets management migration (PR 1 of 7). See `docs/superpowers/specs/2026-04-05-db-backed-secrets-design.md`.