### PR TITLE
feat: auto-migrate env secrets to encrypted DB on startup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,87 +1,71 @@
-# טוקן הבוט מ-BotFather
-TELEGRAM_BOT_TOKEN=
+# ====================================================================
+# Pikud HaOref Bot — Environment Configuration
+# ====================================================================
+#
+# Starting from v0.5.0, most settings (including secrets) are managed
+# via the Dashboard > Configuration page and stored encrypted in the DB.
+#
+# This file only contains BOOTSTRAP variables needed before the DB is
+# accessible, plus infrastructure settings that must be available at
+# the OS/network level.
+#
+# On first startup, secrets found in this file are auto-migrated to
+# the encrypted DB. After migration, you can remove them from here.
+# ====================================================================
 
-# מזהה הצ'אט/ערוץ לשליחת ההתראות (מספר שלילי לערוץ, חיובי לפרטי)
-TELEGRAM_CHAT_ID=
+# === Bootstrap (required) ================================================
 
-# טוקן Mapbox לגנרציית מפות
-MAPBOX_ACCESS_TOKEN=
+# Admin dashboard password AND encryption seed for secrets at rest.
+# This is the ONLY required env var. Minimum 32 random characters recommended.
+# Changing this invalidates all encrypted secrets (use rewrapDek() to rotate).
+DASHBOARD_SECRET=
 
-# פרוקסי ישראלי — נדרש כשרצים מחוץ לישראל (אופציונלי)
+# === Infrastructure (optional, stays in .env) ============================
+
+# Database file path. Default: ./data/subscriptions.db
+# DB_PATH=./data/subscriptions.db
+
+# Proxy for Pikud HaOref API (required outside Israel — API is geo-restricted)
 # PROXY_URL=http://user:pass@hostname:port/
 
-# קישור הצטרפות לערוץ/קבוצה הראשית (אופציונלי)
-# מוצג בתפריט DM של הבוט תחת "הצטרף לערוץ 📢"
-# TELEGRAM_INVITE_LINK=https://t.me/+abc123
-
-# נושאי פורום בקבוצת הטלגרם (אופציונלי)
-# אם לא מוגדרים, כל ההתראות נשלחות לצ'אט הראשי ללא שינוי.
-# איך למצוא את ה-ID: פתח נושא בקבוצה, העתק את ה-URL — המספר אחרי ?thread= הוא ה-message_thread_id.
-TELEGRAM_TOPIC_ID_SECURITY=3        # 🔴 ביטחוני — טילים, כלי טיס, מחבלים
-TELEGRAM_TOPIC_ID_NATURE=2          # 🌍 אסונות טבע — רעידת אדמה, צונאמי
-TELEGRAM_TOPIC_ID_ENVIRONMENTAL=10   # ☢️ סביבתי/כימי — חומרים מסוכנים, רדיולוגי
-TELEGRAM_TOPIC_ID_DRILLS=11          # 🔵 תרגילים — כל סוגי התרגיל
-# TELEGRAM_TOPIC_ID_WHATSAPP=12     # 📲 העברות WhatsApp — ברירת מחדל לכל listener ללא נושא ספציפי
-# TELEGRAM_TOPIC_ID_GENERAL=5       # 📢 הודעות כלליות — newsFlash, general, unknown
-# ⚠️  אל תשתמש ב-1 — thread ID 1 שמור ב-Telegram ומחזיר שגיאה 400
-
-# --- הגבלת שימוש ב-Mapbox (אופציונלי) ---
-
-# מגבלת בקשות חודשית ל-Mapbox Static API.
-# כאשר המגבלה מושגת, התראות נשלחות כטקסט בלבד (ללא מפה).
-# המגבלה החינמית היא 50,000 בקשות/חודש — מומלץ להגדיר 40,000 כ-buffer.
-# אם לא מוגדר — אין הגבלה.
-# MAPBOX_MONTHLY_LIMIT=40000
-
-# גודל cache תמונות בזיכרון (מספר ה-fingerprints המקסימלי השמורים).
-# ה-cache נאפס עם הפעלה מחדש. ברירת מחדל: 20
-# MAPBOX_IMAGE_CACHE_SIZE=20
-
-# דלג על יצירת מפות להתראות תרגיל (סוגים המסתיימים ב-Drill).
-# כאשר מוגדר true, התרגילים נשלחים כטקסט בלבד — חוסך בקשות Mapbox.
-# ברירת מחדל: false
-# MAPBOX_SKIP_DRILLS=false
-
-# חלון עדכון התראות — כמה שניות להמתין לפני שהתראה חדשה מאותו סוג נשלחת כהודעה נפרדת
-# במהלך החלון, ההודעה הקיימת תיערך (תמונה + כיתוב) במקום שליחת הודעה חדשה.
-# ברירת מחדל: 120 שניות
-# ALERT_UPDATE_WINDOW_SECONDS=120
-
-# פורט שרת ה-health (אופציונלי) — GET /health מחזיר uptime, lastAlertAt, lastPollAt, alertsToday
-# ברירת מחדל: 3000
-# HEALTH_PORT=3000
-
-# --- WhatsApp (אופציונלי) ---
-# הפעל את לקוח whatsapp-web.js — סריקת QR נדרשת בהפעלה הראשונה; session נשמר ב-.wwebjs_auth/
-# מאפשר: האזנה לקבוצות/ערוצים WhatsApp + העברה לטלגרם (Listener), ושידור התראות לקבוצות (Broadcaster)
-# ברירת מחדל: false
-# WHATSAPP_ENABLED=true
-
-# זמן המתנה (בשניות) לאחר העדכון האחרון לפני שליחת תמונת מפה לקבוצות WhatsApp.
-# טקסט נשלח מיידית ונערך בזמן אמת; המפה נשלחת אחרי שהגלים מתייצבים.
-# ניתן לשנות גם מהדשבורד (ללא הפעלה מחדש). ברירת מחדל: 15
-# WHATSAPP_MAP_DEBOUNCE_SECONDS=15
-
-# מזהה קבוצה/ערוץ טלגרם לקבלת הודעות מ-WhatsApp Listener
-# אם לא מוגדר — fallback ל-TELEGRAM_CHAT_ID
-# TELEGRAM_FORWARD_GROUP_ID=-1001234567890
-
-# נתיב ל-Chromium בסביבות Docker (Puppeteer)
+# Custom Chromium binary for whatsapp-web.js (required in Docker)
 # PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
