### PR TITLE
feat: wire config resolution into dashboard routes and services

### DIFF
--- a/src/dashboard/routes/landing.ts
+++ b/src/dashboard/routes/landing.ts
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import type Database from 'better-sqlite3';
 import { getSetting, setSetting } from '../settingsRepository.js';
+import { resolveConfig } from '../../config/configResolver.js';
 import { log } from '../../logger.js';
 import { createRateLimitMiddleware } from '../rateLimiter.js';
 
@@ -22,10 +23,10 @@ export function createLandingRouter(db: Database.Database): Router {
   router.get('/config', (_req, res) => {
     const lastDeploy = getSetting(db, 'last_landing_deploy') ?? null;
     res.json({
-      ga4MeasurementId: getSetting(db, 'ga4_measurement_id') ?? process.env.GA4_MEASUREMENT_ID ?? '',
+      ga4MeasurementId: resolveConfig(db, 'ga4_measurement_id') ?? '',
       lastDeploy,
       siteUrl: getSetting(db, 'landing_url') ?? '',
-      githubRepo: getSetting(db, 'github_repo') ?? process.env.GITHUB_REPO ?? '',
+      githubRepo: resolveConfig(db, 'github_repo') ?? '',
       deployStatus: lastDeploy ? 'deployed' : 'never',
     });
   });
@@ -50,8 +51,8 @@ export function createLandingRouter(db: Database.Database): Router {
   });
 
   router.post('/deploy', deployLimiter, async (_req, res) => {
-    const token = process.env.GITHUB_PAT;
-    const repo = getSetting(db, 'github_repo') ?? process.env.GITHUB_REPO ?? '';
+    const token = resolveConfig(db, 'github_pat');
+    const repo = resolveConfig(db, 'github_repo') ?? '';
     if (!token || !repo) {
       res.status(400).json({ error: 'GITHUB_PAT או GITHUB_REPO לא מוגדרים' });
       return;

--- a/src/dashboard/routes/messages.ts
+++ b/src/dashboard/routes/messages.ts
@@ -38,6 +38,7 @@ import {
 } from '../../whatsapp/whatsappFormatter.js';
 import { getRecentAlerts } from '../../db/alertHistoryRepository.js';
 import { createRateLimitMiddleware } from '../rateLimiter.js';
+import { resolveConfig } from '../../config/configResolver.js';
 import { log } from '../../logger.js';
 import type { Alert } from '../../types.js';
 
@@ -356,7 +357,7 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
         ? formattedMessage.slice(0, formattedMessage.lastIndexOf('\n\n', maxBody)) + '\n\n<i>…קוצר</i>'
         : formattedMessage;
 
-      const chatId = process.env.TELEGRAM_CHAT_ID;
+      const chatId = resolveConfig(db, 'telegram_chat_id');
       if (!chatId) {
         errors.push('TELEGRAM_CHAT_ID לא מוגדר');
       } else {
@@ -483,7 +484,7 @@ export function createMessagesRouter(db: Database.Database, bot: Bot, whatsappDe
       return;
     }
 
-    const chatId = process.env.TELEGRAM_CHAT_ID;
+    const chatId = resolveConfig(db, 'telegram_chat_id');
     if (!chatId) {
       res.status(500).json({ error: 'TELEGRAM_CHAT_ID לא מוגדר' });
       return;

--- a/src/dashboard/routes/telegramListeners.ts
+++ b/src/dashboard/routes/telegramListeners.ts
@@ -21,6 +21,7 @@ import {
   type TelegramListenerStatus,
 } from '../../telegram-listener/telegramListenerClient.js';
 import { getSetting } from '../settingsRepository.js';
+import { resolveConfig } from '../../config/configResolver.js';
 import { log } from '../../logger.js';
 import { createRateLimitMiddleware } from '../rateLimiter.js';
 
@@ -204,7 +205,7 @@ export function createTelegramListenerRouter(
   // GET /listeners/telegram-topics
   router.get('/listeners/telegram-topics', async (_req: Request, res: Response) => {
     let liveTopics: Array<{ id: number; name: string }> = [];
-    const chatId = process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID'];
+    const chatId = resolveConfig(db, 'telegram_forward_group_id') ?? resolveConfig(db, 'telegram_chat_id');
     if (chatId) {
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/dashboard/routes/whatsappListeners.ts
+++ b/src/dashboard/routes/whatsappListeners.ts
@@ -9,6 +9,7 @@ import {
   deleteListener,
 } from '../../db/whatsappListenerRepository.js';
 import { getSetting } from '../../dashboard/settingsRepository.js';
+import { resolveConfig } from '../../config/configResolver.js';
 import { log } from '../../logger.js';
 
 const VALID_CHANNEL_TYPES = new Set(['group', 'newsletter']);
@@ -31,7 +32,7 @@ export function createListenersRouter(db: Database.Database, bot: Bot): Router {
   router.get('/telegram-topics', async (_req: Request, res: Response) => {
     // 1. Try live Telegram API
     let liveTopics: Array<{ id: number; name: string }> = [];
-    const chatId = process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID'];
+    const chatId = resolveConfig(db, 'telegram_forward_group_id') ?? resolveConfig(db, 'telegram_chat_id');
     if (chatId) {
       try {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/dashboard/settingsRepository.ts
+++ b/src/dashboard/settingsRepository.ts
@@ -1,21 +1,39 @@
 import type Database from 'better-sqlite3';
+import { isCryptoReady, encryptValue, decryptValue } from './crypto.js';
+import { SECRET_KEYS, envKeyFor as resolverEnvKeyFor } from '../config/configResolver.js';
 
 export function getSetting(db: Database.Database, key: string): string | null {
-  const row = db.prepare('SELECT value FROM settings WHERE key = ?').get(key) as { value: string } | undefined;
-  return row?.value ?? null;
+  const row = db.prepare('SELECT value, encrypted FROM settings WHERE key = ?').get(key) as
+    { value: string; encrypted: number } | undefined;
+  if (!row) return null;
+  if (row.encrypted === 1 && isCryptoReady()) {
+    return decryptValue(row.value);
+  }
+  return row.value;
 }
 
 export function setSetting(db: Database.Database, key: string, value: string): void {
+  const isSecret = SECRET_KEYS.has(key);
+  const storedValue = isSecret && isCryptoReady() ? encryptValue(value) : value;
+  const encrypted = isSecret && isCryptoReady() ? 1 : 0;
+
   db.prepare(`
-    INSERT INTO settings (key, value, updated_at)
-    VALUES (?, ?, datetime('now'))
-    ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
-  `).run(key, value);
+    INSERT INTO settings (key, value, encrypted, updated_at)
+    VALUES (?, ?, ?, datetime('now'))
+    ON CONFLICT(key) DO UPDATE SET
+      value = excluded.value,
+      encrypted = excluded.encrypted,
+      updated_at = excluded.updated_at
+  `).run(key, storedValue, encrypted);
 }
 
 export function getAllSettings(db: Database.Database): Record<string, string> {
-  const rows = db.prepare('SELECT key, value FROM settings').all() as { key: string; value: string }[];
-  return Object.fromEntries(rows.map(r => [r.key, r.value]));
+  const rows = db.prepare('SELECT key, value, encrypted FROM settings').all() as
+    { key: string; value: string; encrypted: number }[];
+  return Object.fromEntries(rows.map(r => {
+    const val = r.encrypted === 1 && isCryptoReady() ? decryptValue(r.value) : r.value;
+    return [r.key, val];
+  }));
 }
 
 export interface SettingMeta {
@@ -28,9 +46,10 @@ export function getAllSettingsWithMeta(
   db: Database.Database,
   allKeys: readonly string[]
 ): Record<string, SettingMeta> {
-  const dbRows = db.prepare('SELECT key, value, updated_at FROM settings').all() as {
+  const dbRows = db.prepare('SELECT key, value, encrypted, updated_at FROM settings').all() as {
     key: string;
     value: string;
+    encrypted: number;
     updated_at: string | null;
   }[];
   const dbMap = new Map(dbRows.map(r => [r.key, r]));
@@ -40,8 +59,11 @@ export function getAllSettingsWithMeta(
   for (const key of allKeys) {
     const dbRow = dbMap.get(key);
     if (dbRow) {
+      const val = dbRow.encrypted === 1 && isCryptoReady()
+        ? decryptValue(dbRow.value)
+        : dbRow.value;
       result[key] = {
-        value: dbRow.value,
+        value: val,
         source: 'db',
         ...(dbRow.updated_at ? { updatedAt: dbRow.updated_at } : {}),
       };
@@ -58,18 +80,7 @@ export function getAllSettingsWithMeta(
 
 /** Maps a settings-table key to its corresponding environment-variable name. */
 function envKeyFor(key: string): string {
-  const overrides: Record<string, string> = {
-    alert_window_seconds:          'ALERT_UPDATE_WINDOW_SECONDS',
-    mapbox_monthly_limit:          'MAPBOX_MONTHLY_LIMIT',
-    mapbox_skip_drills:            'MAPBOX_SKIP_DRILLS',
-    mapbox_image_cache_size:       'MAPBOX_IMAGE_CACHE_SIZE',
-    telegram_invite_link:          'TELEGRAM_INVITE_LINK',
-    whatsapp_enabled:              'WHATSAPP_ENABLED',
-    whatsapp_map_debounce_seconds: 'WHATSAPP_MAP_DEBOUNCE_SECONDS',
-    health_port:                   'HEALTH_PORT',
-    dashboard_port:                'DASHBOARD_PORT',
-    ga4_measurement_id:            'GA4_MEASUREMENT_ID',
-    github_repo:                   'GITHUB_REPO',
-  };
-  return overrides[key] ?? key.toUpperCase();
+  // Delegate to the consolidated map in configResolver; fall back to local overrides
+  // for keys that only exist in the settings pipeline (not in configResolver).
+  return resolverEnvKeyFor(key);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { getActiveMessage, trackMessage, loadActiveMessages } from './alertWindo
 import { getTopicId } from './topicRouter';
 import { Alert } from './types';
 import { initDb, closeDb } from './db/schema';
-import { initializeCache } from './mapService';
+import { initializeCache, setMapboxToken } from './mapService';
 import { setupBotHandlers } from './bot/botSetup';
 import { notifySubscribers, shouldSkipForQuietHours } from './services/dmDispatcher';
 import { dmQueue } from './services/dmQueue.js';
@@ -66,6 +66,9 @@ const dashboardSecretBoot = process.env.DASHBOARD_SECRET;
       'telegram_chat_id',
       'mapbox_access_token',
     ]);
+
+    // Inject resolved Mapbox token into mapService module cache
+    setMapboxToken(resolvedConfig['mapbox_access_token']);
 
     initSubscriptionCache();
     initUsageCache();

--- a/src/mapService.ts
+++ b/src/mapService.ts
@@ -12,6 +12,18 @@ import { loadCacheEntries, saveCacheEntry, deleteCacheEntry, pruneCacheEntries }
 import { getZoneColor } from './config/zoneColors.js';
 import { log } from './logger.js';
 
+/** Injected Mapbox token from configResolver; falls back to process.env. */
+let _mapboxToken: string | undefined;
+
+/** Set the Mapbox token from config resolution (called once at startup). */
+export function setMapboxToken(token: string): void {
+  _mapboxToken = token;
+}
+
+function getMapboxToken(): string {
+  return _mapboxToken ?? process.env.MAPBOX_ACCESS_TOKEN ?? '';
+}
+
 const MAPBOX_URL_MAX_LENGTH = 8000;
 export const SIMPLIFY_TOLERANCE = 0.0003;
 export const SIMPLIFY_TOLERANCE_AGGRESSIVE = 0.003;
@@ -113,7 +125,7 @@ export function _seedCache(alert: Alert, buffer: Buffer): void {
 
 function buildMapboxUrl(geojson: FeatureCollection<Polygon>, style: string, padding: number): string {
   const encoded = encodeURIComponent(JSON.stringify(geojson));
-  const token = process.env.MAPBOX_ACCESS_TOKEN ?? '';
+  const token = getMapboxToken();
   return (
     `https://api.mapbox.com/styles/v1/${style}/static/` +
     `geojson(${encoded})/auto/${MAP_DIMENSIONS}?padding=${padding}&access_token=${token}`
@@ -140,7 +152,7 @@ export function _buildMarkersUrl(
   style: string = getCurrentMapStyle(),
   padding: number = getAdaptivePadding(cityIds.length),
 ): string | null {
-  const token = process.env.MAPBOX_ACCESS_TOKEN ?? '';
+  const token = getMapboxToken();
   const hex = getAlertColor(alertType).replace('#', '');
   const markers = cityIds
     .map((id) => getCityById(id))
@@ -165,7 +177,7 @@ function buildMarkersWithPaddingUrl(
   style: string,
   padding: number,
 ): string | null {
-  const token = process.env.MAPBOX_ACCESS_TOKEN ?? '';
+  const token = getMapboxToken();
   const hex = getAlertColor(alertType).replace('#', '');
 
   const cities = cityIds

--- a/src/whatsapp/whatsappListenerService.ts
+++ b/src/whatsapp/whatsappListenerService.ts
@@ -1,6 +1,7 @@
 import type Database from 'better-sqlite3';
 import { MessageMedia, type Chat } from 'whatsapp-web.js';
 import { getActiveListenersForChannel } from '../db/whatsappListenerRepository.js';
+import { resolveConfig } from '../config/configResolver.js';
 import { getEnabledGroupsForAlertType } from '../db/whatsappGroupRepository.js';
 import { isRoutingCacheLoaded, getWhatsAppTopicIdCached } from '../config/routingCache.js';
 import { getStatus, getClient } from './whatsappService.js';
@@ -144,7 +145,7 @@ export function createMessageHandler(
       if (listeners.length === 0) return;
 
       const targetChatId =
-        process.env['TELEGRAM_FORWARD_GROUP_ID'] ?? process.env['TELEGRAM_CHAT_ID']!;
+        resolveConfig(db, 'telegram_forward_group_id') ?? resolveConfig(db, 'telegram_chat_id') ?? '';
 
       const truncatedBody =
         msg.body.length > MESSAGE_BODY_MAX


### PR DESCRIPTION
## Summary

- `settingsRepository.ts`: Auto-encrypt SECRET_KEYS on `setSetting()`, auto-decrypt on `getSetting()`. Consolidate `envKeyFor()` to use configResolver's map.
- `mapService.ts`: `setMapboxToken()` module-level setter with env fallback
- Dashboard routes: `landing.ts`, `messages.ts`, `telegramListeners.ts`, `whatsappListeners.ts` — all `process.env` reads for DB-backed config replaced with `resolveConfig()`
- `whatsappListenerService.ts`: same for chat ID resolution

## Test plan

- [x] 1043 bot tests pass
- [x] 257 dashboard tests pass (DB_PATH=:memory:)
- [ ] Manual: verify settings page still shows correct values

Stacked on: #155 (feat/config-resolver-core)
Part 2c of 7 in the DB-backed secrets migration.