### PR TITLE
feat: Configuration & Secrets dashboard page

### DIFF
--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -17,6 +17,7 @@ const Messages         = lazy(() => import('./pages/Messages'));
 const WhatsApp         = lazy(() => import('./pages/WhatsApp').then(m => ({ default: m.WhatsApp })));
 const WhatsAppListeners  = lazy(() => import('./pages/WhatsAppListeners').then(m => ({ default: m.WhatsAppListeners })));
 const TelegramListeners  = lazy(() => import('./pages/TelegramListeners').then(m => ({ default: m.TelegramListeners })));
+const Configuration      = lazy(() => import('./pages/Configuration'));
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 30_000 } } });
 
@@ -42,6 +43,7 @@ export function App() {
               <Route path="whatsapp" element={<WhatsApp />} />
               <Route path="whatsapp-listeners" element={<WhatsAppListeners />} />
               <Route path="telegram-listeners" element={<TelegramListeners />} />
+              <Route path="configuration" element={<Configuration />} />
             </Route>
           </Routes>
         </Suspense>

--- a/dashboard-ui/src/api/client.ts
+++ b/dashboard-ui/src/api/client.ts
@@ -33,5 +33,11 @@ export const api = {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
     }),
+  put: <T>(path: string, body: unknown) =>
+    request<T>(path, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
   delete: <T>(path: string) => request<T>(path, { method: 'DELETE' }),
 };

--- a/dashboard-ui/src/components/configuration/RestartBanner.tsx
+++ b/dashboard-ui/src/components/configuration/RestartBanner.tsx
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../../api/client';
+import { AlertTriangle } from 'lucide-react';
+
+interface RestartNeeded {
+  needed: boolean;
+  changedKeys: string[];
+}
+
+const KEY_LABELS: Record<string, string> = {
+  telegram_bot_token: 'Telegram Bot Token',
+  telegram_api_id: 'Telegram API ID',
+  telegram_api_hash: 'Telegram API Hash',
+  health_port: 'Health Port',
+  dashboard_port: 'Dashboard Port',
+  telegram_listener_enabled: 'Telegram Listener',
+};
+
+export function RestartBanner() {
+  const { data } = useQuery({
+    queryKey: ['secrets-restart-needed'],
+    queryFn: () => api.get<RestartNeeded>('/api/secrets/restart-needed'),
+    refetchInterval: 30_000,
+  });
+
+  if (!data?.needed) return null;
+
+  const labels = data.changedKeys.map(k => KEY_LABELS[k] ?? k).join(', ');
+
+  return (
+    <div className="mx-6 mt-4 flex items-center gap-3 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 text-amber-200">
+      <AlertTriangle size={18} className="shrink-0 text-amber-400" />
+      <span className="text-sm">
+        <strong>הפעלה מחדש נדרשת</strong> — שינויים ב: {labels}
+      </span>
+    </div>
+  );
+}