-# --- Telegram Listener (GramJS user-account, אופציונלי) ---
-# הפעל את לקוח GramJS — מאזין לקבוצות/ערוצים שהמפעיל חבר בהם ומעביר הודעות מתאימות לטלגרם
-# נדרש: TELEGRAM_API_ID + TELEGRAM_API_HASH מ-my.telegram.org → API development tools
-# ברירת מחדל: false
-# TELEGRAM_LISTENER_ENABLED=true
+# Cookie security flag override (default: true when NODE_ENV=production)
+# DASHBOARD_SECURE_COOKIE=true
+
+# === Legacy (auto-migrated to DB on first startup) =======================
+# These are kept for backward compatibility. On first run with DASHBOARD_SECRET
+# set, they are encrypted and stored in the DB. After that, manage them via
+# Dashboard > Configuration. You can remove them from this file after migration.
+
+# TELEGRAM_BOT_TOKEN=
+# TELEGRAM_CHAT_ID=
+# MAPBOX_ACCESS_TOKEN=
+# GITHUB_PAT=ghp_xxxxxxxxxxxx
 # TELEGRAM_API_ID=12345678
 # TELEGRAM_API_HASH=abcdef1234567890abcdef1234567890
 
-# --- Admin Dashboard ---
-DASHBOARD_SECRET=your-admin-password-here
-DASHBOARD_PORT=4000
+# === Config (manageable via Dashboard > Settings) ========================
+# All of the following can be set via the dashboard instead of this file.
+# If set here AND in the dashboard, the dashboard value takes priority.
 
-# --- Landing page + GitHub Actions deploy ---
-GA4_MEASUREMENT_ID=G-XXXXXXXXXX
-GITHUB_PAT=ghp_xxxxxxxxxxxx
-GITHUB_REPO=owner/repo-name
+# TELEGRAM_TOPIC_ID_SECURITY=3
+# TELEGRAM_TOPIC_ID_NATURE=2
+# TELEGRAM_TOPIC_ID_ENVIRONMENTAL=10
+# TELEGRAM_TOPIC_ID_DRILLS=11
+# TELEGRAM_TOPIC_ID_WHATSAPP=12
+# TELEGRAM_TOPIC_ID_GENERAL=5
+# TELEGRAM_INVITE_LINK=https://t.me/+abc123
+# MAPBOX_MONTHLY_LIMIT=40000
+# MAPBOX_IMAGE_CACHE_SIZE=20
+# MAPBOX_SKIP_DRILLS=false
+# ALERT_UPDATE_WINDOW_SECONDS=120
+# HEALTH_PORT=3000
+# DASHBOARD_PORT=4000
+# WHATSAPP_ENABLED=true
+# WHATSAPP_MAP_DEBOUNCE_SECONDS=15
+# TELEGRAM_FORWARD_GROUP_ID=-1001234567890
+# TELEGRAM_LISTENER_ENABLED=true
+# GA4_MEASUREMENT_ID=G-XXXXXXXXXX
+# GITHUB_REPO=owner/repo-name

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,9 @@ import { initAlertSerial, getNextAlertSerial } from './config/alertSerial.js';
 import { getDensityLabel } from './config/alertDensity.js';
 import { pruneExpiredContacts } from './db/contactRepository.js';
 import { initCrypto } from './dashboard/crypto.js';
