### PR TITLE
feat: encrypted secrets CRUD API routes

### DIFF
--- a/src/__tests__/dashboard/routes/secrets.test.ts
+++ b/src/__tests__/dashboard/routes/secrets.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import express from 'express';
+import request from 'supertest';
+import { initSchema } from '../../../db/schema.js';
+import { createSecretsRouter, secretsMutateLimiter } from '../../../dashboard/routes/secrets.js';
+import { initCrypto, _resetCryptoForTesting } from '../../../dashboard/crypto.js';
+import { getSetting } from '../../../dashboard/settingsRepository.js';
+
+const TEST_SECRET = 'test-dashboard-secret-for-secrets-api-32chars!';
+
+let db: Database.Database;
+let app: express.Express;
+
+before(() => {
+  _resetCryptoForTesting();
+  db = new Database(':memory:');
+  initSchema(db);
+  initCrypto(db, TEST_SECRET);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/secrets', createSecretsRouter(db));
+});
+
+beforeEach(() => secretsMutateLimiter.clearStore());
+
+after(() => {
+  _resetCryptoForTesting();
+  db.close();
+});
+
+// ── GET /api/secrets ────────────────────────────────────────────────────────
+
+describe('GET /api/secrets', () => {
+  it('returns all 5 secret keys', async () => {
+    const res = await request(app).get('/api/secrets');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.secrets.length, 5);
+    const keys = res.body.secrets.map((s: { key: string }) => s.key).sort();
+    assert.deepEqual(keys, [
+      'github_pat',
+      'mapbox_access_token',
+      'telegram_api_hash',
+      'telegram_api_id',
+      'telegram_bot_token',
+    ]);
+  });
+
+  it('never returns plaintext values', async () => {
+    // Store a secret in DB
+    const { setSetting } = await import('../../../dashboard/settingsRepository.js');
+    setSetting(db, 'telegram_bot_token', 'super-secret-bot-token-12345');
+
+    const res = await request(app).get('/api/secrets');
+    const botToken = res.body.secrets.find((s: { key: string }) => s.key === 'telegram_bot_token');
+    assert.ok(botToken);
+    assert.ok(!botToken.masked.includes('super-secret-bot-token-12345'), 'plaintext should not appear');
+    assert.ok(botToken.masked.includes('•'), 'should be masked');
+    assert.equal(botToken.source, 'db');
+  });
+
+  it('shows source=none when key is not set anywhere', async () => {
+    const res = await request(app).get('/api/secrets');
+    const pat = res.body.secrets.find((s: { key: string }) => s.key === 'github_pat');
+    // github_pat is likely not in env during tests
+    if (!process.env.GITHUB_PAT) {
+      assert.equal(pat.source, 'none');
+    }
+  });
+
+  it('includes requiresRestart flag', async () => {
+    const res = await request(app).get('/api/secrets');
+    const botToken = res.body.secrets.find((s: { key: string }) => s.key === 'telegram_bot_token');
+    const pat = res.body.secrets.find((s: { key: string }) => s.key === 'github_pat');
+    assert.equal(botToken.requiresRestart, true);
+    assert.equal(pat.requiresRestart, false);
+  });
+});
+
+// ── PUT /api/secrets/:key ───────────────────────────────────────────────────
+
+describe('PUT /api/secrets/:key', () => {
+  it('stores an encrypted secret', async () => {
+    const res = await request(app)
+      .put('/api/secrets/telegram_bot_token')
+      .send({ value: 'new-bot-token-xyz' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+
+    // Verify it's encrypted in DB (raw value should not be the plaintext)
+    const row = db.prepare("SELECT value, encrypted FROM settings WHERE key = 'telegram_bot_token'").get() as
+      { value: string; encrypted: number };
+    assert.equal(row.encrypted, 1);
+    assert.ok(!row.value.includes('new-bot-token-xyz'), 'raw DB value should be encrypted');
+
+    // But getSetting auto-decrypts
+    assert.equal(getSetting(db, 'telegram_bot_token'), 'new-bot-token-xyz');
+  });
+
+  it('rejects unknown key', async () => {
+    const res = await request(app)
+      .put('/api/secrets/not_a_real_key')
+      .send({ value: 'something' });
+    assert.equal(res.status, 400);
+  });
+
+  it('rejects empty value', async () => {
+    const res = await request(app)
+      .put('/api/secrets/telegram_bot_token')
+      .send({ value: '' });
+    assert.equal(res.status, 400);
+  });
+
+  it('rejects missing value', async () => {
+    const res = await request(app)
+      .put('/api/secrets/telegram_bot_token')
+      .send({});
+    assert.equal(res.status, 400);
+  });
+
+  it('tracks restart-required keys', async () => {
+    await request(app)
+      .put('/api/secrets/telegram_bot_token')
+      .send({ value: 'changed-token' });
+
+    const restartRes = await request(app).get('/api/secrets/restart-needed');
+    assert.equal(restartRes.body.needed, true);
+    assert.ok(restartRes.body.changedKeys.includes('telegram_bot_token'));
+  });
+});
+
+// ── DELETE /api/secrets/:key ────────────────────────────────────────────────
+
+describe('DELETE /api/secrets/:key', () => {
+  it('removes secret from DB', async () => {
+    // First store one
+    await request(app)
+      .put('/api/secrets/github_pat')
+      .send({ value: 'ghp_test123' });
+    assert.ok(getSetting(db, 'github_pat'));
+
+    // Delete it
+    const res = await request(app).delete('/api/secrets/github_pat');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+
+    // Verify removed from DB
+    const row = db.prepare("SELECT * FROM settings WHERE key = 'github_pat'").get();
+    assert.equal(row, undefined);
+  });
+
+  it('adds to _deleted_secrets list', async () => {
+    await request(app).delete('/api/secrets/mapbox_access_token');
+
+    const raw = db.prepare("SELECT value FROM settings WHERE key = '_deleted_secrets'").get() as
+      { value: string } | undefined;
+    assert.ok(raw);
+    const list = JSON.parse(raw!.value);
+    assert.ok(list.includes('mapbox_access_token'));
+  });
+
+  it('rejects unknown key', async () => {
+    const res = await request(app).delete('/api/secrets/invalid_key');
+    assert.equal(res.status, 400);
+  });
+});
+
+// ── GET /api/secrets/restart-needed ─────────────────────────────────────────
+
+describe('GET /api/secrets/restart-needed', () => {
+  it('returns needed:false when nothing changed (fresh module)', async () => {
+    // Note: previous tests may have changed keys, so this just validates the shape
+    const res = await request(app).get('/api/secrets/restart-needed');
+    assert.equal(res.status, 200);
+    assert.equal(typeof res.body.needed, 'boolean');
+    assert.ok(Array.isArray(res.body.changedKeys));
+  });
+});
+
+// ── Rate limiting ───────────────────────────────────────────────────────────
+
+describe('rate limiting', () => {
+  it('returns 429 after 5 writes', async () => {
+    secretsMutateLimiter.clearStore();
+    for (let i = 0; i < 5; i++) {
+      await request(app)
+        .put('/api/secrets/telegram_bot_token')
+        .send({ value: `token-${i}` });
+    }
+    const res = await request(app)
+      .put('/api/secrets/telegram_bot_token')
+      .send({ value: 'one-too-many' });
+    assert.equal(res.status, 429);
+  });
+});

--- a/src/dashboard/router.ts
+++ b/src/dashboard/router.ts
@@ -10,6 +10,7 @@ import { createMessagesRouter } from './routes/messages.js';
 import { createWhatsAppRouter } from './routes/whatsapp.js';
 import { createListenersRouter } from './routes/whatsappListeners.js';
 import { createTelegramListenerRouter } from './routes/telegramListeners.js';
+import { createSecretsRouter } from './routes/secrets.js';
 import * as whatsappService from '../whatsapp/whatsappService.js';
 import { getEnabledGroupsForAlertType } from '../db/whatsappGroupRepository.js';
 
@@ -28,5 +29,6 @@ export function createApiRouter(db: Database.Database, bot: Bot): Router {
   router.use('/whatsapp/listeners', createListenersRouter(db, bot));
   router.use('/whatsapp', createWhatsAppRouter(db, whatsappService));
   router.use('/telegram', createTelegramListenerRouter(db, bot));
+  router.use('/secrets', createSecretsRouter(db));
   return router;
 }

--- a/src/dashboard/routes/secrets.ts
+++ b/src/dashboard/routes/secrets.ts
@@ -1,0 +1,160 @@
+import { Router } from 'express';
+import type Database from 'better-sqlite3';
+import { getSetting, setSetting } from '../settingsRepository.js';
+import { SECRET_KEYS, RESTART_REQUIRED_KEYS, envKeyFor } from '../../config/configResolver.js';
+import { isCryptoReady } from '../crypto.js';
+import { createRateLimitMiddleware } from '../rateLimiter.js';
+
+// ── Restart tracking ─────────────────────────────────────────────────────────
+
+/** Keys changed since this process booted. Cleared on restart (module load). */
+const changedSinceBootKeys = new Set<string>();
+
+// ── Deletion tracking ────────────────────────────────────────────────────────
+
+const DELETED_SECRETS_KEY = '_deleted_secrets';
+
+function getDeletedSecrets(db: Database.Database): string[] {
+  const raw = getSetting(db, DELETED_SECRETS_KEY);
+  if (!raw) return [];
+  try { return JSON.parse(raw); } catch { return []; }
+}
+
+function addDeletedSecret(db: Database.Database, key: string): void {
+  const current = getDeletedSecrets(db);
+  if (!current.includes(key)) {
+    setSetting(db, DELETED_SECRETS_KEY, JSON.stringify([...current, key]));
+  }
+}
+
+// ── Masking ──────────────────────────────────────────────────────────────────
+
+function maskValue(value: string | null): string {
+  if (!value) return '(לא הוגדר)';
+  if (value.length <= 8) return '••••••••';
+  return value.slice(0, 6) + '•••••';
+}
+
+// ── Rate limiter ─────────────────────────────────────────────────────────────
+
+export const secretsMutateLimiter = createRateLimitMiddleware({
+  maxRequests: 5,
+  windowMs: 60_000,
+  message: 'יותר מדי בקשות — נסה שוב בעוד דקה',
+});
+
+// ── Router ───────────────────────────────────────────────────────────────────
+
+export function createSecretsRouter(db: Database.Database): Router {
+  const router = Router();
+
+  /**
+   * GET /api/secrets
+   * List all secret keys with metadata. Never returns plaintext values.
+   */
+  router.get('/', (_req, res) => {
+    const secrets = [...SECRET_KEYS].map(key => {
+      // Try DB first (getSetting auto-decrypts)
+      const dbValue = getSetting(db, key);
+      // Try env fallback
+      const envValue = process.env[envKeyFor(key)];
+
+      let source: 'db' | 'env' | 'none';
+      let masked: string;
+
+      if (dbValue !== null) {
+        source = 'db';
+        masked = maskValue(dbValue);
+      } else if (envValue !== undefined) {
+        source = 'env';
+        masked = maskValue(envValue);
+      } else {
+        source = 'none';
+        masked = maskValue(null);
+      }
+
+      // Get updated_at from DB row directly (raw query, no decrypt needed)
+      const row = db.prepare('SELECT updated_at FROM settings WHERE key = ?').get(key) as
+        { updated_at: string | null } | undefined;
+
+      return {
+        key,
+        masked,
+        source,
+        updatedAt: row?.updated_at ?? null,
+        requiresRestart: RESTART_REQUIRED_KEYS.has(key),
+      };
+    });
+
+    res.json({ secrets });
+  });
+
+  /**
+   * PUT /api/secrets/:key
+   * Set/update an encrypted secret value.
+   */
+  router.put('/:key', secretsMutateLimiter, (req, res) => {
+    const key = req.params['key'] as string;
+    const { value } = req.body as { value?: string };
+
+    if (!SECRET_KEYS.has(key)) {
+      res.status(400).json({ error: `מפתח לא מוכר: ${key}` });
+      return;
+    }
+
+    if (!value || typeof value !== 'string' || value.trim().length === 0) {
+      res.status(400).json({ error: 'ערך חסר או ריק' });
+      return;
+    }
+
+    if (!isCryptoReady()) {
+      res.status(503).json({ error: 'מערכת ההצפנה לא מאותחלת — בדוק DASHBOARD_SECRET' });
+      return;
+    }
+
+    // setSetting auto-encrypts SECRET_KEYS
+    setSetting(db, key, value.trim());
+
+    if (RESTART_REQUIRED_KEYS.has(key)) {
+      changedSinceBootKeys.add(key);
+    }
+
+    res.json({ ok: true });
+  });
+
+  /**
+   * DELETE /api/secrets/:key
+   * Remove a secret from DB. Falls back to env if present.
+   * Tracks deletion to prevent auto-migration re-import.
+   */
+  router.delete('/:key', secretsMutateLimiter, (req, res) => {
+    const key = req.params['key'] as string;
+
+    if (!SECRET_KEYS.has(key)) {
+      res.status(400).json({ error: `מפתח לא מוכר: ${key}` });
+      return;
+    }
+
+    db.prepare('DELETE FROM settings WHERE key = ?').run(key);
+    addDeletedSecret(db, key);
+
+    if (RESTART_REQUIRED_KEYS.has(key)) {
+      changedSinceBootKeys.add(key);
+    }
+
+    res.json({ ok: true });
+  });
+
+  /**
+   * GET /api/secrets/restart-needed
+   * Returns which restart-required keys were changed since last boot.
+   */
+  router.get('/restart-needed', (_req, res) => {
+    res.json({
+      needed: changedSinceBootKeys.size > 0,
+      changedKeys: [...changedSinceBootKeys],
+    });
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- `GET /api/secrets` — masked values + source/restart metadata (never plaintext)
- `PUT /api/secrets/:key` — encrypted write, validates key in SECRET_KEYS
- `DELETE /api/secrets/:key` — remove + track in `_deleted_secrets` to prevent re-migration
- `GET /api/secrets/restart-needed` — changed keys since boot
- Rate-limited: 5 writes/min per IP
- Mounted in `router.ts` under `/api/secrets`

## Test plan

- [x] 14 integration tests with in-memory DB + crypto
- [ ] Manual: verify via curl against running dashboard

Stacked on: #157 (feat/config-resolver-routes)
Part 3 of 7 in the DB-backed secrets migration.