### PR TITLE
feat(db): add safety_prompts table, safetyPromptRepository, and computeAlertFingerprint

### DIFF
--- a/src/alertHelpers.ts
+++ b/src/alertHelpers.ts
@@ -1,3 +1,11 @@
+import crypto from 'crypto';
+
+/** Returns a stable SHA1 hex fingerprint for an alert, order-independent over cities. */
+export function computeAlertFingerprint(alertType: string, cities: string[]): string {
+  const sorted = [...cities].sort().join(',');
+  return crypto.createHash('sha1').update(`${alertType}:${sorted}`).digest('hex');
+}
+
 /** Exported for testing — checks if an alert type is a drill. */
 export function isDrillAlert(alertType: string): boolean {
   return alertType.endsWith('Drill');

--- a/src/db/safetyPromptRepository.ts
+++ b/src/db/safetyPromptRepository.ts
@@ -1,0 +1,104 @@
+import type Database from 'better-sqlite3';
+
+export interface SafetyPromptRow {
+  id: number;
+  chat_id: number;
+  fingerprint: string;
+  sent_at: string;
+  message_id: number | null;
+  responded: boolean;
+}
+
+type RawRow = {
+  id: number;
+  chat_id: number;
+  fingerprint: string;
+  sent_at: string;
+  message_id: number | null;
+  responded: number;
+  alert_type: string;
+};
+
+function decodeRow(raw: RawRow): SafetyPromptRow {
+  return {
+    id: raw.id,
+    chat_id: raw.chat_id,
+    fingerprint: raw.fingerprint,
+    sent_at: raw.sent_at,
+    message_id: raw.message_id,
+    responded: raw.responded === 1,
+  };
+}
+
+export function insertSafetyPrompt(
+  db: Database.Database,
+  chatId: number,
+  fingerprint: string,
+  messageId?: number,
+  alertType?: string
+): number | null {
+  const result = db
+    .prepare(
+      `INSERT OR IGNORE INTO safety_prompts (chat_id, fingerprint, message_id, alert_type)
+       VALUES (?, ?, ?, ?)`
+    )
+    .run(chatId, fingerprint, messageId ?? null, alertType ?? '');
+  return result.changes === 1 ? Number(result.lastInsertRowid) : null;
+}
+
+export function getSafetyPrompt(
+  db: Database.Database,
+  chatId: number,
+  fingerprint: string
+): SafetyPromptRow | null {
+  const raw = db
+    .prepare('SELECT * FROM safety_prompts WHERE chat_id = ? AND fingerprint = ?')
+    .get(chatId, fingerprint) as RawRow | undefined;
+  return raw ? decodeRow(raw) : null;
+}
+
+export function markPromptResponded(
+  db: Database.Database,
+  chatId: number,
+  fingerprint: string
+): void {
+  db.prepare(
+    'UPDATE safety_prompts SET responded = 1 WHERE chat_id = ? AND fingerprint = ?'
+  ).run(chatId, fingerprint);
+}
+
+export function hasPromptBeenSent(
+  db: Database.Database,
+  chatId: number,
+  fingerprint: string
+): boolean {
+  return getSafetyPrompt(db, chatId, fingerprint) !== null;
+}
+
+export function deleteSafetyPromptsForUser(
+  db: Database.Database,
+  chatId: number
+): void {
+  db.prepare('DELETE FROM safety_prompts WHERE chat_id = ?').run(chatId);
+}
+
+export function deleteUnrespondedPromptsByAlertType(
+  db: Database.Database,
+  alertType: string
+): number {
+  const result = db
+    .prepare('DELETE FROM safety_prompts WHERE responded = 0 AND alert_type = ?')
+    .run(alertType);
+  return result.changes;
+}
+
+export function pruneOldPrompts(
+  db: Database.Database,
+  olderThanHours: number = 24
+): number {
+  const modifier = `-${olderThanHours} hours`;
+  const result = db
+    .prepare(`DELETE FROM safety_prompts WHERE sent_at < datetime('now', ?)`)
+    .run(modifier);
+  return result.changes;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -188,6 +188,18 @@ export function initSchema(database: Database.Database): void {
       expires_at  TEXT NOT NULL,
       FOREIGN KEY (chat_id) REFERENCES users(chat_id) ON DELETE CASCADE
     );
+
+    CREATE TABLE IF NOT EXISTS safety_prompts (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      chat_id      INTEGER NOT NULL,
+      fingerprint  TEXT NOT NULL,
+      sent_at      TEXT NOT NULL DEFAULT (datetime('now')),
+      message_id   INTEGER,
+      responded    INTEGER NOT NULL DEFAULT 0,
+      alert_type   TEXT NOT NULL DEFAULT '',
+      UNIQUE (chat_id, fingerprint),
+      FOREIGN KEY (chat_id) REFERENCES users(chat_id) ON DELETE CASCADE
+    );
   `);
 
   database.exec(
@@ -252,6 +264,7 @@ export function initDb(): void {
     database.prepare('DELETE FROM login_attempts WHERE reset_at < (unixepoch() * 1000)').run();
     database.prepare(`DELETE FROM contacts WHERE status = 'pending' AND created_at < datetime('now', '-7 days')`).run();
     database.prepare(`DELETE FROM safety_status WHERE expires_at < datetime('now')`).run();
+    database.prepare(`DELETE FROM safety_prompts WHERE sent_at < datetime('now', '-24 hours')`).run();
   })();
 
   // Integrity check — warn if users table is empty but alert history exists (possible data loss)


### PR DESCRIPTION
## Summary
- Adds \`safety_prompts\` table to \`initSchema()\` with UNIQUE(chat_id, fingerprint), FK cascade from \`users\`, and an \`alert_type\` column (required for \`deleteUnrespondedPromptsByAlertType\` — fingerprints are one-way SHA1)
- Implements \`safetyPromptRepository.ts\` with 7 typed functions
- Adds \`computeAlertFingerprint(alertType, cities)\` to \`alertHelpers.ts\` using node:crypto SHA1
- Wires \`pruneOldPrompts\` SQL (24h default) into \`initDb()\` transaction

Closes #170