### PR TITLE
feat: centralized config resolution module (DB → env fallback)

### DIFF
--- a/src/__tests__/configResolver.test.ts
+++ b/src/__tests__/configResolver.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import { initCrypto, encryptValue, _resetCryptoForTesting } from '../dashboard/crypto.js';
+import {
+  resolveConfig,
+  resolveRequiredConfigs,
+  ConfigMissingError,
+  SECRET_KEYS,
+  CONFIG_KEYS,
+  RESTART_REQUIRED_KEYS,
+  ENV_KEY_MAP,
+  envKeyFor,
+} from '../config/configResolver.js';
+
+const TEST_SECRET = 'test-secret-for-config-resolver-tests-32chars!';
+
+function createDb(): Database.Database {
+  const db = new Database(':memory:');
+  initSchema(db);
+  return db;
+}
+
+describe('configResolver', () => {
+  let db: Database.Database;
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    _resetCryptoForTesting();
+    db = createDb();
+    initCrypto(db, TEST_SECRET);
+  });
+
+  afterEach(() => {
+    _resetCryptoForTesting();
+    // Restore any env vars we modified
+    for (const [key, val] of Object.entries(savedEnv)) {
+      if (val === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = val;
+      }
+    }
+    Object.keys(savedEnv).forEach(k => delete savedEnv[k]);
+  });
+
+  function setEnv(key: string, value: string): void {
+    savedEnv[key] = process.env[key];
+    process.env[key] = value;
+  }
+
+  function clearEnv(key: string): void {
+    savedEnv[key] = process.env[key];
+    delete process.env[key];
+  }
+
+  // ── Key Registries ────────────────────────────────────────────────────
+
+  describe('key registries', () => {
+    it('SECRET_KEYS contains expected keys', () => {
+      assert.ok(SECRET_KEYS.has('telegram_bot_token'));
+      assert.ok(SECRET_KEYS.has('mapbox_access_token'));
+      assert.ok(SECRET_KEYS.has('github_pat'));
+      assert.ok(SECRET_KEYS.has('telegram_api_id'));
+      assert.ok(SECRET_KEYS.has('telegram_api_hash'));
+      assert.equal(SECRET_KEYS.size, 5);
+    });
+
+    it('RESTART_REQUIRED_KEYS is a subset of SECRET_KEYS + CONFIG_KEYS', () => {
+      for (const key of RESTART_REQUIRED_KEYS) {
+        assert.ok(
+          SECRET_KEYS.has(key) || CONFIG_KEYS.has(key),
+          `${key} should be in SECRET_KEYS or CONFIG_KEYS`
+        );
+      }
+    });
+
+    it('every SECRET_KEY has an ENV_KEY_MAP entry', () => {
+      for (const key of SECRET_KEYS) {
+        assert.ok(ENV_KEY_MAP[key], `${key} should have an ENV_KEY_MAP entry`);
+      }
+    });
+  });
+
+  // ── envKeyFor ─────────────────────────────────────────────────────────
+
+  describe('envKeyFor', () => {
+    it('returns mapped env var for known keys', () => {
+      assert.equal(envKeyFor('telegram_bot_token'), 'TELEGRAM_BOT_TOKEN');
+      assert.equal(envKeyFor('alert_window_seconds'), 'ALERT_UPDATE_WINDOW_SECONDS');
+      assert.equal(envKeyFor('mapbox_monthly_limit'), 'MAPBOX_MONTHLY_LIMIT');
+    });
+
+    it('defaults to UPPER_CASE for unknown keys', () => {
+      assert.equal(envKeyFor('some_new_key'), 'SOME_NEW_KEY');
+    });
+  });
+
+  // ── resolveConfig ─────────────────────────────────────────────────────
+
+  describe('resolveConfig', () => {
+    it('returns DB value when present (non-encrypted)', () => {
+      db.prepare("INSERT INTO settings (key, value) VALUES ('telegram_chat_id', '-1001234')").run();
+      assert.equal(resolveConfig(db, 'telegram_chat_id'), '-1001234');
+    });
+
+    it('returns decrypted DB value when encrypted', () => {
+      const encrypted = encryptValue('bot-token-123');
+      db.prepare("INSERT INTO settings (key, value, encrypted) VALUES ('telegram_bot_token', ?, 1)").run(encrypted);
+      assert.equal(resolveConfig(db, 'telegram_bot_token'), 'bot-token-123');
+    });
+
+    it('falls back to env var when DB has no row', () => {
+      setEnv('TELEGRAM_BOT_TOKEN', 'env-token-456');
+      assert.equal(resolveConfig(db, 'telegram_bot_token'), 'env-token-456');
+    });
+
+    it('DB value takes priority over env var', () => {
+      db.prepare("INSERT INTO settings (key, value) VALUES ('telegram_chat_id', 'from-db')").run();
+      setEnv('TELEGRAM_CHAT_ID', 'from-env');
+      assert.equal(resolveConfig(db, 'telegram_chat_id'), 'from-db');
+    });
+
+    it('returns null when neither DB nor env has the key', () => {
+      clearEnv('SOME_NONEXISTENT_VAR');
+      assert.equal(resolveConfig(db, 'some_nonexistent_var'), null);
+    });
+
+    it('uses ENV_KEY_MAP override for env fallback', () => {
+      setEnv('ALERT_UPDATE_WINDOW_SECONDS', '90');
+      assert.equal(resolveConfig(db, 'alert_window_seconds'), '90');
+    });
+  });
+
+  // ── resolveRequiredConfigs ────────────────────────────────────────────
+
+  describe('resolveRequiredConfigs', () => {
+    it('returns all values when all keys resolve', () => {
+      db.prepare("INSERT INTO settings (key, value) VALUES ('telegram_chat_id', '-100999')").run();
+      setEnv('TELEGRAM_BOT_TOKEN', 'tok-abc');
+
+      const result = resolveRequiredConfigs(db, ['telegram_chat_id', 'telegram_bot_token']);
+      assert.deepEqual(result, {
+        telegram_chat_id: '-100999',
+        telegram_bot_token: 'tok-abc',
+      });
+    });
+
+    it('throws ConfigMissingError listing all missing keys', () => {
+      clearEnv('TELEGRAM_BOT_TOKEN');
+      clearEnv('MAPBOX_ACCESS_TOKEN');
+      clearEnv('TELEGRAM_CHAT_ID');
+
+      try {
+        resolveRequiredConfigs(db, ['telegram_bot_token', 'mapbox_access_token', 'telegram_chat_id']);
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.ok(err instanceof ConfigMissingError);
+        assert.deepEqual([...err.missingKeys].sort(), [
+          'mapbox_access_token',
+          'telegram_bot_token',
+          'telegram_chat_id',
+        ]);
+      }
+    });
+
+    it('error message includes env var names', () => {
+      clearEnv('TELEGRAM_BOT_TOKEN');
+      try {
+        resolveRequiredConfigs(db, ['telegram_bot_token']);
+        assert.fail('should have thrown');
+      } catch (err) {
+        assert.ok(err instanceof ConfigMissingError);
+        assert.ok(err.message.includes('TELEGRAM_BOT_TOKEN'));
+      }
+    });
+
+    it('returns empty record for empty keys list', () => {
+      const result = resolveRequiredConfigs(db, []);
+      assert.deepEqual(result, {});
+    });
+  });
+});