-import { resolveConfig, resolveRequiredConfigs, ConfigMissingError } from './config/configResolver.js';
+import { getSetting, setSetting } from './dashboard/settingsRepository.js';
+import { resolveConfig, resolveRequiredConfigs, ConfigMissingError, SECRET_KEYS, envKeyFor } from './config/configResolver.js';
+import { isCryptoReady } from './dashboard/crypto.js';
 
 // Prevent broken-pipe errors from crashing the bot when a stdout consumer exits.
 process.stdout.on('error', (err: NodeJS.ErrnoException) => {
@@ -49,6 +51,40 @@ process.stdout.on('error', (err: NodeJS.ErrnoException) => {
 // All other config is resolved from DB → env fallback after initDb().
 const dashboardSecretBoot = process.env.DASHBOARD_SECRET;
 
+/**
+ * One-time migration: copies secrets from .env to encrypted DB storage.
+ * Only migrates keys that: (1) exist in env, (2) don't exist in DB, (3) weren't
+ * intentionally deleted via the dashboard (_deleted_secrets tracking).
+ */
+function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
+  try {
+    const deletedRaw = getSetting(db, '_deleted_secrets');
+    const deletedKeys: string[] = deletedRaw ? JSON.parse(deletedRaw) : [];
+    let migrated = 0;
+
+    for (const key of SECRET_KEYS) {
+      const envName = envKeyFor(key);
+      const envValue = process.env[envName];
+      if (!envValue) continue;
+
+      const existing = getSetting(db, key);
+      if (existing !== null) continue;
+
+      if (deletedKeys.includes(key)) continue;
+
+      setSetting(db, key, envValue);
+      migrated++;
+      log('info', 'Migration', `${key} הועבר מ-.env למסד הנתונים (מוצפן)`);
+    }
+
+    if (migrated > 0) {
+      log('success', 'Migration', `${migrated} סודות הועברו מ-.env למסד הנתונים`);
+    }
+  } catch (err) {
+    log('warn', 'Migration', `מיגרציה אוטומטית נכשלה — ממשיך עם ערכי env: ${err}`);
+  }
+}
+
 (async () => {
   let alertsToday = 0;
   let resolvedConfig: Record<string, string>;
@@ -58,6 +94,11 @@ const dashboardSecretBoot = process.env.DASHBOARD_SECRET;
     // Init crypto (envelope encryption for secrets in DB)
     if (dashboardSecretBoot) {
       initCrypto(getDb(), dashboardSecretBoot);
+    }
+
+    // Auto-migrate secrets from env to encrypted DB (first run / upgrade path)
+    if (isCryptoReady()) {
+      autoMigrateEnvSecrets(getDb());
     }
 
     // Resolve all required config from DB → env fallback


### PR DESCRIPTION
## Summary

- `autoMigrateEnvSecrets()` in `index.ts`: on boot, copies SECRET_KEYS from env to encrypted DB
  - Respects `_deleted_secrets` list — keys removed via dashboard are NOT re-imported
  - Non-fatal: wrapped in try/catch, logs warning on failure
  - Idempotent: safe to re-run on every startup
- `.env.example`: restructured for bootstrap-only workflow
  - Bootstrap: `DASHBOARD_SECRET` (only required var)
  - Infrastructure: `DB_PATH`, `PROXY_URL`, `PUPPETEER_EXECUTABLE_PATH`
  - Legacy: commented-out vars with migration note
  - Config: all dashboard-managed vars with note about DB priority

## Test plan

- [x] 1043 bot tests pass
- [ ] Manual E2E: start with full .env → secrets migrate → appear in dashboard as DB source
- [ ] Manual: remove tokens from .env, restart → bot works (reads from DB)
- [ ] Manual: delete a secret via dashboard → restart → NOT re-migrated from env

Stacked on: #160 (feat/secrets-ui)
Part 5 of 7 (final) in the DB-backed secrets migration.