### PR TITLE
feat(db): add safety_status table and safetyStatusRepository

### DIFF
--- a/src/db/safetyStatusRepository.ts
+++ b/src/db/safetyStatusRepository.ts
@@ -1,0 +1,74 @@
+import type Database from 'better-sqlite3';
+
+export interface SafetyStatusRow {
+  chat_id: number;
+  status: 'ok' | 'help' | 'dismissed';
+  updated_at: string;
+  expires_at: string;
+}
+
+type RawRow = {
+  chat_id: number;
+  status: string;
+  updated_at: string;
+  expires_at: string;
+};
+
+function decodeRow(raw: RawRow): SafetyStatusRow {
+  return {
+    chat_id: raw.chat_id,
+    status: raw.status as SafetyStatusRow['status'],
+    updated_at: raw.updated_at,
+    expires_at: raw.expires_at,
+  };
+}
+
+export function upsertSafetyStatus(
+  db: Database.Database,
+  chatId: number,
+  status: 'ok' | 'help' | 'dismissed'
+): void {
+  db.prepare(`
+    INSERT OR REPLACE INTO safety_status (chat_id, status, updated_at, expires_at)
+    VALUES (?, ?, datetime('now'), datetime('now', '+24 hours'))
+  `).run(chatId, status);
+}
+
+export function getSafetyStatus(
+  db: Database.Database,
+  chatId: number
+): SafetyStatusRow | null {
+  const raw = db.prepare(`
+    SELECT * FROM safety_status
+    WHERE chat_id = ? AND expires_at >= datetime('now')
+  `).get(chatId) as RawRow | undefined;
+  return raw ? decodeRow(raw) : null;
+}
+
+export function clearSafetyStatus(db: Database.Database, chatId: number): void {
+  db.prepare('DELETE FROM safety_status WHERE chat_id = ?').run(chatId);
+}
+
+export function pruneExpiredSafetyStatuses(db: Database.Database): number {
+  const result = db
+    .prepare(`DELETE FROM safety_status WHERE expires_at < datetime('now')`)
+    .run();
+  return result.changes;
+}
+
+export function getActiveStatusesForContacts(
+  db: Database.Database,
+  chatIds: number[]
+): SafetyStatusRow[] {
+  if (chatIds.length === 0) return [];
+  const placeholders = chatIds.map(() => '?').join(', ');
+  // Spread chatIds to match the N positional ? placeholders in IN (${placeholders})
+  // better-sqlite3 requires one argument per ?, not a single array argument
+  const rows = db
+    .prepare(`
+      SELECT * FROM safety_status
+      WHERE chat_id IN (${placeholders}) AND expires_at >= datetime('now')
+    `)
+    .all(...chatIds) as RawRow[];
+  return rows.map(decodeRow);
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -180,6 +180,14 @@ export function initSchema(database: Database.Database): void {
       update_time   INTEGER NOT NULL DEFAULT 1,
       FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE CASCADE
     );
+
+    CREATE TABLE IF NOT EXISTS safety_status (
+      chat_id     INTEGER PRIMARY KEY,
+      status      TEXT CHECK (status IN ('ok', 'help', 'dismissed')) NOT NULL,
+      updated_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      expires_at  TEXT NOT NULL,
+      FOREIGN KEY (chat_id) REFERENCES users(chat_id) ON DELETE CASCADE
+    );
   `);
 
   database.exec(
@@ -243,6 +251,7 @@ export function initDb(): void {
     database.prepare(`DELETE FROM alert_history WHERE fired_at < datetime('now', '-7 days')`).run();
     database.prepare('DELETE FROM login_attempts WHERE reset_at < (unixepoch() * 1000)').run();
     database.prepare(`DELETE FROM contacts WHERE status = 'pending' AND created_at < datetime('now', '-7 days')`).run();
+    database.prepare(`DELETE FROM safety_status WHERE expires_at < datetime('now')`).run();
   })();
 
   // Integrity check — warn if users table is empty but alert history exists (possible data loss)


### PR DESCRIPTION
## Summary
- Adds `safety_status` table to `initSchema()` with CHECK constraint on status and FK cascade from `users`
- Implements `safetyStatusRepository.ts` with 5 typed functions (upsert, get, clear, prune, batch-fetch)
- Wires `pruneExpiredSafetyStatuses` SQL into `initDb()` transaction

Closes #169