--- a/src/config/configResolver.ts
+++ b/src/config/configResolver.ts
@@ -1,0 +1,161 @@
+/**
+ * Central configuration resolution: DB (with decryption) → env var fallback → null.
+ *
+ * Consolidates all process.env reads into a single module with a clear
+ * key registry, making it easy to audit what config exists and where it comes from.
+ */
+
+import type Database from 'better-sqlite3';
+import { isCryptoReady, decryptValue } from '../dashboard/crypto.js';
+
+// ── Key Registries ───────────────────────────────────────────────────────────
+
+/** Secret keys that are encrypted in the DB via the DEK. */
+export const SECRET_KEYS: ReadonlySet<string> = new Set([
+  'telegram_bot_token',
+  'mapbox_access_token',
+  'github_pat',
+  'telegram_api_id',
+  'telegram_api_hash',
+]);
+
+/** Non-secret config keys that can be stored in the DB (many already are). */
+export const CONFIG_KEYS: ReadonlySet<string> = new Set([
+  'telegram_chat_id',
+  'telegram_forward_group_id',
+  'whatsapp_invite_link',
+  'whatsapp_enabled',
+  'whatsapp_map_debounce_seconds',
+  'health_port',
+  'dashboard_port',
+  'telegram_listener_enabled',
+  'alert_window_seconds',
+  'mapbox_monthly_limit',
+  'mapbox_skip_drills',
+  'mapbox_image_cache_size',
+  'ga4_measurement_id',
+  'github_repo',
+  'telegram_invite_link',
+  'topic_id_security',
+  'topic_id_nature',
+  'topic_id_environmental',
+  'topic_id_drills',
+  'topic_id_general',
+  'topic_id_whatsapp',
+  'quiet_hours_global',
+  'all_clear_mode',
+  'all_clear_topic_id',
+  'landing_url',
+  'privacy_defaults',
+]);
+
+/** Keys whose change requires a process restart to take effect. */
+export const RESTART_REQUIRED_KEYS: ReadonlySet<string> = new Set([
+  'telegram_bot_token',
+  'telegram_api_id',
+  'telegram_api_hash',
+  'health_port',
+  'dashboard_port',
+  'telegram_listener_enabled',
+]);
+
+/**
+ * Maps a DB settings key to its corresponding environment variable name.
+ * Keys not listed here default to UPPER_CASE of the key itself.
+ */
+export const ENV_KEY_MAP: Readonly<Record<string, string>> = {
+  // Secrets
+  telegram_bot_token:            'TELEGRAM_BOT_TOKEN',
+  mapbox_access_token:           'MAPBOX_ACCESS_TOKEN',
+  github_pat:                    'GITHUB_PAT',
+  telegram_api_id:               'TELEGRAM_API_ID',
+  telegram_api_hash:             'TELEGRAM_API_HASH',
+  // Config with non-obvious env var names
+  alert_window_seconds:          'ALERT_UPDATE_WINDOW_SECONDS',
+  mapbox_monthly_limit:          'MAPBOX_MONTHLY_LIMIT',
+  mapbox_skip_drills:            'MAPBOX_SKIP_DRILLS',
+  mapbox_image_cache_size:       'MAPBOX_IMAGE_CACHE_SIZE',
+  telegram_invite_link:          'TELEGRAM_INVITE_LINK',
+  whatsapp_enabled:              'WHATSAPP_ENABLED',
+  whatsapp_map_debounce_seconds: 'WHATSAPP_MAP_DEBOUNCE_SECONDS',
+  whatsapp_invite_link:          'WHATSAPP_INVITE_LINK',
+  health_port:                   'HEALTH_PORT',
+  dashboard_port:                'DASHBOARD_PORT',
+  ga4_measurement_id:            'GA4_MEASUREMENT_ID',
+  github_repo:                   'GITHUB_REPO',
+  telegram_chat_id:              'TELEGRAM_CHAT_ID',
+  telegram_forward_group_id:     'TELEGRAM_FORWARD_GROUP_ID',
+  telegram_listener_enabled:     'TELEGRAM_LISTENER_ENABLED',
+};
+
+// ── Resolution ───────────────────────────────────────────────────────────────
+
+/** Convert a DB key to its env var name. */
+export function envKeyFor(key: string): string {
+  return ENV_KEY_MAP[key] ?? key.toUpperCase();
+}
+
+/**
+ * Resolve a single config/secret value.
+ *
+ * Priority: DB value (decrypted if encrypted) → env var fallback → null.
+ */
+export function resolveConfig(db: Database.Database, key: string): string | null {
+  // 1. Try DB
+  const row = db.prepare('SELECT value, encrypted FROM settings WHERE key = ?').get(key) as
+    { value: string; encrypted: number } | undefined;
+
+  if (row) {
+    if (row.encrypted === 1 && isCryptoReady()) {
+      return decryptValue(row.value);
+    }
+    // Non-encrypted DB value, or crypto not ready (shouldn't happen for encrypted rows)
+    if (row.encrypted === 0) {
+      return row.value;
+    }
+  }
+
+  // 2. Env var fallback
+  const envVar = envKeyFor(key);
+  const envValue = process.env[envVar];
+  return envValue ?? null;
+}
+
+/** Error thrown when required config keys are missing from both DB and env. */
+export class ConfigMissingError extends Error {
+  readonly missingKeys: readonly string[];
+
+  constructor(missingKeys: readonly string[]) {
+    const keyList = missingKeys.map(k => `  - ${k} (env: ${envKeyFor(k)})`).join('\n');
+    super(`Missing required configuration:\n${keyList}`);
+    this.name = 'ConfigMissingError';
+    this.missingKeys = missingKeys;
+  }
+}
+
+/**
+ * Resolve multiple required config keys. Returns a Record of key → value.
+ * Throws ConfigMissingError if any key resolves to null.
+ */
+export function resolveRequiredConfigs(
+  db: Database.Database,
+  keys: readonly string[]
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  const missing: string[] = [];
+
+  for (const key of keys) {
+    const value = resolveConfig(db, key);
+    if (value === null) {
+      missing.push(key);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  if (missing.length > 0) {
+    throw new ConfigMissingError(missing);
+  }
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Add `src/config/configResolver.ts` — single source of truth for config/secret resolution
- `SECRET_KEYS` (5): telegram_bot_token, mapbox_access_token, github_pat, telegram_api_id, telegram_api_hash
- `RESTART_REQUIRED_KEYS` (6): tokens + ports + listener flag
- `resolveConfig(db, key)`: DB (auto-decrypt) → env fallback → null
- `resolveRequiredConfigs(db, keys)`: batch resolve, throws `ConfigMissingError` listing all missing

## Notes

- Pure addition — zero production code modified
- Consolidates the `envKeyFor()` mapping from settingsRepository.ts (will be unified in PR 2c)

## Test plan

- [x] 15 unit tests in `src/__tests__/configResolver.test.ts`
- [x] Crypto integration: encrypted DB values correctly decrypted

Stacked on: #153 (feat/crypto-module)
Part 2a of 7 in the DB-backed secrets migration.