### PR TITLE
feat: configurable DM relevance strings and all-clear text

### DIFF
--- a/dashboard-ui/src/components/messages/DmTemplatesPanel.tsx
+++ b/dashboard-ui/src/components/messages/DmTemplatesPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
+import { ConfirmModal } from '../ConfirmModal';
 import { api } from '../../api/client';
 
 interface SettingsMap {
@@ -37,8 +38,9 @@ const DM_FIELDS = [
 export function DmTemplatesPanel() {
   const queryClient = useQueryClient();
   const [edits, setEdits] = useState<Record<string, string>>({});
+  const [showResetConfirm, setShowResetConfirm] = useState(false);
 
-  const { data: settings } = useQuery<SettingsMap>({
+  const { data: settings, isLoading, isError } = useQuery<SettingsMap>({
     queryKey: ['settings'],
     queryFn: () => api.get<SettingsMap>('/api/settings'),
   });
@@ -58,6 +60,9 @@ export function DmTemplatesPanel() {
   });
 
   const hasEdits = Object.keys(edits).length > 0;
+
+  if (isLoading) return <div className="text-text-muted text-sm">טוען הגדרות...</div>;
+  if (isError) return <div className="text-red-400 text-sm">שגיאה בטעינת הגדרות</div>;
 
   return (
     <div className="space-y-5">
@@ -119,11 +124,7 @@ export function DmTemplatesPanel() {
         </button>
         <button
           type="button"
-          onClick={() => {
-            const resets: Record<string, string> = {};
-            for (const f of DM_FIELDS) resets[f.key] = '';
-            saveMutation.mutate(resets);
-          }}
+          onClick={() => setShowResetConfirm(true)}
           disabled={saveMutation.isPending}
           className="px-4 py-1.5 text-sm rounded-lg border border-border text-text-muted
                      hover:text-text-primary transition-colors disabled:opacity-40"
@@ -131,6 +132,20 @@ export function DmTemplatesPanel() {
           איפוס לברירת מחדל
         </button>
       </div>
+
+      <ConfirmModal
+        open={showResetConfirm}
+        onCancel={() => setShowResetConfirm(false)}
+        onConfirm={() => {
+          setShowResetConfirm(false);
+          const resets: Record<string, string> = {};
+          for (const f of DM_FIELDS) resets[f.key] = '';
+          saveMutation.mutate(resets);
+        }}
+        title="איפוס הגדרות DM"
+        description="כל הטקסטים יחזרו לברירת המחדל. פעולה זו לא ניתנת לביטול."
+        danger
+      />
     </div>
   );
 }

--- a/dashboard-ui/src/components/messages/DmTemplatesPanel.tsx
+++ b/dashboard-ui/src/components/messages/DmTemplatesPanel.tsx
@@ -1,0 +1,136 @@
+import { useState, useEffect } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
+import { api } from '../../api/client';
+
+interface SettingsMap {
+  [key: string]: string | undefined;
+}
+
+const DM_FIELDS = [
+  {
+    key: 'dm_all_clear_text',
+    label: 'הודעת "נשמו"',
+    description: 'טקסט שנשלח כשההתראה מסתיימת. {{עיר}} מוחלף בעיר המגורים.',
+    defaultValue: '\u{1F54A}\uFE0F נשמו! ההתראה ב{{עיר}} הסתיימה. אתם בטוחים.',
+  },
+  {
+    key: 'dm_relevance_in_area',
+    label: 'מחוון — באזורך',
+    description: 'מוצג כשההתראה בעיר המגורים של המשתמש.',
+    defaultValue: '\u{1F534} באזורך',
+  },
+  {
+    key: 'dm_relevance_nearby',
+    label: 'מחוון — באזור קרוב',
+    description: 'מוצג כשההתראה באזור סמוך לעיר המגורים.',
+    defaultValue: '\u{1F7E1} באזור קרוב',
+  },
+  {
+    key: 'dm_relevance_not_area',
+    label: 'מחוון — לא באזורך',
+    description: 'מוצג כשההתראה לא באזור עיר המגורים.',
+    defaultValue: '\u{1F7E2} לא באזורך',
+  },
+] as const;
+
+export function DmTemplatesPanel() {
+  const queryClient = useQueryClient();
+  const [edits, setEdits] = useState<Record<string, string>>({});
+
+  const { data: settings } = useQuery<SettingsMap>({
+    queryKey: ['settings'],
+    queryFn: () => api.get<SettingsMap>('/api/settings'),
+  });
+
+  // Reset edits when settings reload
+  useEffect(() => { setEdits({}); }, [settings]);
+
+  const saveMutation = useMutation({
+    mutationFn: (updates: Record<string, string>) =>
+      api.patch('/api/settings', updates),
+    onSuccess: () => {
+      setEdits({});
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('הגדרות DM נשמרו');
+    },
+    onError: (err) => toast.error(err instanceof Error ? err.message : 'שגיאה בשמירה'),
+  });
+
+  const hasEdits = Object.keys(edits).length > 0;
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h3 className="text-lg font-semibold text-text-primary mb-1">הודעות DM</h3>
+        <p className="text-sm text-text-muted">עריכת טקסטים שנשלחים בהודעות פרטיות למנויים</p>
+      </div>
+
+      {DM_FIELDS.map((field) => {
+        const currentValue = edits[field.key] ?? settings?.[field.key] ?? '';
+        const isEdited = field.key in edits;
+
+        return (
+          <div key={field.key} className="space-y-1">
+            <label className="block text-sm font-medium text-text-primary">
+              {field.label}
+              {isEdited && <span className="text-amber mr-1 text-xs">(שונה)</span>}
+            </label>
+            <p className="text-xs text-text-muted">{field.description}</p>
+            <input
+              type="text"
+              dir="rtl"
+              value={currentValue}
+              placeholder={field.defaultValue}
+              onChange={(e) =>
+                setEdits((prev) => ({ ...prev, [field.key]: e.target.value }))
+              }
+              className="w-full bg-surface border border-border rounded-lg px-3 py-2 text-sm
+                         text-text-primary focus:outline-none focus:border-amber/50 focus:ring-1
+                         focus:ring-amber/20"
+            />
+            {isEdited && (
+              <button
+                type="button"
+                onClick={() =>
+                  setEdits((prev) => {
+                    const { [field.key]: _, ...rest } = prev;
+                    return rest;
+                  })
+                }
+                className="text-xs text-text-muted hover:text-text-primary transition-colors"
+              >
+                בטל שינוי
+              </button>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="flex gap-2 pt-2">
+        <button
+          type="button"
+          onClick={() => saveMutation.mutate(edits)}
+          disabled={!hasEdits || saveMutation.isPending}
+          className="px-4 py-1.5 text-sm rounded-lg bg-amber text-base font-medium
+                     hover:bg-amber-dark transition-colors disabled:opacity-40"
+        >
+          {saveMutation.isPending ? 'שומר...' : 'שמור שינויים'}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            const resets: Record<string, string> = {};
+            for (const f of DM_FIELDS) resets[f.key] = '';
+            saveMutation.mutate(resets);
+          }}
+          disabled={saveMutation.isPending}
+          className="px-4 py-1.5 text-sm rounded-lg border border-border text-text-muted
+                     hover:text-text-primary transition-colors disabled:opacity-40"
+        >
+          איפוס לברירת מחדל
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/dashboard-ui/src/pages/Messages.tsx
+++ b/dashboard-ui/src/pages/Messages.tsx
@@ -11,6 +11,7 @@ import { SimulationPanel } from '../components/messages/SimulationPanel';
 import { SystemMessagePanel } from '../components/messages/SystemMessagePanel';
 import { RoutingSection } from '../components/messages/RoutingSection';
 import { TemplateBodyEditor } from '../components/messages/TemplateBodyEditor';
+import { DmTemplatesPanel } from '../components/messages/DmTemplatesPanel';
 import type { TemplateEntry, TemplateEdit } from '../components/messages/TemplateRow';
 import { ORDERED_CATEGORIES, ALERT_TYPE_CATEGORY } from '../utils/categoryConfig';
 import type { AlertCategory } from '../utils/categoryConfig';
@@ -31,7 +32,7 @@ export default function Messages() {
   const [importModalOpen, setImportModalOpen] = useState(false);
   const [pendingImport, setPendingImport] = useState<ImportRow[] | null>(null);
   const [rightPanelTab, setRightPanelTab] = useState<'simulation' | 'system'>('simulation');
-  const [mainTab, setMainTab] = useState<'types' | 'editor' | 'routing'>('types');
+  const [mainTab, setMainTab] = useState<'types' | 'editor' | 'routing' | 'dm'>('types');
 
   // Fetch all template entries
   const { data: templates = [] } = useQuery<TemplateEntry[]>({
@@ -268,6 +269,7 @@ export default function Messages() {
             ['types', 'סוגי התראות'] as const,
             ['editor', 'עורך תבנית'] as const,
             ['routing', 'ניתוב'] as const,
+            ['dm', 'הודעות DM'] as const,
           ]).map(([key, label]) => (
             <button
               key={key}
@@ -304,6 +306,7 @@ export default function Messages() {
             ))}
             {mainTab === 'editor' && <TemplateBodyEditor templates={templates} />}
             {mainTab === 'routing' && <RoutingSection />}
+            {mainTab === 'dm' && <DmTemplatesPanel />}
           </div>
 
           {/* Right column: simulation / system message (sticky) */}

--- a/src/__tests__/allClearIntegration.test.ts
+++ b/src/__tests__/allClearIntegration.test.ts
@@ -10,6 +10,7 @@ import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createAllClearTracker } from '../services/allClearTracker.js';
 import { createAllClearService } from '../services/allClearService.js';
+import type { SubscriberInfo } from '../db/subscriptionRepository.js';
 import type Database from 'better-sqlite3';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -59,6 +60,17 @@ function fakeDb(settings: Record<string, string>): Database.Database {
  * @param topicId - all_clear_topic_id (optional)
  * @param getUserIdsByZone - spy for subscriber lookup
  */
+function makeSubscriber(chatId: number): SubscriberInfo {
+  return {
+    chat_id: chatId,
+    format: 'short',
+    quiet_hours_enabled: false,
+    muted_until: null,
+    home_city: null,
+    matchedCities: [],
+  };
+}
+
 function makeStack(
   mode: string,
   topicId?: number,
@@ -71,11 +83,17 @@ function makeStack(
   const telegramCalls: Array<{ chatId: string; topicId: number | undefined; text: string }> = [];
   const renderCalls: Array<{ zone: string; alertType: string }> = [];
 
+  // Bridge getUserIdsByZone to getUsersByHomeCityInCities for integration tests
+  const getUsersByHomeCityInCities = (_cities: string[]) =>
+    getUserIdsByZone([]).map((id) => makeSubscriber(id));
+
   const service = createAllClearService({
     db: fakeDb(settings),
     chatId: 'chan-test',
     sendTelegram: async (chatId, tid, text) => { telegramCalls.push({ chatId, topicId: tid, text }); },
     getUserIdsByZone,
+    getUsersByHomeCityInCities,
+    shouldSkipForQuietHours: () => false,
     sendDm: async (userId, text) => { dmCalls.push({ userId, text }); },
     renderTemplate: (zone, alertType) => {
       renderCalls.push({ zone, alertType });
@@ -190,6 +208,8 @@ describe('allClearIntegration — duplicate suppression', () => {
       chatId: 'c',
       sendTelegram: async () => {},
       getUserIdsByZone: () => [1],
+      getUsersByHomeCityInCities: () => [makeSubscriber(1)],
+      shouldSkipForQuietHours: () => false,
       sendDm: async () => { firedCount++; },
       renderTemplate: () => 'text',
     });

--- a/src/__tests__/allClearIntegration.test.ts
+++ b/src/__tests__/allClearIntegration.test.ts
@@ -53,13 +53,6 @@ function fakeDb(settings: Record<string, string>): Database.Database {
   } as unknown as Database.Database;
 }
 
-/**
- * Creates a fully-wired tracker + service stack with injectable spies.
- *
- * @param mode - all_clear_mode setting ('dm' | 'channel' | 'both')
- * @param topicId - all_clear_topic_id (optional)
- * @param getUserIdsByZone - spy for subscriber lookup
- */
 function makeSubscriber(chatId: number): SubscriberInfo {
   return {
     chat_id: chatId,
@@ -71,10 +64,17 @@ function makeSubscriber(chatId: number): SubscriberInfo {
   };
 }
 
+/**
+ * Creates a fully-wired tracker + service stack with injectable spies.
+ *
+ * @param mode - all_clear_mode setting ('dm' | 'channel' | 'both')
+ * @param topicId - all_clear_topic_id (optional)
+ * @param getSubscribers - returns subscribers for given cities (default: empty)
+ */
 function makeStack(
   mode: string,
   topicId?: number,
-  getUserIdsByZone: (zones: string[]) => number[] = () => []
+  getSubscribers: (cities: string[]) => SubscriberInfo[] = () => []
 ) {
   const settings: Record<string, string> = { all_clear_mode: mode };
   if (topicId !== undefined) settings['all_clear_topic_id'] = String(topicId);
@@ -83,16 +83,11 @@ function makeStack(
   const telegramCalls: Array<{ chatId: string; topicId: number | undefined; text: string }> = [];
   const renderCalls: Array<{ zone: string; alertType: string }> = [];
 
-  // Bridge getUserIdsByZone to getUsersByHomeCityInCities for integration tests
-  const getUsersByHomeCityInCities = (_cities: string[]) =>
-    getUserIdsByZone([]).map((id) => makeSubscriber(id));
-
   const service = createAllClearService({
     db: fakeDb(settings),
     chatId: 'chan-test',
     sendTelegram: async (chatId, tid, text) => { telegramCalls.push({ chatId, topicId: tid, text }); },
-    getUserIdsByZone,
-    getUsersByHomeCityInCities,
+    getUsersByHomeCityInCities: getSubscribers,
     shouldSkipForQuietHours: () => false,
     sendDm: async (userId, text) => { dmCalls.push({ userId, text }); },
     renderTemplate: (zone, alertType) => {
@@ -115,7 +110,7 @@ function makeStack(
 
 describe('allClearIntegration — dm mode', () => {
   it('sends DM to zone subscribers after quiet window expires', async () => {
-    const { tracker, timers, dmCalls, telegramCalls } = makeStack('dm', undefined, () => [10, 20]);
+    const { tracker, timers, dmCalls, telegramCalls } = makeStack('dm', undefined, () => [makeSubscriber(10), makeSubscriber(20)]);
 
     tracker.recordAlert(['גליל עליון'], 'missiles');
     assert.equal(dmCalls.length, 0, 'No DM before timer fires');
@@ -147,7 +142,7 @@ describe('allClearIntegration — dm mode', () => {
 
 describe('allClearIntegration — cancelAlert (official "האירוע הסתיים")', () => {
   it('suppresses all-clear when cancelAlert is called before timer fires', async () => {
-    const { tracker, timers, dmCalls } = makeStack('dm', undefined, () => [99]);
+    const { tracker, timers, dmCalls } = makeStack('dm', undefined, () => [makeSubscriber(99)]);
 
     tracker.recordAlert(['דן'], 'missiles');
     assert.equal(timers.pendingCount(), 1);
@@ -164,7 +159,7 @@ describe('allClearIntegration — cancelAlert (official "האירוע הסתיי
   });
 
   it('cancelAlert does not prevent future alerts for the same zone', async () => {
-    const { tracker, timers, dmCalls } = makeStack('dm', undefined, () => [5]);
+    const { tracker, timers, dmCalls } = makeStack('dm', undefined, () => [makeSubscriber(5)]);
 
     tracker.recordAlert(['דן'], 'missiles');
     tracker.cancelAlert(['דן']); // official cancel
@@ -183,7 +178,7 @@ describe('allClearIntegration — cancelAlert (official "האירוע הסתיי
 
 describe('allClearIntegration — timer reset', () => {
   it('new alert resets the timer and all-clear fires after the second window', async () => {
-    const { tracker, timers, dmCalls } = makeStack('dm', undefined, () => [1]);
+    const { tracker, timers, dmCalls } = makeStack('dm', undefined, () => [makeSubscriber(1)]);
 
     tracker.recordAlert(['שרון'], 'missiles');
     assert.equal(timers.pendingCount(), 1, 'First timer scheduled');
@@ -207,7 +202,6 @@ describe('allClearIntegration — duplicate suppression', () => {
       db: fakeDb({ all_clear_mode: 'dm' }),
       chatId: 'c',
       sendTelegram: async () => {},
-      getUserIdsByZone: () => [1],
       getUsersByHomeCityInCities: () => [makeSubscriber(1)],
       shouldSkipForQuietHours: () => false,
       sendDm: async () => { firedCount++; },
@@ -239,7 +233,7 @@ describe('allClearIntegration — duplicate suppression', () => {
 
 describe('allClearIntegration — channel mode', () => {
   it('sends to channel with configured topicId, no DMs', async () => {
-    const { tracker, timers, dmCalls, telegramCalls } = makeStack('channel', 888, () => [1, 2]);
+    const { tracker, timers, dmCalls, telegramCalls } = makeStack('channel', 888, () => [makeSubscriber(1), makeSubscriber(2)]);
 
     tracker.recordAlert(['חיפה'], 'missiles');
     timers.fireAll();
@@ -256,7 +250,7 @@ describe('allClearIntegration — channel mode', () => {
 
 describe('allClearIntegration — both mode', () => {
   it('sends DM and channel message', async () => {
-    const { tracker, timers, dmCalls, telegramCalls } = makeStack('both', 999, () => [7]);
+    const { tracker, timers, dmCalls, telegramCalls } = makeStack('both', 999, () => [makeSubscriber(7)]);
 
     tracker.recordAlert(['נגב'], 'missiles');
     timers.fireAll();
@@ -272,7 +266,7 @@ describe('allClearIntegration — both mode', () => {
 
 describe('allClearIntegration — alertType passed through', () => {
   it('renderTemplate receives the correct alertType from recordAlert', async () => {
-    const { tracker, timers, renderCalls } = makeStack('dm', undefined, () => [1]);
+    const { tracker, timers, renderCalls } = makeStack('dm', undefined, () => [makeSubscriber(1)]);
 
     tracker.recordAlert(['תל אביב'], 'earthQuake');
     timers.fireAll();

--- a/src/__tests__/allClearIntegration.test.ts
+++ b/src/__tests__/allClearIntegration.test.ts
@@ -279,8 +279,8 @@ describe('allClearIntegration — alertType passed through', () => {
   });
 
   it('multiple zones with different alert types each pass their own alertType', async () => {
-    const { tracker, timers, renderCalls } = makeStack('dm', undefined, (zones) =>
-      zones.length > 0 ? [1] : []
+    const { tracker, timers, renderCalls } = makeStack('dm', undefined, (cities) =>
+      cities.length > 0 ? [makeSubscriber(1)] : []
     );
 
     tracker.recordAlert(['גליל עליון'], 'missiles');

--- a/src/__tests__/allClearService.test.ts
+++ b/src/__tests__/allClearService.test.ts
@@ -33,7 +33,6 @@ function makeSubscriber(overrides: Partial<SubscriberInfo> & { chat_id: number }
 function makeService(opts: {
   mode: string;
   topicId?: number;
-  getUserIdsByZone?: (zones: string[]) => number[];
   getUsersByHomeCityInCities?: (cityNames: string[]) => SubscriberInfo[];
   shouldSkipForQuietHours?: (alertType: string, quietEnabled: boolean, now: Date) => boolean;
   dmAllClearText?: string;
@@ -49,7 +48,6 @@ function makeService(opts: {
     db: fakeDb(settings),
     chatId: 'chan-123',
     sendTelegram: async (chatId, tid, text) => { telegramCalls.push({ chatId, topicId: tid, text }); },
-    getUserIdsByZone: opts.getUserIdsByZone ?? (() => []),
     getUsersByHomeCityInCities: opts.getUsersByHomeCityInCities ?? (() => []),
     shouldSkipForQuietHours: opts.shouldSkipForQuietHours ?? (() => false),
     sendDm: async (userId, text) => { dmCalls.push({ userId, text }); },
@@ -93,7 +91,7 @@ describe('allClearService — dm mode', () => {
       db: fakeDb({}), // no all_clear_mode key → defaults to 'dm'
       chatId: 'c',
       sendTelegram: async () => { throw new Error('should not be called'); },
-      getUserIdsByZone: () => [99],
+
       getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 99, home_city: 'חיפה' })],
       shouldSkipForQuietHours: () => false,
       sendDm: async (userId) => { dmCalls.push({ userId }); },
@@ -110,7 +108,7 @@ describe('allClearService — channel mode', () => {
     const { service, dmCalls, telegramCalls } = makeService({
       mode: 'channel',
       topicId: 555,
-      getUserIdsByZone: () => [1, 2],
+
       getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 1 }), makeSubscriber({ chat_id: 2 })],
     });
 
@@ -176,7 +174,7 @@ describe('allClearService — error resilience', () => {
       db: fakeDb({ all_clear_mode: 'dm' }),
       chatId: 'c',
       sendTelegram: async () => {},
-      getUserIdsByZone: () => [],
+
       getUsersByHomeCityInCities: () => [
         makeSubscriber({ chat_id: 1 }),
         makeSubscriber({ chat_id: 2 }),
@@ -201,7 +199,7 @@ describe('allClearService — error resilience', () => {
       db: fakeDb({ all_clear_mode: 'channel' }),
       chatId: 'c',
       sendTelegram: async () => { callCount++; throw new Error('network error'); },
-      getUserIdsByZone: () => [],
+
       getUsersByHomeCityInCities: () => [],
       shouldSkipForQuietHours: () => false,
       sendDm: async () => {},

--- a/src/__tests__/allClearService.test.ts
+++ b/src/__tests__/allClearService.test.ts
@@ -1,6 +1,8 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import { createAllClearService } from '../services/allClearService.js';
+import type { AllClearEvent } from '../services/allClearService.js';
+import type { SubscriberInfo } from '../db/subscriptionRepository.js';
 import type Database from 'better-sqlite3';
 
 // Builds a fake better-sqlite3 DB that returns settings from an in-memory map.
@@ -16,14 +18,27 @@ function fakeDb(settings: Record<string, string>): Database.Database {
   } as unknown as Database.Database;
 }
 
+function makeSubscriber(overrides: Partial<SubscriberInfo> & { chat_id: number }): SubscriberInfo {
+  return {
+    format: 'short',
+    quiet_hours_enabled: false,
+    muted_until: null,
+    home_city: null,
+    matchedCities: [],
+    ...overrides,
+  };
+}
+
 // Builds a service instance with controllable spies.
-function makeService(
-  mode: string,
-  topicId?: number,
-  getUserIdsByZone: (zones: string[]) => number[] = () => []
-) {
-  const settings: Record<string, string> = { all_clear_mode: mode };
-  if (topicId !== undefined) settings['all_clear_topic_id'] = String(topicId);
+function makeService(opts: {
+  mode: string;
+  topicId?: number;
+  getUserIdsByZone?: (zones: string[]) => number[];
+  getUsersByHomeCityInCities?: (cityNames: string[]) => SubscriberInfo[];
+  shouldSkipForQuietHours?: (alertType: string, quietEnabled: boolean, now: Date) => boolean;
+}) {
+  const settings: Record<string, string> = { all_clear_mode: opts.mode };
+  if (opts.topicId !== undefined) settings['all_clear_topic_id'] = String(opts.topicId);
 
   const dmCalls: Array<{ userId: number; text: string }> = [];
   const telegramCalls: Array<{ chatId: string; topicId: number | undefined; text: string }> = [];
@@ -32,7 +47,9 @@ function makeService(
     db: fakeDb(settings),
     chatId: 'chan-123',
     sendTelegram: async (chatId, tid, text) => { telegramCalls.push({ chatId, topicId: tid, text }); },
-    getUserIdsByZone,
+    getUserIdsByZone: opts.getUserIdsByZone ?? (() => []),
+    getUsersByHomeCityInCities: opts.getUsersByHomeCityInCities ?? (() => []),
+    shouldSkipForQuietHours: opts.shouldSkipForQuietHours ?? (() => false),
     sendDm: async (userId, text) => { dmCalls.push({ userId, text }); },
     renderTemplate: (zone, alertType) => `[${alertType}] ${zone}`,
   });
@@ -41,21 +58,30 @@ function makeService(
 }
 
 describe('allClearService — dm mode', () => {
-  it('sends DM to all subscribers of the zone', async () => {
-    const { service, dmCalls, telegramCalls } = makeService('dm', undefined, () => [10, 20]);
+  it('sends DM to subscribers whose home_city is in alertCities', async () => {
+    const { service, dmCalls, telegramCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: (cities) =>
+        cities.includes('תל אביב')
+          ? [makeSubscriber({ chat_id: 10, home_city: 'תל אביב' }), makeSubscriber({ chat_id: 20, home_city: 'תל אביב' })]
+          : [],
+    });
 
-    await service.handleAllClear([{ zone: 'גליל עליון', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב', 'רמת גן'] }]);
 
     assert.equal(dmCalls.length, 2);
     assert.equal(dmCalls[0].userId, 10);
     assert.equal(dmCalls[1].userId, 20);
-    assert.ok(dmCalls[0].text.includes('גליל עליון'), 'Rendered text passed to DM');
+    assert.ok(dmCalls[0].text.includes('דן'), 'Rendered text passed to DM');
     assert.equal(telegramCalls.length, 0, 'No channel message in dm mode');
   });
 
-  it('sends no DM when zone has no subscribers', async () => {
-    const { service, dmCalls } = makeService('dm', undefined, () => []);
-    await service.handleAllClear([{ zone: 'גולן', alertType: 'missiles' }]);
+  it('sends no DM when no subscribers have home_city in alertCities', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [],
+    });
+    await service.handleAllClear([{ zone: 'גולן', alertType: 'missiles', alertCities: ['קצרין'] }]);
     assert.equal(dmCalls.length, 0);
   });
 
@@ -66,10 +92,12 @@ describe('allClearService — dm mode', () => {
       chatId: 'c',
       sendTelegram: async () => { throw new Error('should not be called'); },
       getUserIdsByZone: () => [99],
+      getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 99, home_city: 'חיפה' })],
+      shouldSkipForQuietHours: () => false,
       sendDm: async (userId) => { dmCalls.push({ userId }); },
       renderTemplate: () => 'text',
     });
-    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['חיפה'] }]);
     assert.equal(dmCalls.length, 1);
     assert.equal(dmCalls[0].userId, 99);
   });
@@ -77,9 +105,14 @@ describe('allClearService — dm mode', () => {
 
 describe('allClearService — channel mode', () => {
   it('sends to channel with configured topicId, no DMs', async () => {
-    const { service, dmCalls, telegramCalls } = makeService('channel', 555, () => [1, 2]);
+    const { service, dmCalls, telegramCalls } = makeService({
+      mode: 'channel',
+      topicId: 555,
+      getUserIdsByZone: () => [1, 2],
+      getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 1 }), makeSubscriber({ chat_id: 2 })],
+    });
 
-    await service.handleAllClear([{ zone: 'שרון', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'שרון', alertType: 'missiles', alertCities: ['נתניה'] }]);
 
     assert.equal(telegramCalls.length, 1);
     assert.equal(telegramCalls[0].chatId, 'chan-123');
@@ -89,17 +122,21 @@ describe('allClearService — channel mode', () => {
   });
 
   it('sends with undefined topicId when not configured', async () => {
-    const { service, telegramCalls } = makeService('channel'); // no topicId
-    await service.handleAllClear([{ zone: 'חיפה', alertType: 'missiles' }]);
+    const { service, telegramCalls } = makeService({ mode: 'channel' }); // no topicId
+    await service.handleAllClear([{ zone: 'חיפה', alertType: 'missiles', alertCities: ['חיפה'] }]);
     assert.equal(telegramCalls[0].topicId, undefined);
   });
 });
 
 describe('allClearService — both mode', () => {
   it('sends DM and channel message', async () => {
-    const { service, dmCalls, telegramCalls } = makeService('both', 777, () => [99]);
+    const { service, dmCalls, telegramCalls } = makeService({
+      mode: 'both',
+      topicId: 777,
+      getUsersByHomeCityInCities: () => [makeSubscriber({ chat_id: 99, home_city: 'ירושלים' })],
+    });
 
-    await service.handleAllClear([{ zone: 'ירושלים', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'ירושלים', alertType: 'missiles', alertCities: ['ירושלים'] }]);
 
     assert.equal(dmCalls.length, 1);
     assert.equal(dmCalls[0].userId, 99);
@@ -110,13 +147,19 @@ describe('allClearService — both mode', () => {
 
 describe('allClearService — multiple events', () => {
   it('processes each zone event independently', async () => {
-    const { service, dmCalls } = makeService('dm', undefined, (zones) =>
-      zones.includes('דן') ? [1] : zones.includes('שרון') ? [2] : []
-    );
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: (cities) =>
+        cities.includes('תל אביב')
+          ? [makeSubscriber({ chat_id: 1, home_city: 'תל אביב' })]
+          : cities.includes('נתניה')
+            ? [makeSubscriber({ chat_id: 2, home_city: 'נתניה' })]
+            : [],
+    });
 
     await service.handleAllClear([
-      { zone: 'דן', alertType: 'missiles' },
-      { zone: 'שרון', alertType: 'missiles' },
+      { zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] },
+      { zone: 'שרון', alertType: 'missiles', alertCities: ['נתניה'] },
     ]);
 
     const userIds = dmCalls.map((c) => c.userId).sort();
@@ -131,7 +174,13 @@ describe('allClearService — error resilience', () => {
       db: fakeDb({ all_clear_mode: 'dm' }),
       chatId: 'c',
       sendTelegram: async () => {},
-      getUserIdsByZone: () => [1, 2, 3],
+      getUserIdsByZone: () => [],
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 1 }),
+        makeSubscriber({ chat_id: 2 }),
+        makeSubscriber({ chat_id: 3 }),
+      ],
+      shouldSkipForQuietHours: () => false,
       sendDm: async (userId) => {
         if (userId === 2) throw new Error('Telegram 429');
         successfulIds.push(userId);
@@ -139,7 +188,7 @@ describe('allClearService — error resilience', () => {
       renderTemplate: () => 'text',
     });
 
-    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles' }]);
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
 
     assert.deepEqual(successfulIds.sort(), [1, 3], 'Users 1 and 3 received DM despite failure for user 2');
   });
@@ -151,16 +200,110 @@ describe('allClearService — error resilience', () => {
       chatId: 'c',
       sendTelegram: async () => { callCount++; throw new Error('network error'); },
       getUserIdsByZone: () => [],
+      getUsersByHomeCityInCities: () => [],
+      shouldSkipForQuietHours: () => false,
       sendDm: async () => {},
       renderTemplate: () => 'text',
     });
 
     // Two events — both should be attempted even though the first throws
     await service.handleAllClear([
-      { zone: 'דן', alertType: 'missiles' },
-      { zone: 'שרון', alertType: 'missiles' },
+      { zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] },
+      { zone: 'שרון', alertType: 'missiles', alertCities: ['נתניה'] },
     ]);
 
     assert.equal(callCount, 2, 'Both channel sends attempted despite first failure');
+  });
+});
+
+describe('allClearService — home_city filtering', () => {
+  it('user with home_city in alertCities receives all-clear', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: (cities) =>
+        cities.includes('חיפה')
+          ? [makeSubscriber({ chat_id: 42, home_city: 'חיפה' })]
+          : [],
+    });
+
+    await service.handleAllClear([{ zone: 'חיפה', alertType: 'missiles', alertCities: ['חיפה', 'קריית אתא'] }]);
+
+    assert.equal(dmCalls.length, 1);
+    assert.equal(dmCalls[0].userId, 42);
+  });
+
+  it('user with home_city NOT in alertCities does NOT receive all-clear', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      // getUsersByHomeCityInCities correctly returns empty when home_city not in list
+      getUsersByHomeCityInCities: () => [],
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 0, 'No DM sent when home_city not in alertCities');
+  });
+});
+
+describe('allClearService — quiet hours and snooze', () => {
+  it('user in quiet hours does NOT receive all-clear for drills', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 50, home_city: 'תל אביב', quiet_hours_enabled: true }),
+      ],
+      shouldSkipForQuietHours: (_alertType, quietEnabled) => quietEnabled,
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'drill', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 0, 'DM skipped for quiet-hours user');
+  });
+
+  it('user in quiet hours DOES receive all-clear for security alerts', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 51, home_city: 'תל אביב', quiet_hours_enabled: true }),
+      ],
+      // shouldSkipForQuietHours returns false for security alerts even when quiet is enabled
+      shouldSkipForQuietHours: () => false,
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 1, 'DM sent for security alert despite quiet hours');
+    assert.equal(dmCalls[0].userId, 51);
+  });
+
+  it('snoozed user does NOT receive all-clear for general alerts', async () => {
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 60, home_city: 'תל אביב', muted_until: futureDate }),
+      ],
+    });
+
+    // 'general' category is suppressible by snooze
+    await service.handleAllClear([{ zone: 'דן', alertType: 'newsFlash', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 0, 'DM skipped for snoozed user');
+  });
+
+  it('snoozed user DOES receive all-clear for security alerts', async () => {
+    const futureDate = new Date(Date.now() + 3600 * 1000).toISOString();
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 61, home_city: 'תל אביב', muted_until: futureDate }),
+      ],
+    });
+
+    // 'missiles' maps to 'security' category — snooze does NOT apply
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 1, 'DM sent for security alert despite snooze');
+    assert.equal(dmCalls[0].userId, 61);
   });
 });

--- a/src/__tests__/allClearService.test.ts
+++ b/src/__tests__/allClearService.test.ts
@@ -36,9 +36,11 @@ function makeService(opts: {
   getUserIdsByZone?: (zones: string[]) => number[];
   getUsersByHomeCityInCities?: (cityNames: string[]) => SubscriberInfo[];
   shouldSkipForQuietHours?: (alertType: string, quietEnabled: boolean, now: Date) => boolean;
+  dmAllClearText?: string;
 }) {
   const settings: Record<string, string> = { all_clear_mode: opts.mode };
   if (opts.topicId !== undefined) settings['all_clear_topic_id'] = String(opts.topicId);
+  if (opts.dmAllClearText !== undefined) settings['dm_all_clear_text'] = opts.dmAllClearText;
 
   const dmCalls: Array<{ userId: number; text: string }> = [];
   const telegramCalls: Array<{ chatId: string; topicId: number | undefined; text: string }> = [];
@@ -305,5 +307,50 @@ describe('allClearService — quiet hours and snooze', () => {
 
     assert.equal(dmCalls.length, 1, 'DM sent for security alert despite snooze');
     assert.equal(dmCalls[0].userId, 61);
+  });
+});
+
+describe('allClearService — dm_all_clear_text setting', () => {
+  it('uses dm_all_clear_text when configured, substituting {{עיר}}', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      dmAllClearText: '🕊️ נשמו! ההתראה ב{{עיר}} הסתיימה.',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 70, home_city: 'חיפה' }),
+      ],
+    });
+
+    await service.handleAllClear([{ zone: 'קריות', alertType: 'missiles', alertCities: ['חיפה'] }]);
+
+    assert.equal(dmCalls.length, 1);
+    assert.equal(dmCalls[0].text, '🕊️ נשמו! ההתראה בחיפה הסתיימה.');
+  });
+
+  it('falls back to renderTemplate when dm_all_clear_text is not set', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 71, home_city: 'תל אביב' }),
+      ],
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls.length, 1);
+    assert.equal(dmCalls[0].text, '[missiles] דן', 'Falls back to renderTemplate output');
+  });
+
+  it('substitutes {{עיר}} with zone when subscriber has no home_city', async () => {
+    const { service, dmCalls } = makeService({
+      mode: 'dm',
+      dmAllClearText: 'נשמו ב{{עיר}}!',
+      getUsersByHomeCityInCities: () => [
+        makeSubscriber({ chat_id: 72, home_city: null }),
+      ],
+    });
+
+    await service.handleAllClear([{ zone: 'דן', alertType: 'missiles', alertCities: ['תל אביב'] }]);
+
+    assert.equal(dmCalls[0].text, 'נשמו בדן!', 'Falls back to zone name when home_city is null');
   });
 });

--- a/src/__tests__/allClearTracker.test.ts
+++ b/src/__tests__/allClearTracker.test.ts
@@ -43,19 +43,67 @@ describe('allClearTracker', () => {
     assert.deepEqual(fired[0], [{ zone: 'גליל עליון', alertType: 'missiles', alertCities: [] }]);
   });
 
-  it('fires onAllClear with alertCities when provided', () => {
+  it('fires onAllClear with alertCities when provided (with getCityZone)', () => {
     const fired: AllClearEvent[][] = [];
     const timers = createFakeTimers();
     const tracker = createAllClearTracker({
       scheduleFn: timers.scheduleFn,
       cancelScheduleFn: timers.cancelScheduleFn,
       onAllClear: (events) => fired.push(events),
+      getCityZone: (city) => city === 'תל אביב' || city === 'רמת גן' ? 'דן' : undefined,
     });
 
     tracker.recordAlert(['דן'], 'missiles', ['תל אביב', 'רמת גן']);
     timers.fireAll();
     assert.equal(fired.length, 1);
     assert.deepEqual(fired[0][0].alertCities, ['תל אביב', 'רמת גן']);
+  });
+
+  it('filters alertCities to only cities belonging to each zone', () => {
+    const fired: AllClearEvent[][] = [];
+    const timers = createFakeTimers();
+    const zoneMap: Record<string, string> = {
+      'תל אביב': 'דן',
+      'רמת גן': 'דן',
+      'חיפה': 'קריות',
+      'קריית שמונה': 'קריות',
+    };
+    const tracker = createAllClearTracker({
+      scheduleFn: timers.scheduleFn,
+      cancelScheduleFn: timers.cancelScheduleFn,
+      onAllClear: (events) => fired.push(events),
+      getCityZone: (city) => zoneMap[city],
+    });
+
+    // Alert spans two zones with 4 cities
+    tracker.recordAlert(['דן', 'קריות'], 'missiles', ['תל אביב', 'רמת גן', 'חיפה', 'קריית שמונה']);
+    timers.fireAll();
+
+    assert.equal(fired.length, 2, 'Each zone fires independently');
+    const danEvent = fired.flat().find(e => e.zone === 'דן')!;
+    const kriotEvent = fired.flat().find(e => e.zone === 'קריות')!;
+    assert.deepEqual(danEvent.alertCities.sort(), ['רמת גן', 'תל אביב']);
+    assert.deepEqual(kriotEvent.alertCities.sort(), ['חיפה', 'קריית שמונה']);
+  });
+
+  it('merges cities when second alert arrives for same zone', () => {
+    const fired: AllClearEvent[][] = [];
+    const timers = createFakeTimers();
+    const tracker = createAllClearTracker({
+      scheduleFn: timers.scheduleFn,
+      cancelScheduleFn: timers.cancelScheduleFn,
+      onAllClear: (events) => fired.push(events),
+      getCityZone: (city) => city === 'תל אביב' || city === 'רמת גן' || city === 'בני ברק' ? 'דן' : undefined,
+    });
+
+    // First alert wave
+    tracker.recordAlert(['דן'], 'missiles', ['תל אביב', 'רמת גן']);
+    // Second alert wave (same zone, new city)
+    tracker.recordAlert(['דן'], 'missiles', ['בני ברק']);
+    timers.fireAll();
+
+    assert.equal(fired.length, 1);
+    assert.deepEqual(fired[0][0].alertCities.sort(), ['בני ברק', 'רמת גן', 'תל אביב']);
   });
 
   it('resets the timer when a new alert arrives for the same zone', () => {

--- a/src/__tests__/allClearTracker.test.ts
+++ b/src/__tests__/allClearTracker.test.ts
@@ -40,7 +40,22 @@ describe('allClearTracker', () => {
 
     timers.fireAll();
     assert.equal(fired.length, 1);
-    assert.deepEqual(fired[0], [{ zone: 'גליל עליון', alertType: 'missiles' }]);
+    assert.deepEqual(fired[0], [{ zone: 'גליל עליון', alertType: 'missiles', alertCities: [] }]);
+  });
+
+  it('fires onAllClear with alertCities when provided', () => {
+    const fired: AllClearEvent[][] = [];
+    const timers = createFakeTimers();
+    const tracker = createAllClearTracker({
+      scheduleFn: timers.scheduleFn,
+      cancelScheduleFn: timers.cancelScheduleFn,
+      onAllClear: (events) => fired.push(events),
+    });
+
+    tracker.recordAlert(['דן'], 'missiles', ['תל אביב', 'רמת גן']);
+    timers.fireAll();
+    assert.equal(fired.length, 1);
+    assert.deepEqual(fired[0][0].alertCities, ['תל אביב', 'רמת גן']);
   });
 
   it('resets the timer when a new alert arrives for the same zone', () => {
@@ -61,7 +76,7 @@ describe('allClearTracker', () => {
 
     timers.fireAll();
     assert.equal(fired.length, 1, 'Should fire exactly once');
-    assert.deepEqual(fired[0], [{ zone: 'דן', alertType: 'missiles' }]);
+    assert.deepEqual(fired[0], [{ zone: 'דן', alertType: 'missiles', alertCities: [] }]);
   });
 
   it('deduplicates — does not fire twice for same zone without new alert', () => {

--- a/src/__tests__/dmDispatcher.test.ts
+++ b/src/__tests__/dmDispatcher.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import type { Alert } from '../types';
-import { buildShortMessage, buildAlertDmMessage, buildNewsFlashDmMessage, buildDmText, shouldSkipForQuietHours, notifySubscribers } from '../services/dmDispatcher';
+import { buildShortMessage, buildAlertDmMessage, buildNewsFlashDmMessage, buildDmText, shouldSkipForQuietHours, notifySubscribers, getRelevanceType, getRelevanceText } from '../services/dmDispatcher';
 import type { DmTask } from '../services/dmQueue';
 
 // Use in-memory DB for all notifySubscribers integration tests
@@ -746,5 +746,58 @@ describe('buildNewsFlashDmMessage — headline location suffix', () => {
     // Non-preliminary headline is always "📢 הודעה מיוחדת"
     assert.ok(msg.includes('📢 הודעה מיוחדת'), `expected non-preliminary headline, got: ${msg}`);
     assert.ok(!msg.includes('באזורך') || msg.split('\n').some(l => l.includes('📢')), 'non-preliminary headline must not say "באזורך"');
+  });
+});
+
+describe('getRelevanceType', () => {
+  it('returns null when homeCity is null', () => {
+    assert.equal(getRelevanceType(null, ['תל אביב']), null);
+  });
+
+  it('returns null when alertCities is empty', () => {
+    assert.equal(getRelevanceType('תל אביב', []), null);
+  });
+
+  it('returns in_area when homeCity is in alertCities', () => {
+    assert.equal(getRelevanceType('תל אביב', ['תל אביב', 'רמת גן']), 'in_area');
+  });
+
+  it('returns nearby when homeCity zone matches an alert city zone', () => {
+    // Both אור יהודה and אזור are in the same zone as nearby cities in דן
+    const result = getRelevanceType('אור יהודה', ['תל אביב']);
+    // This depends on city data — if both are in דן zone, returns 'nearby'
+    // If city data doesn't match zones, it returns 'not_area'
+    assert.ok(result === 'nearby' || result === 'not_area',
+      `Expected nearby or not_area, got: ${result}`);
+  });
+
+  it('returns not_area when no zone match', () => {
+    // Use a city definitely not in the same zone as the alert
+    const result = getRelevanceType('אילת', ['קריית שמונה']);
+    assert.equal(result, 'not_area');
+  });
+});
+
+describe('getRelevanceText', () => {
+  it('maps in_area to correct default string', () => {
+    const result = getRelevanceText('in_area');
+    assert.ok(result.includes('באזורך'), `Expected "באזורך", got: ${result}`);
+  });
+
+  it('maps nearby to correct default string', () => {
+    const result = getRelevanceText('nearby');
+    assert.ok(result.includes('באזור קרוב'), `Expected "באזור קרוב", got: ${result}`);
+  });
+
+  it('maps not_area to correct default string', () => {
+    const result = getRelevanceText('not_area');
+    assert.ok(result.includes('לא באזורך'), `Expected "לא באזורך", got: ${result}`);
+  });
+
+  it('uses provided strings over defaults', () => {
+    const custom = { inArea: 'CUSTOM_IN', nearby: 'CUSTOM_NEAR', notInArea: 'CUSTOM_NOT' };
+    assert.equal(getRelevanceText('in_area', custom), 'CUSTOM_IN');
+    assert.equal(getRelevanceText('nearby', custom), 'CUSTOM_NEAR');
+    assert.equal(getRelevanceText('not_area', custom), 'CUSTOM_NOT');
   });
 });

--- a/src/__tests__/subscriptionRepository.test.ts
+++ b/src/__tests__/subscriptionRepository.test.ts
@@ -13,6 +13,7 @@ import {
   removeAllSubscriptions,
   getUsersForCities,
   getUserIdsByZone,
+  getUsersByHomeCityInCities,
   initSubscriptionCache,
   updateSubscriberData,
 } from '../db/subscriptionRepository';
@@ -298,5 +299,75 @@ describe('subscriptionRepository — getUserIdsByZone', () => {
 
     const ids = getUserIdsByZone(['דן']);
     assert.ok(!ids.includes(1006), 'Inactive DM user should be excluded');
+  });
+});
+
+describe('subscriptionRepository — getUsersByHomeCityInCities', () => {
+  before(() => { initDb(); });
+  after(() => { closeDb(); });
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM subscriptions').run();
+    getDb().prepare('DELETE FROM users').run();
+    initSubscriptionCache();
+  });
+
+  it('returns users whose home_city is in the provided list', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2001, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2001, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2002, 'חיפה');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2002, 'חיפה');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב', 'חיפה']);
+    const ids = results.map((r) => r.chat_id).sort();
+    assert.deepEqual(ids, [2001, 2002]);
+  });
+
+  it('excludes users whose home_city is NOT in the list', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2003, 'באר שבע');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2003, 'באר שבע');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב', 'חיפה']);
+    assert.equal(results.length, 0, 'User with home_city not in list should be excluded');
+  });
+
+  it('excludes users with is_dm_active = false', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city, is_dm_active) VALUES (?, ?, 0)').run(2004, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2004, 'תל אביב');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב']);
+    assert.equal(results.length, 0, 'Inactive DM user should be excluded');
+  });
+
+  it('returns empty array when no home_city matches', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2005, 'אילת');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2005, 'אילת');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב', 'ירושלים']);
+    assert.deepEqual(results, []);
+  });
+
+  it('returns empty array for empty city list', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city) VALUES (?, ?)').run(2006, 'תל אביב');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2006, 'תל אביב');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities([]);
+    assert.deepEqual(results, []);
+  });
+
+  it('includes quiet_hours_enabled and muted_until in returned data', () => {
+    getDb().prepare('INSERT OR IGNORE INTO users (chat_id, home_city, quiet_hours_enabled, muted_until) VALUES (?, ?, 1, ?)').run(2007, 'תל אביב', '2099-01-01T00:00:00Z');
+    getDb().prepare('INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(2007, 'תל אביב');
+    initSubscriptionCache();
+
+    const results = getUsersByHomeCityInCities(['תל אביב']);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].quiet_hours_enabled, true);
+    assert.equal(results[0].muted_until, '2099-01-01T00:00:00Z');
+    assert.equal(results[0].home_city, 'תל אביב');
   });
 });

--- a/src/__tests__/telegramBot.test.ts
+++ b/src/__tests__/telegramBot.test.ts
@@ -14,6 +14,7 @@ import {
   isMediaEditError,
   isMessageGoneError,
   renderAllClearTemplate,
+  renderBodyTemplate,
   type EditBotApi,
 } from '../telegramBot.js';
 import type { Alert } from '../types.js';
@@ -741,5 +742,32 @@ describe('renderAllClearTemplate', () => {
     assert.ok(parts.length >= 2, 'Message must have at least two parts');
     assert.ok(parts[0].startsWith('✅'), 'First part is the emoji+title');
     assert.ok(parts[1].includes('שרון'), 'Second part contains zone');
+  });
+});
+
+describe('renderBodyTemplate', () => {
+  const vars = { time: '14:32', cities: 'תל אביב, רמת גן', cityCount: 2, title: 'ירי רקטות', emoji: '🔴' };
+
+  it('substitutes all 5 Hebrew placeholders', () => {
+    const template = '{{אמוגי}} {{כותרת}} | {{זמן}} | {{מספר_ערים}} ערים\n{{ערים}}';
+    const result = renderBodyTemplate(template, vars);
+    assert.equal(result, '🔴 ירי רקטות | 14:32 | 2 ערים\nתל אביב, רמת גן');
+  });
+
+  it('normalizes whitespace inside braces', () => {
+    const template = '{{ ערים }} · {{ זמן }}';
+    const result = renderBodyTemplate(template, vars);
+    assert.equal(result, 'תל אביב, רמת גן · 14:32');
+  });
+
+  it('leaves unknown placeholders as literal text', () => {
+    const template = '{{שם}} · {{ערים}}';
+    const result = renderBodyTemplate(template, vars);
+    assert.equal(result, '{{שם}} · תל אביב, רמת גן');
+  });
+
+  it('handles empty template', () => {
+    const result = renderBodyTemplate('', vars);
+    assert.equal(result, '');
   });
 });

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -31,6 +31,10 @@ const ALLOWED_KEYS = new Set([
   'privacy_defaults',
   'all_clear_mode',
   'all_clear_topic_id',
+  'dm_all_clear_text',
+  'dm_relevance_in_area',
+  'dm_relevance_nearby',
+  'dm_relevance_not_area',
 ]);
 
 export function createSettingsRouter(db: Database.Database): Router {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -218,7 +218,7 @@ export function initSchema(database: Database.Database): void {
   // existing users remain subscribed after migration.
   addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN is_dm_active INTEGER NOT NULL DEFAULT 1');
 
-  // v0.5 — full template body: nullable TEXT column; NULL = use default assembled structure
+  // Template body: nullable TEXT column; NULL = use default assembled structure
   addColumnIfMissing(database, 'ALTER TABLE message_templates ADD COLUMN body_template TEXT DEFAULT NULL');
 
   database.prepare('CREATE UNIQUE INDEX IF NOT EXISTS idx_users_connection_code ON users(connection_code) WHERE connection_code IS NOT NULL').run();

--- a/src/db/subscriptionRepository.ts
+++ b/src/db/subscriptionRepository.ts
@@ -250,6 +250,58 @@ export function getUserIdsByZone(zones: string[]): number[] {
   return Array.from(chatIds);
 }
 
+// Returns DM-active subscribers whose home_city is in the provided city list.
+// Used by allClearService to dispatch "שקט חזר" messages only to users
+// whose home city was actually in the alert (not just any city in the zone).
+export function getUsersByHomeCityInCities(cityNames: string[]): SubscriberInfo[] {
+  if (cityNames.length === 0) return [];
+
+  if (!cacheInitialized) {
+    // DB fallback
+    const placeholders = cityNames.map(() => '?').join(', ');
+    const rows = getDb()
+      .prepare(
+        `SELECT DISTINCT u.chat_id, u.format, u.quiet_hours_enabled, u.muted_until, u.home_city
+         FROM users u
+         WHERE u.home_city IN (${placeholders}) AND u.is_dm_active = 1`
+      )
+      .all(...cityNames) as {
+        chat_id: number;
+        format: NotificationFormat;
+        quiet_hours_enabled: number;
+        muted_until: string | null;
+        home_city: string | null;
+      }[];
+
+    return rows.map((row) => ({
+      chat_id: row.chat_id,
+      format: row.format,
+      quiet_hours_enabled: row.quiet_hours_enabled === 1,
+      muted_until: row.muted_until ?? null,
+      home_city: row.home_city ?? null,
+      matchedCities: row.home_city ? [row.home_city] : [],
+    }));
+  }
+
+  const citySet = new Set(cityNames);
+  const results: SubscriberInfo[] = [];
+
+  for (const [chatId, data] of subscriberData) {
+    if (!data.is_dm_active) continue;
+    if (!data.home_city || !citySet.has(data.home_city)) continue;
+    results.push({
+      chat_id: chatId,
+      format: data.format,
+      quiet_hours_enabled: data.quiet_hours_enabled,
+      muted_until: data.muted_until,
+      home_city: data.home_city,
+      matchedCities: [data.home_city],
+    });
+  }
+
+  return results;
+}
+
 export function evictSubscriberFromCache(chatId: number, cityName?: string): void {
   if (!cacheInitialized) return;
   if (cityName !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import { createMessageHandler } from './whatsapp/whatsappListenerService.js';
 import { initializeTelegramListener } from './telegram-listener/telegramListenerService.js';
 import { disconnect as disconnectTelegramListener } from './telegram-listener/telegramListenerClient.js';
 import { InputFile } from 'grammy';
-import { initSubscriptionCache, getUserIdsByZone, getUsersByHomeCityInCities } from './db/subscriptionRepository.js';
+import { initSubscriptionCache, getUsersByHomeCityInCities } from './db/subscriptionRepository.js';
 import { initUsageCache } from './db/mapboxUsageRepository.js';
 import { createAllClearTracker } from './services/allClearTracker.js';
 import { createAllClearService } from './services/allClearService.js';
@@ -168,7 +168,6 @@ for (const envVar of REQUIRED_ENV_VARS) {
         ...(topicId != null ? { message_thread_id: topicId } : {}),
       });
     },
-    getUserIdsByZone,
     getUsersByHomeCityInCities,
     shouldSkipForQuietHours,
     sendDm: async (userId, text) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ import { Alert } from './types';
 import { initDb, closeDb } from './db/schema';
 import { initializeCache } from './mapService';
 import { setupBotHandlers } from './bot/botSetup';
-import { notifySubscribers } from './services/dmDispatcher';
+import { notifySubscribers, shouldSkipForQuietHours } from './services/dmDispatcher';
+import { dmQueue } from './services/dmQueue.js';
 import { shouldSkipMap } from './alertHelpers';
 import { handleNewAlert } from './alertHandler';
 import { insertAlert as insertAlertHistory, countAlertsToday, getDailyCountsForMonth } from './db/alertHistoryRepository.js';
@@ -27,7 +28,7 @@ import { createMessageHandler } from './whatsapp/whatsappListenerService.js';
 import { initializeTelegramListener } from './telegram-listener/telegramListenerService.js';
 import { disconnect as disconnectTelegramListener } from './telegram-listener/telegramListenerClient.js';
 import { InputFile } from 'grammy';
-import { initSubscriptionCache, getUserIdsByZone } from './db/subscriptionRepository.js';
+import { initSubscriptionCache, getUserIdsByZone, getUsersByHomeCityInCities } from './db/subscriptionRepository.js';
 import { initUsageCache } from './db/mapboxUsageRepository.js';
 import { createAllClearTracker } from './services/allClearTracker.js';
 import { createAllClearService } from './services/allClearService.js';
@@ -168,8 +169,10 @@ for (const envVar of REQUIRED_ENV_VARS) {
       });
     },
     getUserIdsByZone,
+    getUsersByHomeCityInCities,
+    shouldSkipForQuietHours,
     sendDm: async (userId, text) => {
-      await bot.api.sendMessage(String(userId), text, { parse_mode: 'HTML' });
+      dmQueue.enqueueAll([{ chatId: String(userId), text }]);
     },
     renderTemplate: renderAllClearTemplate,
   });
@@ -234,7 +237,7 @@ for (const envVar of REQUIRED_ENV_VARS) {
       if (isOfficialAllClear) {
         allClearTracker.cancelAlert(alertZones);
       } else {
-        allClearTracker.recordAlert(alertZones, alert.type);
+        allClearTracker.recordAlert(alertZones, alert.type, alert.cities);
       }
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -178,6 +178,7 @@ for (const envVar of REQUIRED_ENV_VARS) {
   });
 
   const allClearTracker = createAllClearTracker({
+    getCityZone: (city) => getCityData(city)?.zone,
     onAllClear: (events) => {
       allClearService.handleAllClear(events).catch(err =>
         log('error', 'Index', `handleAllClear נכשל: ${String(err)}`)

--- a/src/services/allClearService.ts
+++ b/src/services/allClearService.ts
@@ -12,7 +12,6 @@ export interface AllClearServiceDeps {
   db: Database.Database;
   chatId: string;
   sendTelegram: (chatId: string, topicId: number | undefined, text: string) => Promise<void>;
-  getUserIdsByZone: (zones: string[]) => number[];
   getUsersByHomeCityInCities: (cityNames: string[]) => SubscriberInfo[];
   shouldSkipForQuietHours: (alertType: string, quietEnabled: boolean, now: Date) => boolean;
   sendDm: (userId: number, text: string) => Promise<void>;

--- a/src/services/allClearService.ts
+++ b/src/services/allClearService.ts
@@ -1,13 +1,10 @@
 import type Database from 'better-sqlite3';
 import { getSetting } from '../dashboard/settingsRepository.js';
 import { log } from '../logger.js';
-
-// Mirrors AllClearEvent from allClearTracker.ts (PR #133).
-// Import from there once that PR is merged.
-export interface AllClearEvent {
-  zone: string;
-  alertType: string;
-}
+import { ALERT_TYPE_CATEGORY } from '../topicRouter.js';
+import type { AllClearEvent } from './allClearTracker.js';
+import type { SubscriberInfo } from '../db/subscriptionRepository.js';
+export type { AllClearEvent };
 
 export type AllClearMode = 'dm' | 'channel' | 'both';
 
@@ -16,6 +13,8 @@ export interface AllClearServiceDeps {
   chatId: string;
   sendTelegram: (chatId: string, topicId: number | undefined, text: string) => Promise<void>;
   getUserIdsByZone: (zones: string[]) => number[];
+  getUsersByHomeCityInCities: (cityNames: string[]) => SubscriberInfo[];
+  shouldSkipForQuietHours: (alertType: string, quietEnabled: boolean, now: Date) => boolean;
   sendDm: (userId: number, text: string) => Promise<void>;
   renderTemplate: (zone: string, alertType: string) => string;
 }
@@ -26,7 +25,7 @@ export function createAllClearService(deps: AllClearServiceDeps) {
     const topicIdStr = getSetting(deps.db, 'all_clear_topic_id');
     const topicId = topicIdStr ? Number(topicIdStr) : undefined;
 
-    for (const { zone, alertType } of events) {
+    for (const { zone, alertType, alertCities } of events) {
       let text: string;
       try {
         text = deps.renderTemplate(zone, alertType);
@@ -36,12 +35,27 @@ export function createAllClearService(deps: AllClearServiceDeps) {
       }
 
       if (mode === 'dm' || mode === 'both') {
-        const userIds = deps.getUserIdsByZone([zone]);
-        for (const userId of userIds) {
+        const subscribers = deps.getUsersByHomeCityInCities(alertCities);
+        const now = new Date();
+
+        // Quiet-hours and snooze: only suppress drills/general categories.
+        // Security, nature, and environmental alerts always pass through.
+        const category = ALERT_TYPE_CATEGORY[alertType] ?? 'general';
+        const muteApplies = category === 'drills' || category === 'general';
+
+        for (const subscriber of subscribers) {
+          // Quiet-hours filter
+          if (deps.shouldSkipForQuietHours(alertType, subscriber.quiet_hours_enabled, now)) {
+            continue;
+          }
+          // Snooze filter
+          if (muteApplies && subscriber.muted_until && new Date(subscriber.muted_until) > now) {
+            continue;
+          }
           try {
-            await deps.sendDm(userId, text);
+            await deps.sendDm(subscriber.chat_id, text);
           } catch (err) {
-            log('error', 'AllClear', `DM נכשל למשתמש ${userId} (אזור "${zone}"): ${String(err)}`);
+            log('error', 'AllClear', `DM נכשל למשתמש ${subscriber.chat_id} (אזור "${zone}"): ${String(err)}`);
           }
         }
       }

--- a/src/services/allClearService.ts
+++ b/src/services/allClearService.ts
@@ -45,25 +45,35 @@ export function createAllClearService(deps: AllClearServiceDeps) {
         const category = ALERT_TYPE_CATEGORY[alertType] ?? 'general';
         const muteApplies = category === 'drills' || category === 'general';
 
+        let skippedQH = 0;
+        let skippedMuted = 0;
+
         for (const subscriber of subscribers) {
           // Quiet-hours filter
           if (deps.shouldSkipForQuietHours(alertType, subscriber.quiet_hours_enabled, now)) {
+            skippedQH++;
             continue;
           }
           // Snooze filter
           if (muteApplies && subscriber.muted_until && new Date(subscriber.muted_until) > now) {
+            skippedMuted++;
             continue;
           }
           // Personalize DM: substitute {{עיר}} with subscriber's home city
           const dmText = dmAllClearRaw
             ? dmAllClearRaw.replace(/\{\{עיר\}\}/g, subscriber.home_city ?? zone)
             : text;
+          // In production, sendDm enqueues synchronously via dmQueue — delivery errors are
+          // handled by the queue's per-message retry logic, not by this catch block.
           try {
             await deps.sendDm(subscriber.chat_id, dmText);
           } catch (err) {
             log('error', 'AllClear', `DM נכשל למשתמש ${subscriber.chat_id} (אזור "${zone}"): ${String(err)}`);
           }
         }
+
+        if (skippedQH > 0) log('info', 'AllClear', `🔕 שעות שקט: ${skippedQH} מנויים דולגו (${alertType})`);
+        if (skippedMuted > 0) log('info', 'AllClear', `🔇 מושתק: ${skippedMuted} מנויים דולגו (${alertType})`);
       }
 
       if (mode === 'channel' || mode === 'both') {

--- a/src/services/allClearService.ts
+++ b/src/services/allClearService.ts
@@ -38,6 +38,9 @@ export function createAllClearService(deps: AllClearServiceDeps) {
         const subscribers = deps.getUsersByHomeCityInCities(alertCities);
         const now = new Date();
 
+        // DM-specific all-clear text (configurable via dashboard). Falls back to channel template.
+        const dmAllClearRaw = getSetting(deps.db, 'dm_all_clear_text') || null;
+
         // Quiet-hours and snooze: only suppress drills/general categories.
         // Security, nature, and environmental alerts always pass through.
         const category = ALERT_TYPE_CATEGORY[alertType] ?? 'general';
@@ -52,8 +55,12 @@ export function createAllClearService(deps: AllClearServiceDeps) {
           if (muteApplies && subscriber.muted_until && new Date(subscriber.muted_until) > now) {
             continue;
           }
+          // Personalize DM: substitute {{עיר}} with subscriber's home city
+          const dmText = dmAllClearRaw
+            ? dmAllClearRaw.replace(/\{\{עיר\}\}/g, subscriber.home_city ?? zone)
+            : text;
           try {
-            await deps.sendDm(subscriber.chat_id, text);
+            await deps.sendDm(subscriber.chat_id, dmText);
           } catch (err) {
             log('error', 'AllClear', `DM נכשל למשתמש ${subscriber.chat_id} (אזור "${zone}"): ${String(err)}`);
           }

--- a/src/services/allClearTracker.ts
+++ b/src/services/allClearTracker.ts
@@ -1,6 +1,7 @@
 export interface AllClearEvent {
   zone: string;
   alertType: string;
+  alertCities: string[];
 }
 
 export interface AllClearDeps {
@@ -13,6 +14,7 @@ export interface AllClearDeps {
 interface ZoneTimer {
   id: ReturnType<typeof setTimeout>;
   alertType: string;
+  alertCities: string[];
 }
 
 const DEFAULT_QUIET_WINDOW_MS = 600_000; // 10 minutes
@@ -24,7 +26,7 @@ export function createAllClearTracker(deps: AllClearDeps) {
   const cancel = deps.cancelScheduleFn ?? clearTimeout;
   const windowMs = deps.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS;
 
-  function recordAlert(zones: string[], alertType: string): void {
+  function recordAlert(zones: string[], alertType: string, alertCities: string[] = []): void {
     for (const zone of zones) {
       const existing = timers.get(zone);
       if (existing) cancel(existing.id);
@@ -35,11 +37,11 @@ export function createAllClearTracker(deps: AllClearDeps) {
       const id = schedule(() => {
         if (!firedZones.has(zone)) {
           firedZones.add(zone);
-          deps.onAllClear([{ zone, alertType }]);
+          deps.onAllClear([{ zone, alertType, alertCities }]);
         }
         timers.delete(zone);
       }, windowMs);
-      timers.set(zone, { id, alertType });
+      timers.set(zone, { id, alertType, alertCities });
     }
   }
 

--- a/src/services/allClearTracker.ts
+++ b/src/services/allClearTracker.ts
@@ -9,6 +9,8 @@ export interface AllClearDeps {
   cancelScheduleFn?: (id: ReturnType<typeof setTimeout>) => void;
   onAllClear: (events: AllClearEvent[]) => void;
   quietWindowMs?: number;
+  /** Maps a city name to its zone. Used to filter alertCities per zone. */
+  getCityZone?: (city: string) => string | undefined;
 }
 
 interface ZoneTimer {
@@ -25,11 +27,19 @@ export function createAllClearTracker(deps: AllClearDeps) {
   const schedule = deps.scheduleFn ?? setTimeout;
   const cancel = deps.cancelScheduleFn ?? clearTimeout;
   const windowMs = deps.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS;
+  const getCityZone = deps.getCityZone ?? (() => undefined);
 
   function recordAlert(zones: string[], alertType: string, alertCities: string[] = []): void {
     for (const zone of zones) {
       const existing = timers.get(zone);
       if (existing) cancel(existing.id);
+
+      // Filter: only cities belonging to THIS zone (prevents duplicate DMs across zones)
+      const zoneCities = alertCities.filter(c => getCityZone(c) === zone);
+      // Merge: combine with previously recorded cities for the same zone
+      const mergedCities = existing
+        ? [...new Set([...existing.alertCities, ...zoneCities])]
+        : zoneCities;
 
       // New alert resets dedupe — a fresh all-clear should fire later
       firedZones.delete(zone);
@@ -37,11 +47,11 @@ export function createAllClearTracker(deps: AllClearDeps) {
       const id = schedule(() => {
         if (!firedZones.has(zone)) {
           firedZones.add(zone);
-          deps.onAllClear([{ zone, alertType, alertCities }]);
+          deps.onAllClear([{ zone, alertType, alertCities: mergedCities }]);
         }
         timers.delete(zone);
       }, windowMs);
-      timers.set(zone, { id, alertType, alertCities });
+      timers.set(zone, { id, alertType, alertCities: mergedCities });
     }
   }
 

--- a/src/services/dmDispatcher.ts
+++ b/src/services/dmDispatcher.ts
@@ -6,28 +6,78 @@ import { ALERT_TYPE_CATEGORY } from '../topicRouter.js';
 import { dmQueue, type DmTask } from './dmQueue.js';
 import { log } from '../logger.js';
 import { renderCountdownBar } from '../config/urgency.js';
+import { getSetting } from '../dashboard/settingsRepository.js';
+import { getDb } from '../db/schema.js';
 
-/**
- * Returns a personal relevance indicator based on the subscriber's home city.
- * - 🔴 באזורך — home_city is directly in the alert
- * - 🟡 באזור קרוב — home_city shares a zone with an alert city
- * - 🟢 לא באזורך — no geographic match
- * Returns null if home_city is not set or alert has no cities.
- */
-export function getRelevanceIndicator(homeCity: string | null, alertCities: string[]): string | null {
+// Default relevance strings — overridable via dashboard settings
+const DEFAULT_RELEVANCE_IN_AREA = '🔴 באזורך';
+const DEFAULT_RELEVANCE_NEARBY = '🟡 באזור קרוב';
+const DEFAULT_RELEVANCE_NOT_AREA = '🟢 לא באזורך';
+
+/** Reads relevance strings from settings table. Called once per notifySubscribers() invocation.
+ *  Falls back to defaults if DB is not available (e.g. in tests). */
+export function getRelevanceStrings(): { inArea: string; nearby: string; notInArea: string } {
+  try {
+    const db = getDb();
+    return {
+      inArea: getSetting(db, 'dm_relevance_in_area') ?? DEFAULT_RELEVANCE_IN_AREA,
+      nearby: getSetting(db, 'dm_relevance_nearby') ?? DEFAULT_RELEVANCE_NEARBY,
+      notInArea: getSetting(db, 'dm_relevance_not_area') ?? DEFAULT_RELEVANCE_NOT_AREA,
+    };
+  } catch {
+    return {
+      inArea: DEFAULT_RELEVANCE_IN_AREA,
+      nearby: DEFAULT_RELEVANCE_NEARBY,
+      notInArea: DEFAULT_RELEVANCE_NOT_AREA,
+    };
+  }
+}
+
+export type RelevanceType = 'in_area' | 'nearby' | 'not_area';
+
+/** Returns the geographic relevance type (pure logic, no text). */
+export function getRelevanceType(homeCity: string | null, alertCities: string[]): RelevanceType | null {
   if (!homeCity || alertCities.length === 0) return null;
 
-  if (alertCities.includes(homeCity)) return '🔴 באזורך';
+  if (alertCities.includes(homeCity)) return 'in_area';
 
   const homeCityData = getCityData(homeCity);
   if (homeCityData?.zone) {
     for (const city of alertCities) {
       const cityData = getCityData(city);
-      if (cityData?.zone === homeCityData.zone) return '🟡 באזור קרוב';
+      if (cityData?.zone === homeCityData.zone) return 'nearby';
     }
   }
 
-  return '🟢 לא באזורך';
+  return 'not_area';
+}
+
+/** Maps a relevance type to its display text (from settings or defaults). */
+export function getRelevanceText(
+  type: RelevanceType,
+  strings?: { inArea: string; nearby: string; notInArea: string },
+): string {
+  const s = strings ?? getRelevanceStrings();
+  const map: Record<RelevanceType, string> = {
+    in_area: s.inArea,
+    nearby: s.nearby,
+    not_area: s.notInArea,
+  };
+  return map[type];
+}
+
+/**
+ * Returns a personal relevance indicator based on the subscriber's home city.
+ * Convenience wrapper — returns the display text directly.
+ */
+export function getRelevanceIndicator(
+  homeCity: string | null,
+  alertCities: string[],
+  strings?: { inArea: string; nearby: string; notInArea: string },
+): string | null {
+  const type = getRelevanceType(homeCity, alertCities);
+  if (!type) return null;
+  return getRelevanceText(type, strings);
 }
 
 function getMinCountdown(cityNames: string[]): number {
@@ -58,14 +108,14 @@ export function buildAlertDmMessage(alert: Alert, homeCity?: string | null): str
 
   const parts: string[] = [];
 
-  const relevance = getRelevanceIndicator(homeCity ?? null, alert.cities);
-  if (relevance) parts.push(relevance);
+  const relevanceType = getRelevanceType(homeCity ?? null, alert.cities);
+  if (relevanceType) parts.push(getRelevanceText(relevanceType));
 
   // Only say "באזורך" when the home city is actually in the alert,
   // or when the subscriber has no home city set (relevance = null).
-  // "🟡 באזור קרוב" and "🟢 לא באזורך" get a plain title — the
+  // "nearby" and "not_area" get a plain title — the
   // relevance indicator already tells the full story.
-  const homeInAlert = relevance === '🔴 באזורך' || homeCity == null;
+  const homeInAlert = relevanceType === 'in_area' || homeCity == null;
   const titleLine = isNationwide
     ? `${emoji} ${title}`
     : homeInAlert
@@ -130,12 +180,12 @@ export function buildNewsFlashDmMessage(alert: Alert, homeCity?: string | null):
 
   const parts: string[] = [];
 
-  const relevance = getRelevanceIndicator(homeCity ?? null, alert.cities);
-  if (relevance) parts.push(relevance);
+  const relevanceType2 = getRelevanceType(homeCity ?? null, alert.cities);
+  if (relevanceType2) parts.push(getRelevanceText(relevanceType2));
 
   // Only say "באזורך" in the preliminary headline when home city is in the alert
   // or when no home city is set — mirrors the fix in buildAlertDmMessage.
-  const homeInAlert = relevance === '🔴 באזורך' || homeCity == null;
+  const homeInAlert = relevanceType2 === 'in_area' || homeCity == null;
   const headline = isPreliminary
     ? `⚠️ התראה מקדימה${allLabels.length > 0 && homeInAlert ? ' באזורך' : ''}`
     : `📢 הודעה מיוחדת`;

--- a/src/services/dmDispatcher.ts
+++ b/src/services/dmDispatcher.ts
@@ -14,7 +14,7 @@ const DEFAULT_RELEVANCE_IN_AREA = '🔴 באזורך';
 const DEFAULT_RELEVANCE_NEARBY = '🟡 באזור קרוב';
 const DEFAULT_RELEVANCE_NOT_AREA = '🟢 לא באזורך';
 
-/** Reads relevance strings from settings table. Called once per notifySubscribers() invocation.
+/** Reads relevance strings from settings table. Called once per notifySubscribers() batch.
  *  Falls back to defaults if DB is not available (e.g. in tests). */
 export function getRelevanceStrings(): { inArea: string; nearby: string; notInArea: string } {
   try {
@@ -100,7 +100,7 @@ export function buildShortMessage(alert: Alert): string {
   return `${emoji} ${title} | ${cities}${more}${cdSuffix}`;
 }
 
-export function buildAlertDmMessage(alert: Alert, homeCity?: string | null): string {
+export function buildAlertDmMessage(alert: Alert, homeCity?: string | null, strings?: { inArea: string; nearby: string; notInArea: string }): string {
   const emoji = getEmoji(alert.type);
   const title = getTitleHe(alert.type);
   const category = ALERT_TYPE_CATEGORY[alert.type] ?? 'general';
@@ -110,7 +110,7 @@ export function buildAlertDmMessage(alert: Alert, homeCity?: string | null): str
   const parts: string[] = [];
 
   const relevanceType = getRelevanceType(homeCity ?? null, alert.cities);
-  if (relevanceType) parts.push(getRelevanceText(relevanceType));
+  if (relevanceType) parts.push(getRelevanceText(relevanceType, strings));
 
   // Only say "באזורך" when the home city is actually in the alert,
   // or when the subscriber has no home city set (relevance = null).
@@ -154,7 +154,7 @@ function isPreliminaryAlert(instructions?: string): boolean {
   );
 }
 
-export function buildNewsFlashDmMessage(alert: Alert, homeCity?: string | null): string {
+export function buildNewsFlashDmMessage(alert: Alert, homeCity?: string | null, strings?: { inArea: string; nearby: string; notInArea: string }): string {
   const isPreliminary = isPreliminaryAlert(alert.instructions);
 
   const seenZones = new Set<string>();
@@ -182,7 +182,7 @@ export function buildNewsFlashDmMessage(alert: Alert, homeCity?: string | null):
   const parts: string[] = [];
 
   const relevanceType2 = getRelevanceType(homeCity ?? null, alert.cities);
-  if (relevanceType2) parts.push(getRelevanceText(relevanceType2));
+  if (relevanceType2) parts.push(getRelevanceText(relevanceType2, strings));
 
   // Only say "באזורך" in the preliminary headline when home city is in the alert
   // or when no home city is set — mirrors the fix in buildAlertDmMessage.
@@ -206,9 +206,9 @@ export function buildNewsFlashDmMessage(alert: Alert, homeCity?: string | null):
 
 // Issue 3: format param removed — DM format was unified; short/detailed produce identical output.
 // NotificationFormat is still stored in the DB and shown in the UI settings panel.
-export function buildDmText(alert: Alert, homeCity?: string | null): string {
-  if (alert.type === 'newsFlash') return buildNewsFlashDmMessage(alert, homeCity);
-  return buildAlertDmMessage(alert, homeCity);
+export function buildDmText(alert: Alert, homeCity?: string | null, strings?: { inArea: string; nearby: string; notInArea: string }): string {
+  if (alert.type === 'newsFlash') return buildNewsFlashDmMessage(alert, homeCity, strings);
+  return buildAlertDmMessage(alert, homeCity, strings);
 }
 
 function getIsraelHour(now: Date): number {
@@ -269,9 +269,10 @@ export function notifySubscribers(
       ? afterQuietHours.filter(({ muted_until }) => !muted_until || new Date(muted_until) <= now)
       : afterQuietHours;
 
+    const relevanceStrings = getRelevanceStrings();
     const tasks = afterMute.map(({ chat_id, matchedCities, home_city }) => {
       const personalAlert: Alert = { ...alert, cities: matchedCities };
-      return { chatId: String(chat_id), text: buildDmText(personalAlert, home_city) };
+      return { chatId: String(chat_id), text: buildDmText(personalAlert, home_city, relevanceStrings) };
     });
 
     const skippedQH = subscribers.length - afterQuietHours.length;

--- a/src/services/dmDispatcher.ts
+++ b/src/services/dmDispatcher.ts
@@ -24,7 +24,8 @@ export function getRelevanceStrings(): { inArea: string; nearby: string; notInAr
       nearby: getSetting(db, 'dm_relevance_nearby') ?? DEFAULT_RELEVANCE_NEARBY,
       notInArea: getSetting(db, 'dm_relevance_not_area') ?? DEFAULT_RELEVANCE_NOT_AREA,
     };
-  } catch {
+  } catch (err) {
+    log('warn', 'DM', `getRelevanceStrings: DB לא זמין — שימוש בברירות מחדל: ${String(err)}`);
     return {
       inArea: DEFAULT_RELEVANCE_IN_AREA,
       nearby: DEFAULT_RELEVANCE_NEARBY,

--- a/src/telegramBot.ts
+++ b/src/telegramBot.ts
@@ -178,6 +178,18 @@ export function renderBodyTemplate(template: string, vars: TemplateVars): string
   return result;
 }
 
+function formatSerialSuffix(serial: number | undefined, density: 'חריג' | 'רגיל' | null | undefined, now: Date): string | null {
+  if (serial == null) return null;
+  const dateStr = now.toLocaleDateString('he-IL', {
+    timeZone: 'Asia/Jerusalem',
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  });
+  const densitySuffix = density === 'חריג' ? ` \u00B7 \u26A0\uFE0F ${escapeHtml('חריג')}` : '';
+  return `<i>#${serial} \u00B7 ${escapeHtml(dateStr)}${densitySuffix}</i>`;
+}
+
 export function formatAlertMessage(alert: Alert, serial?: number, density?: 'חריג' | 'רגיל' | null): string {
   const actionCard = buildActionCard(alert.type);
   const emoji = getEmoji(alert.type);
@@ -196,16 +208,18 @@ export function formatAlertMessage(alert: Alert, serial?: number, density?: 'ח�
       ? buildZoneOnlyList(alert.cities)
       : buildZonedCityList(alert.cities);
 
-  // If a custom body template exists, render it and return early
+  // If a custom body template exists, render it (still appending serial/density)
   const bodyTemplate = getBodyTemplate(alert.type);
   if (bodyTemplate) {
-    return renderBodyTemplate(bodyTemplate, {
+    const rendered = renderBodyTemplate(bodyTemplate, {
       time: timeStr,
       cities: cityList,
       cityCount: alert.cities.length,
       title,
       emoji,
     });
+    const serialLine = formatSerialSuffix(serial, density, now);
+    return serialLine ? `${rendered}\n\n${serialLine}` : rendered;
   }
 
   // Default assembly (no custom template)
@@ -230,16 +244,8 @@ export function formatAlertMessage(alert: Alert, serial?: number, density?: 'ח�
   if (instructionsPart) parts.push(instructionsPart);
   if (cityList) parts.push(cityList);
 
-  if (serial != null) {
-    const dateStr = now.toLocaleDateString('he-IL', {
-      timeZone: 'Asia/Jerusalem',
-      day: '2-digit',
-      month: '2-digit',
-      year: 'numeric',
-    });
-    const densitySuffix = density === 'חריג' ? ` \u00B7 \u26A0\uFE0F ${escapeHtml('חריג')}` : '';
-    parts.push(`<i>#${serial} \u00B7 ${escapeHtml(dateStr)}${densitySuffix}</i>`);
-  }
+  const serialLine = formatSerialSuffix(serial, density, now);
+  if (serialLine) parts.push(serialLine);
 
   return parts.join('\n\n');
 }


### PR DESCRIPTION
## Summary
- DM relevance indicators ("באזורך", "באזור קרוב", "לא באזורך") now configurable via dashboard settings
- All-clear text ("נשמו!") configurable via `dm_all_clear_text` setting
- Refactored `getRelevanceIndicator` → split into `getRelevanceType` (pure logic) + `getRelevanceText` (display) to prevent string comparison breakage when text is customized
- New 4th tab "הודעות DM" in Messages page with 4 editable text fields

## Stacked on
- `fix/all-clear-home-city` (PR #152)
- `feat/template-system` (PR #156)

## Changes
- `src/dashboard/routes/settings.ts` — 4 new keys in `ALLOWED_KEYS`
- `src/services/dmDispatcher.ts` — `getRelevanceType()`, `getRelevanceText()`, `getRelevanceStrings()` with DB fallback
- `dashboard-ui/src/components/messages/DmTemplatesPanel.tsx` — new component
- `dashboard-ui/src/pages/Messages.tsx` — 4th tab added

## Test plan
- [x] All 1016 backend tests pass (includes merged all-clear tests)
- [x] 70 dmDispatcher tests pass
- [x] Dashboard build succeeds
- [ ] Manual: change `dm_relevance_in_area` in dashboard, send test alert, verify DM uses custom text
- [ ] Manual: reset all DM texts to default, verify hardcoded defaults appear