--- a/dashboard-ui/src/components/configuration/SecretCard.tsx
+++ b/dashboard-ui/src/components/configuration/SecretCard.tsx
@@ -1,0 +1,82 @@
+import { Pencil, Trash2, RotateCcw } from 'lucide-react';
+
+export interface SecretInfo {
+  key: string;
+  masked: string;
+  source: 'db' | 'env' | 'none';
+  updatedAt: string | null;
+  requiresRestart: boolean;
+}
+
+interface SecretCardProps {
+  secret: SecretInfo;
+  onEdit: () => void;
+  onDelete: () => void;
+}
+
+const KEY_LABELS: Record<string, string> = {
+  telegram_bot_token: 'Telegram Bot Token',
+  mapbox_access_token: 'Mapbox Access Token',
+  github_pat: 'GitHub PAT',
+  telegram_api_id: 'Telegram API ID',
+  telegram_api_hash: 'Telegram API Hash',
+};
+
+const SOURCE_BADGES: Record<string, { label: string; cls: string }> = {
+  db:   { label: 'DB',     cls: 'bg-green-500/20 text-green-400 border-green-500/30' },
+  env:  { label: 'ENV',    cls: 'bg-blue-500/20 text-blue-400 border-blue-500/30' },
+  none: { label: 'חסר',   cls: 'bg-red-500/20 text-red-400 border-red-500/30' },
+};
+
+export function SecretCard({ secret, onEdit, onDelete }: SecretCardProps) {
+  const label = KEY_LABELS[secret.key] ?? secret.key;
+  const badge = SOURCE_BADGES[secret.source];
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-glass)] p-4 backdrop-blur-md">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium text-text-primary">{label}</span>
+            <span className={`inline-block rounded border px-1.5 py-0.5 text-[10px] font-semibold leading-none ${badge.cls}`}>
+              {badge.label}
+            </span>
+            {secret.requiresRestart && (
+              <span className="inline-flex items-center gap-1 rounded border border-amber-500/30 bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-semibold leading-none text-amber-400">
+                <RotateCcw size={10} />
+                restart
+              </span>
+            )}
+          </div>
+          <code className="mt-1.5 block text-xs text-text-secondary" dir="ltr">
+            {secret.masked}
+          </code>
+          {secret.updatedAt && (
+            <span className="mt-1 block text-[11px] text-text-secondary/60">
+              עודכן: {new Date(secret.updatedAt + 'Z').toLocaleString('he-IL')}
+            </span>
+          )}
+        </div>
+
+        <div className="flex shrink-0 gap-1.5">
+          <button
+            onClick={onEdit}
+            className="rounded-md p-1.5 text-text-secondary transition hover:bg-blue-500/10 hover:text-blue-400"
+            title="ערוך"
+          >
+            <Pencil size={14} />
+          </button>
+          {secret.source === 'db' && (
+            <button
+              onClick={onDelete}
+              className="rounded-md p-1.5 text-text-secondary transition hover:bg-red-500/10 hover:text-red-400"
+              title="מחק (חזרה ל-ENV)"
+            >
+              <Trash2 size={14} />
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard-ui/src/components/configuration/SecretEditModal.tsx
+++ b/dashboard-ui/src/components/configuration/SecretEditModal.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+
+interface SecretEditModalProps {
+  secretKey: string;
+  onSave: (value: string) => void;
+  onCancel: () => void;
+  saving: boolean;
+}
+
+const KEY_LABELS: Record<string, string> = {
+  telegram_bot_token: 'Telegram Bot Token',
+  mapbox_access_token: 'Mapbox Access Token',
+  github_pat: 'GitHub PAT',
+  telegram_api_id: 'Telegram API ID',
+  telegram_api_hash: 'Telegram API Hash',
+};
+
+export function SecretEditModal({ secretKey, onSave, onCancel, saving }: SecretEditModalProps) {
+  const [value, setValue] = useState('');
+  const [visible, setVisible] = useState(false);
+
+  const label = KEY_LABELS[secretKey] ?? secretKey;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="w-full max-w-md rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] p-6 shadow-2xl">
+        <h3 className="mb-4 text-lg font-semibold text-text-primary">
+          {label}
+        </h3>
+
+        <div className="relative">
+          <input
+            type={visible ? 'text' : 'password'}
+            value={value}
+            onChange={e => setValue(e.target.value)}
+            placeholder="הזן ערך חדש..."
+            className="w-full rounded-lg border border-[var(--color-border)] bg-[var(--color-glass)] px-4 py-2.5 pl-10 text-sm text-text-primary placeholder-text-secondary outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/30"
+            dir="ltr"
+            autoFocus
+          />
+          <button
+            type="button"
+            onClick={() => setVisible(v => !v)}
+            className="absolute left-3 top-1/2 -translate-y-1/2 text-text-secondary hover:text-text-primary"
+          >
+            {visible ? <EyeOff size={16} /> : <Eye size={16} />}
+          </button>
+        </div>
+
+        <div className="mt-5 flex gap-3">
+          <button
+            onClick={() => onSave(value.trim())}
+            disabled={saving || !value.trim()}
+            className="flex-1 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-blue-500 disabled:opacity-50"
+          >
+            {saving ? 'שומר...' : 'שמור'}
+          </button>
+          <button
+            onClick={onCancel}
+            disabled={saving}
+            className="rounded-lg border border-[var(--color-border)] px-4 py-2 text-sm text-text-secondary transition hover:text-text-primary"
+          >
+            ביטול
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard-ui/src/layout/Root.tsx
+++ b/dashboard-ui/src/layout/Root.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Sidebar } from './Sidebar';
 import { StatusStrip } from './StatusStrip';
 import { CommandPalette } from './CommandPalette';
+import { RestartBanner } from '../components/configuration/RestartBanner';
 
 export function Root() {
   const [uptime, setUptime] = useState(0);
@@ -12,6 +13,7 @@ export function Root() {
       <Sidebar uptime={uptime} />
       <main className="flex-1 flex flex-col overflow-hidden min-w-0 relative z-10">
         <StatusStrip onUptime={setUptime} />
+        <RestartBanner />
         <div className="flex-1 overflow-y-auto p-6">
           <Outlet />
         </div>

--- a/dashboard-ui/src/layout/Sidebar.tsx
+++ b/dashboard-ui/src/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import {
   Activity, Bell, Users, Radio, SlidersHorizontal,
   Globe, MessageSquare, Phone, Rss, MessageCircle,
-  LayoutDashboard, Settings, ChevronLeft, ChevronDown,
+  LayoutDashboard, Settings, ChevronLeft, ChevronDown, KeyRound,
 } from 'lucide-react';
 import { LiveDot } from '../components/ui';
 
@@ -54,9 +54,10 @@ const NAV: SidebarEntry[] = [
       label: 'מערכת',
       defaultOpen: false,
       items: [
-        { to: '/settings', icon: Settings,      label: 'הגדרות' },
-        { to: '/messages', icon: MessageSquare, label: 'תבניות הודעות' },
-        { to: '/landing',  icon: Globe,         label: 'אתר נחיתה' },
+        { to: '/configuration', icon: KeyRound,       label: 'הגדרות ואבטחה' },
+        { to: '/settings',      icon: Settings,       label: 'הגדרות' },
+        { to: '/messages',      icon: MessageSquare,  label: 'תבניות הודעות' },
+        { to: '/landing',       icon: Globe,          label: 'אתר נחיתה' },
       ],
     },
   },

--- a/dashboard-ui/src/pages/Configuration.tsx
+++ b/dashboard-ui/src/pages/Configuration.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { KeyRound, Shield } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { api } from '../api/client';
+import { PageTransition } from '../components/ui';
+import { Skeleton } from '../components/Skeleton';
+import { SecretCard, type SecretInfo } from '../components/configuration/SecretCard';
+import { SecretEditModal } from '../components/configuration/SecretEditModal';
+import { ConfirmModal } from '../components/ConfirmModal';
+
+interface SecretsResponse {
+  secrets: SecretInfo[];
+}
+
+export function Configuration() {
+  const queryClient = useQueryClient();
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [deletingKey, setDeletingKey] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['secrets'],
+    queryFn: () => api.get<SecretsResponse>('/api/secrets'),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: ({ key, value }: { key: string; value: string }) =>
+      api.put<{ ok: boolean }>(`/api/secrets/${key}`, { value }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['secrets'] });
+      queryClient.invalidateQueries({ queryKey: ['secrets-restart-needed'] });
+      setEditingKey(null);
+      toast.success('הסוד נשמר בהצלחה');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'שמירה נכשלה');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (key: string) => api.delete<{ ok: boolean }>(`/api/secrets/${key}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['secrets'] });
+      queryClient.invalidateQueries({ queryKey: ['secrets-restart-needed'] });
+      setDeletingKey(null);
+      toast.success('הסוד נמחק — חזרה ל-ENV אם קיים');
+    },
+    onError: (err: Error) => {
+      toast.error(err.message || 'מחיקה נכשלה');
+    },
+  });
+
+  return (
+    <PageTransition>
+      <div className="mx-auto max-w-3xl space-y-8">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-blue-500/10">
+            <Shield size={20} className="text-blue-400" />
+          </div>
+          <div>
+            <h1 className="text-xl font-bold text-text-primary">הגדרות ואבטחה</h1>
+            <p className="text-sm text-text-secondary">ניהול מפתחות API וסודות מוצפנים</p>
+          </div>
+        </div>
+
+        {/* Secrets Section */}
+        <section>
+          <div className="mb-3 flex items-center gap-2">
+            <KeyRound size={16} className="text-text-secondary" />
+            <h2 className="text-sm font-semibold text-text-secondary uppercase tracking-wider">
+              סודות מוצפנים
+            </h2>
+          </div>
+
+          {isLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-20 rounded-lg" />
+              ))}
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {data?.secrets.map(secret => (
+                <SecretCard
+                  key={secret.key}
+                  secret={secret}
+                  onEdit={() => setEditingKey(secret.key)}
+                  onDelete={() => setDeletingKey(secret.key)}
+                />
+              ))}
+            </div>
+          )}
+
+          <p className="mt-3 text-xs text-text-secondary/50">
+            כל הסודות מוצפנים ב-AES-256-GCM ומאוחסנים בבסיס הנתונים. ערכים מ-ENV משמשים כ-fallback.
+          </p>
+        </section>
+      </div>
+
+      {/* Edit Modal */}
+      {editingKey && (
+        <SecretEditModal
+          secretKey={editingKey}
+          onSave={value => saveMutation.mutate({ key: editingKey, value })}
+          onCancel={() => setEditingKey(null)}
+          saving={saveMutation.isPending}
+        />
+      )}
+
+      {/* Delete Confirm */}
+      <ConfirmModal
+        open={deletingKey !== null}
+        title="מחיקת סוד"
+        description={`למחוק את ${deletingKey ?? ''} מהמסד? אם קיים ערך ב-.env, הוא ישמש כ-fallback.`}
+        onConfirm={() => { if (deletingKey) deleteMutation.mutate(deletingKey); }}
+        onCancel={() => setDeletingKey(null)}
+        danger
+      />
+    </PageTransition>
+  );
+}
+
+export default Configuration;


### PR DESCRIPTION
## Summary

- New page: `Configuration.tsx` — encrypted secrets management UI
- `SecretCard`: masked values, source badges (DB/ENV/Missing), restart indicators
- `SecretEditModal`: password-type input with visibility toggle
- `RestartBanner`: persistent amber banner in Root.tsx layout (polls every 30s)
- `api/client.ts`: added `put()` method
- Sidebar: "הגדרות ואבטחה" (KeyRound icon) in System group, before Settings
- Lazy-loaded at `/configuration` — 6.76 kB code-split chunk

## Test plan

- [x] Dashboard builds without errors
- [ ] Manual: navigate to /configuration, verify secrets listed
- [ ] Manual: edit a secret, verify masked value updates
- [ ] Manual: delete a secret, verify removed
- [ ] Manual: change restart-required key, verify banner appears

Stacked on: #158 (feat/secrets-api)
Part 4 of 7 in the DB-backed secrets migration.