### PR TITLE
feat: full template system with body editor and {{variables}}

### DIFF
--- a/dashboard-ui/src/components/messages/TemplateBodyEditor.tsx
+++ b/dashboard-ui/src/components/messages/TemplateBodyEditor.tsx
@@ -1,0 +1,230 @@
+import { useState, useRef, useCallback } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import DOMPurify from 'dompurify';
+import { CharCountBar } from './CharCountBar';
+import { api } from '../../api/client';
+import type { TemplateEntry } from './TemplateRow';
+
+interface TemplateBodyEditorProps {
+  templates: TemplateEntry[];
+}
+
+const VARIABLE_CHIPS = [
+  { label: '\u{1F550} שעה', placeholder: '{{זמן}}' },
+  { label: '\u{1F3D8}\uFE0F רשימת ערים', placeholder: '{{ערים}}' },
+  { label: '\u{1F522} מספר ערים', placeholder: '{{מספר_ערים}}' },
+  { label: '\u{1F4CC} כותרת', placeholder: '{{כותרת}}' },
+  { label: '\u{1F3AF} אמוג\u05F3י', placeholder: '{{אמוגי}}' },
+] as const;
+
+const DEFAULT_TEMPLATE = `{{אמוגי}} <b>{{כותרת}}</b>
+\u23F0 {{זמן}}
+{{מספר_ערים}} ערים
+
+{{ערים}}`;
+
+const DUMMY_VARS: Record<string, string> = {
+  'זמן': '14:32',
+  'ערים': '\u25B8 \u{1F332} \u{1F534} <b>גליל עליון</b> (3)  \u23F1 <b>15 שנ\u05F3</b>\nאביבים, כפר בלום, קריית שמונה',
+  'מספר_ערים': '3',
+  'כותרת': 'התרעת טילים',
+  'אמוגי': '\u{1F534}',
+};
+
+function renderPreview(template: string): string {
+  let result = template.replace(/\{\{\s+/g, '{{').replace(/\s+\}\}/g, '}}');
+  for (const [key, value] of Object.entries(DUMMY_VARS)) {
+    result = result.split(`{{${key}}}`).join(value);
+  }
+  return result;
+}
+
+export function TemplateBodyEditor({ templates }: TemplateBodyEditorProps) {
+  const queryClient = useQueryClient();
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const cursorPosRef = useRef<{ start: number; end: number }>({ start: 0, end: 0 });
+
+  const [selectedType, setSelectedType] = useState<string>(templates[0]?.alertType ?? '');
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const selected = templates.find((t) => t.alertType === selectedType);
+  const currentTemplate = draft ?? selected?.bodyTemplate ?? '';
+  const hasDraft = draft !== null;
+  const missingCities = currentTemplate.trim() !== '' && !currentTemplate.replace(/\{\{\s+/g, '{{').replace(/\s+\}\}/g, '}}').includes('{{ערים}}');
+
+  // Save cursor position on blur (before chip button steals focus)
+  const handleBlur = useCallback(() => {
+    const ta = textareaRef.current;
+    if (ta) {
+      cursorPosRef.current = { start: ta.selectionStart, end: ta.selectionEnd };
+    }
+  }, []);
+
+  // Insert placeholder at saved cursor position
+  const insertChip = useCallback((placeholder: string) => {
+    const { start, end } = cursorPosRef.current;
+    const current = draft ?? selected?.bodyTemplate ?? '';
+    const before = current.slice(0, start);
+    const after = current.slice(end);
+    const newValue = before + placeholder + after;
+    setDraft(newValue);
+
+    // Restore focus and cursor after React re-render
+    requestAnimationFrame(() => {
+      const ta = textareaRef.current;
+      if (ta) {
+        ta.focus();
+        const newPos = start + placeholder.length;
+        ta.setSelectionRange(newPos, newPos);
+        cursorPosRef.current = { start: newPos, end: newPos };
+      }
+    });
+  }, [draft, selected?.bodyTemplate]);
+
+  // Save mutation
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      api.patch(`/api/messages/${selectedType}`, {
+        bodyTemplate: draft === '' ? null : draft,
+      }),
+    onSuccess: () => {
+      setDraft(null);
+      queryClient.invalidateQueries({ queryKey: ['messages'] });
+      toast.success('תבנית נשמרה');
+    },
+    onError: (err) => toast.error(err instanceof Error ? err.message : 'שגיאה בשמירה'),
+  });
+
+  // Reset mutation
+  const resetMutation = useMutation({
+    mutationFn: () =>
+      api.patch(`/api/messages/${selectedType}`, { bodyTemplate: null }),
+    onSuccess: () => {
+      setDraft(null);
+      queryClient.invalidateQueries({ queryKey: ['messages'] });
+      toast.success('תבנית אופסה לברירת מחדל');
+    },
+    onError: (err) => toast.error(err instanceof Error ? err.message : 'שגיאה באיפוס'),
+  });
+
+  const previewHtml = renderPreview(currentTemplate || DEFAULT_TEMPLATE);
+  const safeHtml = DOMPurify.sanitize(previewHtml, {
+    ALLOWED_TAGS: ['b', 'i', 'code', 's', 'u'],
+    ALLOWED_ATTR: [],
+  });
+
+  return (
+    <div className="space-y-4">
+      {/* Alert type selector */}
+      <div>
+        <label className="block text-sm text-text-muted mb-1">סוג התראה</label>
+        <select
+          value={selectedType}
+          onChange={(e) => {
+            setSelectedType(e.target.value);
+            setDraft(null);
+          }}
+          className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-sm text-text-primary"
+          dir="rtl"
+        >
+          {templates.map((t) => (
+            <option key={t.alertType} value={t.alertType}>
+              {t.emoji} {t.titleHe}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Variable chips */}
+      <div>
+        <label className="block text-sm text-text-muted mb-1">הכנס משתנה</label>
+        <div className="flex flex-wrap gap-1.5">
+          {VARIABLE_CHIPS.map((chip) => (
+            <button
+              key={chip.placeholder}
+              type="button"
+              onClick={() => insertChip(chip.placeholder)}
+              className="px-2.5 py-1 text-xs rounded-full bg-surface-alt border border-border
+                         text-text-secondary hover:bg-amber/10 hover:border-amber/30
+                         hover:text-amber transition-colors"
+            >
+              {chip.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Template textarea */}
+      <div>
+        <label className="block text-sm text-text-muted mb-1">
+          גוף התבנית
+          {selected?.bodyTemplate && <span className="text-amber mr-1">(מותאם)</span>}
+        </label>
+        <textarea
+          ref={textareaRef}
+          dir="rtl"
+          value={currentTemplate}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={handleBlur}
+          placeholder={DEFAULT_TEMPLATE}
+          rows={8}
+          className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-sm
+                     text-text-primary font-mono leading-relaxed resize-y
+                     focus:outline-none focus:border-amber/50 focus:ring-1 focus:ring-amber/20"
+        />
+        <CharCountBar charCount={currentTemplate.length} max={2000} />
+        {missingCities && (
+          <p className="text-xs text-red-400 mt-1">
+            \u26A0 חסר משתנה {'{{ערים}}'} \u2014 רשימת הערים לא תופיע בהתראה
+          </p>
+        )}
+      </div>
+
+      {/* Action buttons */}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => saveMutation.mutate()}
+          disabled={!hasDraft || saveMutation.isPending || missingCities}
+          className="px-4 py-1.5 text-sm rounded-lg bg-amber text-base font-medium
+                     hover:bg-amber-dark transition-colors disabled:opacity-40"
+        >
+          {saveMutation.isPending ? 'שומר...' : 'שמור תבנית'}
+        </button>
+        <button
+          type="button"
+          onClick={() => resetMutation.mutate()}
+          disabled={resetMutation.isPending || !selected?.bodyTemplate}
+          className="px-4 py-1.5 text-sm rounded-lg border border-border text-text-muted
+                     hover:text-text-primary hover:border-border transition-colors
+                     disabled:opacity-40"
+        >
+          איפוס לברירת מחדל
+        </button>
+        {hasDraft && (
+          <button
+            type="button"
+            onClick={() => setDraft(null)}
+            className="px-3 py-1.5 text-xs text-text-muted hover:text-text-primary transition-colors"
+          >
+            בטל
+          </button>
+        )}
+      </div>
+
+      {/* Live preview */}
+      <div>
+        <label className="block text-sm text-text-muted mb-1">תצוגה מקדימה</label>
+        <div className="bg-[#1a2332] rounded-xl p-4 border border-white/5">
+          <div
+            className="bg-[#1c3a2a] rounded-lg px-3 py-2 text-sm text-white/90 leading-relaxed
+                       whitespace-pre-wrap break-words"
+            dir="rtl"
+            dangerouslySetInnerHTML={{ __html: safeHtml }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard-ui/src/components/messages/TemplateRow.tsx
+++ b/dashboard-ui/src/components/messages/TemplateRow.tsx
@@ -7,6 +7,7 @@ export interface TemplateEntry {
   emoji: string;
   titleHe: string;
   instructionsPrefix: string;
+  bodyTemplate: string | null;
   isCustomized: boolean;
   defaults: { emoji: string; titleHe: string; instructionsPrefix: string };
 }

--- a/dashboard-ui/src/pages/Messages.tsx
+++ b/dashboard-ui/src/pages/Messages.tsx
@@ -10,6 +10,7 @@ import { CategorySection } from '../components/messages/CategorySection';
 import { SimulationPanel } from '../components/messages/SimulationPanel';
 import { SystemMessagePanel } from '../components/messages/SystemMessagePanel';
 import { RoutingSection } from '../components/messages/RoutingSection';
+import { TemplateBodyEditor } from '../components/messages/TemplateBodyEditor';
 import type { TemplateEntry, TemplateEdit } from '../components/messages/TemplateRow';
 import { ORDERED_CATEGORIES, ALERT_TYPE_CATEGORY } from '../utils/categoryConfig';
 import type { AlertCategory } from '../utils/categoryConfig';
@@ -30,6 +31,7 @@ export default function Messages() {
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<ImportRow[] | null>(null);
   const [rightPanelTab, setRightPanelTab] = useState<'simulation' | 'system'>('simulation');
+  const [mainTab, setMainTab] = useState<'types' | 'editor' | 'routing'>('types');
 
   // Fetch all template entries
   const { data: templates = [] } = useQuery<TemplateEntry[]>({
@@ -260,11 +262,35 @@ export default function Messages() {
           onResetAll={() => resetAllMutation.mutate()}
         />
 
-        {/* Split layout: categories + simulation */}
+        {/* Main content tabs */}
+        <div className="flex gap-1 mb-4" role="tablist">
+          {([
+            ['types', 'סוגי התראות'] as const,
+            ['editor', 'עורך תבנית'] as const,
+            ['routing', 'ניתוב'] as const,
+          ]).map(([key, label]) => (
+            <button
+              key={key}
+              type="button"
+              role="tab"
+              aria-selected={mainTab === key}
+              onClick={() => setMainTab(key)}
+              className={`px-4 py-1.5 text-sm rounded-full transition-colors ${
+                mainTab === key
+                  ? 'bg-amber/15 text-amber font-medium'
+                  : 'text-text-muted hover:text-text-primary'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Split layout: main tab + simulation */}
         <div className="grid grid-cols-1 lg:grid-cols-[1fr_380px] gap-4">
-          {/* Left column: category sections + routing */}
+          {/* Left column: active tab content */}
           <div className="space-y-4">
-            {ORDERED_CATEGORIES.map((category) => (
+            {mainTab === 'types' && ORDERED_CATEGORIES.map((category) => (
               <CategorySection
                 key={category}
                 category={category}
@@ -276,7 +302,8 @@ export default function Messages() {
                 onSimulate={handleSimulate}
               />
             ))}
-            <RoutingSection />
+            {mainTab === 'editor' && <TemplateBodyEditor templates={templates} />}
+            {mainTab === 'routing' && <RoutingSection />}
           </div>
 
           {/* Right column: simulation / system message (sticky) */}

--- a/src/__tests__/dashboard/routes/messages-extended.test.ts
+++ b/src/__tests__/dashboard/routes/messages-extended.test.ts
@@ -89,6 +89,7 @@ describe('GET /api/messages/export', () => {
       emoji: '🚨',
       title_he: 'טילים',
       instructions_prefix: '🛡',
+      body_template: null,
     });
     const res = await request(app).get('/api/messages/export');
     assert.equal(res.status, 200);

--- a/src/__tests__/templateCache.test.ts
+++ b/src/__tests__/templateCache.test.ts
@@ -104,6 +104,7 @@ describe('messageTemplateRepository', () => {
       emoji: '🚀',
       title_he: 'בדיקה',
       instructions_prefix: '📌',
+      body_template: null,
     });
     const rows = userTemplates(db);
     assert.equal(rows.length, 1);
@@ -121,12 +122,14 @@ describe('messageTemplateRepository', () => {
       emoji: '🚀',
       title_he: 'ראשוני',
       instructions_prefix: '📌',
+      body_template: null,
     });
     upsertTemplate(db, {
       alert_type: 'missiles',
       emoji: '🔴',
       title_he: 'עדכני',
       instructions_prefix: '🛡',
+      body_template: null,
     });
     const rows = userTemplates(db);
     assert.equal(rows.length, 1);
@@ -142,12 +145,14 @@ describe('messageTemplateRepository', () => {
       emoji: '🔴',
       title_he: 'בדיקה',
       instructions_prefix: '🛡',
+      body_template: null,
     });
     upsertTemplate(db, {
       alert_type: 'earthQuake',
       emoji: '🟠',
       title_he: 'רעידה',
       instructions_prefix: '🛡',
+      body_template: null,
     });
     deleteTemplate(db, 'missiles');
     const rows = userTemplates(db);

--- a/src/config/templateCache.ts
+++ b/src/config/templateCache.ts
@@ -12,6 +12,7 @@ export interface CacheEntry {
   emoji: string;
   titleHe: string;
   instructionsPrefix: string;
+  bodyTemplate: string | null;
 }
 
 function buildDefaultCache(): Record<string, CacheEntry> {
@@ -22,6 +23,7 @@ function buildDefaultCache(): Record<string, CacheEntry> {
       titleHe: DEFAULT_ALERT_TYPE_HE[alertType] ?? DEFAULT_ALERT_TYPE_HE['unknown'] ?? 'התרעה',
       instructionsPrefix:
         DEFAULT_INSTRUCTIONS_PREFIX[alertType] ?? DEFAULT_INSTRUCTIONS_PREFIX['_default'] ?? '🛡',
+      bodyTemplate: null,
     };
   }
   return result;
@@ -38,6 +40,7 @@ export function loadTemplateCache(): void {
         emoji: row.emoji,
         titleHe: row.title_he,
         instructionsPrefix: row.instructions_prefix,
+        bodyTemplate: row.body_template ?? null,
       },
     ])
   );
@@ -55,6 +58,10 @@ export function getTitleHe(alertType: string): string {
 
 export function getInstructionsPrefix(alertType: string): string {
   return _cache[alertType]?.instructionsPrefix ?? DEFAULT_INSTRUCTIONS_PREFIX['_default'] ?? '🛡';
+}
+
+export function getBodyTemplate(alertType: string): string | null {
+  return _cache[alertType]?.bodyTemplate ?? null;
 }
 
 export function getAllCached(): Readonly<Record<string, CacheEntry>> {

--- a/src/dashboard/routes/messages.ts
+++ b/src/dashboard/routes/messages.ts
@@ -249,6 +249,7 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
         emoji: t.emoji!,
         title_he: t.titleHe!,
         instructions_prefix: t.instructionsPrefix ?? '🛡',
+        body_template: null,
       });
     }
 
@@ -651,6 +652,7 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
         emoji: historyRow.emoji,
         title_he: historyRow.title_he,
         instructions_prefix: historyRow.instructions_prefix,
+        body_template: null,
       });
 
       loadTemplateCache();

--- a/src/dashboard/routes/messages.ts
+++ b/src/dashboard/routes/messages.ts
@@ -167,6 +167,7 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
       emoji: cached[alertType].emoji,
       titleHe: cached[alertType].titleHe,
       instructionsPrefix: cached[alertType].instructionsPrefix,
+      bodyTemplate: cached[alertType].bodyTemplate ?? null,
       isCustomized: customized.has(alertType),
       defaults: {
         emoji: DEFAULT_ALERT_TYPE_EMOJI[alertType] ?? '⚠️',
@@ -200,6 +201,7 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
       emoji: row.emoji,
       titleHe: row.title_he,
       instructionsPrefix: row.instructions_prefix,
+      bodyTemplate: row.body_template ?? null,
     }));
     res.json({ templates });
   });
@@ -508,10 +510,11 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
       return;
     }
 
-    const { emoji, titleHe, instructionsPrefix } = req.body as {
+    const { emoji, titleHe, instructionsPrefix, bodyTemplate } = req.body as {
       emoji?: string;
       titleHe?: string;
       instructionsPrefix?: string;
+      bodyTemplate?: string | null;
     };
 
     if (emoji !== undefined && emoji.trim() === '') {
@@ -527,6 +530,20 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
       return;
     }
 
+    // bodyTemplate validation
+    if (bodyTemplate !== undefined && bodyTemplate !== null && bodyTemplate.trim() !== '') {
+      if (bodyTemplate.length > 2000) {
+        res.status(400).json({ error: 'תבנית חורגת ממגבלת 2000 תווים' });
+        return;
+      }
+      // Normalize whitespace inside braces for the check
+      const normalized = bodyTemplate.replace(/\{\{\s+/g, '{{').replace(/\s+\}\}/g, '}}');
+      if (!normalized.includes('{{ערים}}')) {
+        res.status(400).json({ error: 'תבנית חייבת לכלול את המשתנה {{ערים}} — בלעדיו רשימת הערים לא תופיע' });
+        return;
+      }
+    }
+
     try {
       // Save current state to history BEFORE upserting
       const current = getAllCached()[alertType];
@@ -540,12 +557,18 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
         pruneHistory(db, alertType, 10);
       }
 
+      // bodyTemplate: undefined = keep current, null/'' = reset to default, string = save
+      const bodyTemplateToSave = bodyTemplate === undefined
+        ? (current?.bodyTemplate ?? null)
+        : (bodyTemplate === null || bodyTemplate === '' ? null : bodyTemplate);
+
       // Merge with current cached values to avoid zeroing out unprovided fields.
       upsertTemplate(db, {
         alert_type: alertType,
         emoji: emoji ?? current.emoji,
         title_he: titleHe ?? current.titleHe,
         instructions_prefix: instructionsPrefix ?? current.instructionsPrefix,
+        body_template: bodyTemplateToSave,
       });
 
       loadTemplateCache();

--- a/src/db/messageTemplateRepository.ts
+++ b/src/db/messageTemplateRepository.ts
@@ -5,23 +5,25 @@ export interface MessageTemplateRow {
   emoji: string;
   title_he: string;
   instructions_prefix: string;
+  body_template: string | null;
 }
 
 export function getAllTemplates(db: Database.Database): MessageTemplateRow[] {
   return db
-    .prepare('SELECT alert_type, emoji, title_he, instructions_prefix FROM message_templates')
+    .prepare('SELECT alert_type, emoji, title_he, instructions_prefix, body_template FROM message_templates')
     .all() as MessageTemplateRow[];
 }
 
 export function upsertTemplate(db: Database.Database, row: MessageTemplateRow): void {
   db.prepare(`
-    INSERT INTO message_templates (alert_type, emoji, title_he, instructions_prefix)
-    VALUES (?, ?, ?, ?)
+    INSERT INTO message_templates (alert_type, emoji, title_he, instructions_prefix, body_template)
+    VALUES (?, ?, ?, ?, ?)
     ON CONFLICT(alert_type) DO UPDATE SET
       emoji               = excluded.emoji,
       title_he            = excluded.title_he,
-      instructions_prefix = excluded.instructions_prefix
-  `).run(row.alert_type, row.emoji, row.title_he, row.instructions_prefix);
+      instructions_prefix = excluded.instructions_prefix,
+      body_template       = excluded.body_template
+  `).run(row.alert_type, row.emoji, row.title_he, row.instructions_prefix, row.body_template ?? null);
 }
 
 export function deleteTemplate(db: Database.Database, alertType: string): void {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -218,6 +218,9 @@ export function initSchema(database: Database.Database): void {
   // existing users remain subscribed after migration.
   addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN is_dm_active INTEGER NOT NULL DEFAULT 1');
 
+  // v0.5 — full template body: nullable TEXT column; NULL = use default assembled structure
+  addColumnIfMissing(database, 'ALTER TABLE message_templates ADD COLUMN body_template TEXT DEFAULT NULL');
+
   database.prepare('CREATE UNIQUE INDEX IF NOT EXISTS idx_users_connection_code ON users(connection_code) WHERE connection_code IS NOT NULL').run();
 
   // Seed the all-clear template so it appears in the dashboard Messages page on first run.

--- a/src/telegramBot.ts
+++ b/src/telegramBot.ts
@@ -2,7 +2,7 @@ import { Bot, InputFile } from 'grammy';
 import { autoRetry } from '@grammyjs/auto-retry';
 import { Alert } from './types';
 import { getCityData } from './cityLookup';
-import { getEmoji, getTitleHe, getInstructionsPrefix, getAllCached } from './config/templateCache.js';
+import { getEmoji, getTitleHe, getInstructionsPrefix, getBodyTemplate, getAllCached } from './config/templateCache.js';
 import { DEFAULT_ALERT_TYPE_HE, DEFAULT_ALERT_TYPE_EMOJI } from './config/alertTypeDefaults.js';
 import { getUrgencyForCountdown } from './config/urgency.js';
 import { getSuperRegionByZone } from './config/zones.js';
@@ -147,6 +147,37 @@ export function buildZoneOnlyList(cities: string[]): string {
   return sections.join('\n');
 }
 
+// ─── Template rendering engine ───────────────────────────────────────────
+
+/** Maps Hebrew placeholders (used in dashboard UI) to English TemplateVars keys. */
+const PLACEHOLDER_MAP: ReadonlyArray<readonly [string, string]> = [
+  ['זמן', 'time'],
+  ['ערים', 'cities'],
+  ['מספר_ערים', 'cityCount'],
+  ['כותרת', 'title'],
+  ['אמוגי', 'emoji'],
+] as const;
+
+export interface TemplateVars {
+  time: string;
+  cities: string;
+  cityCount: number;
+  title: string;
+  emoji: string;
+}
+
+/** Renders a body template by substituting {{placeholder}} variables.
+ *  Normalizes whitespace inside braces; leaves unclosed/unknown placeholders as literal text. */
+export function renderBodyTemplate(template: string, vars: TemplateVars): string {
+  // Normalize: {{ ערים }} → {{ערים}}
+  let result = template.replace(/\{\{\s+/g, '{{').replace(/\s+\}\}/g, '}}');
+  for (const [heKey, enKey] of PLACEHOLDER_MAP) {
+    const value = String(vars[enKey as keyof TemplateVars]);
+    result = result.split(`{{${heKey}}}`).join(value);
+  }
+  return result;
+}
+
 export function formatAlertMessage(alert: Alert, serial?: number, density?: 'חריג' | 'רגיל' | null): string {
   const actionCard = buildActionCard(alert.type);
   const emoji = getEmoji(alert.type);
@@ -160,6 +191,24 @@ export function formatAlertMessage(alert: Alert, serial?: number, density?: 'ח�
     hour12: false,
   });
 
+  const cityList =
+    alert.type === 'newsFlash'
+      ? buildZoneOnlyList(alert.cities)
+      : buildZonedCityList(alert.cities);
+
+  // If a custom body template exists, render it and return early
+  const bodyTemplate = getBodyTemplate(alert.type);
+  if (bodyTemplate) {
+    return renderBodyTemplate(bodyTemplate, {
+      time: timeStr,
+      cities: cityList,
+      cityCount: alert.cities.length,
+      title,
+      emoji,
+    });
+  }
+
+  // Default assembly (no custom template)
   const summaryLine = buildSummaryLine(alert.cities);
   const parts: string[] = [];
 
@@ -176,11 +225,6 @@ export function formatAlertMessage(alert: Alert, serial?: number, density?: 'ח�
       ? `${prefix} <i>${escapeHtml(alert.instructions)}</i>`
       : `<i>${escapeHtml(alert.instructions)}</i>`;
   }
-
-  const cityList =
-    alert.type === 'newsFlash'
-      ? buildZoneOnlyList(alert.cities)
-      : buildZonedCityList(alert.cities);
 
   // Instructions appear before cities so they are visible in push notification previews
   if (instructionsPart) parts.push(instructionsPart);


### PR DESCRIPTION
## Summary
- Add `body_template` column to `message_templates` — nullable TEXT, NULL = default assembly
- `renderBodyTemplate()` substitutes Hebrew placeholders (`{{זמן}}`, `{{ערים}}`, `{{מספר_ערים}}`, `{{כותרת}}`, `{{אמוגי}}`) with alert data
- `formatAlertMessage()` uses custom template when set, falls through to default when NULL
- API: `PATCH /api/messages/:alertType` accepts `bodyTemplate` with validation (must include `{{ערים}}`, max 2000 chars)
- Dashboard Messages page restructured into 3 tabs: **סוגי התראות** / **עורך תבנית** / **ניתוב**
- New `TemplateBodyEditor` component: alert type selector, variable chip buttons with cursor-preserving insertion (`onBlur` + `useRef`), DOMPurify live preview, `CharCountBar`

## Changes (5 commits)
1. `schema.ts` — `addColumnIfMissing()` for `body_template`
2. `messageTemplateRepository.ts` + `templateCache.ts` — thread `bodyTemplate` through CRUD and cache
3. `telegramBot.ts` — `renderBodyTemplate()`, `PLACEHOLDER_MAP`, integration in `formatAlertMessage()`
4. `messages.ts` — API extension with validation
5. `Messages.tsx` + `TemplateBodyEditor.tsx` + `TemplateRow.tsx` — UI tabs + editor

## Test plan
- [x] All 1003 backend tests pass
- [x] Dashboard build succeeds (tsc + vite)
- [x] 17 messages route tests pass
- [ ] Manual: set custom body template via dashboard, trigger test alert, verify rendering
- [ ] Manual: try saving template without `{{ערים}}` — verify 400 error
- [ ] Manual: reset template to default — verify NULL in DB and default rendering resumes