### PR TITLE
feat: add getUsersWithHomeCity to userRepository (Epic B Task 1)

### DIFF
--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -2,6 +2,7 @@ import { describe, it, before, after, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'fs';
 import path from 'path';
+import Database from 'better-sqlite3';
 
 const dataDir = path.join(process.cwd(), 'data');
 if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir);
@@ -17,11 +18,13 @@ import {
   setOnboardingStep,
   setConnectionCode,
   findUserByConnectionCode,
+  getUsersWithHomeCity,
   setFormat,
   setQuietHours,
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
+import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });
@@ -254,5 +257,49 @@ describe('userRepository — v0.4.1 profile fields', () => {
       deleteUser(888);
       assert.equal(getUser(888), undefined);
     });
+  });
+});
+
+describe('getUsersWithHomeCity', () => {
+  let db: InstanceType<typeof Database>;
+
+  before(() => {
+    db = new Database(':memory:');
+    initSchema(db);
+  });
+
+  after(() => { db.close(); });
+
+  beforeEach(() => {
+    db.prepare('DELETE FROM users').run();
+  });
+
+  it('returns users with a non-null, non-empty home_city', () => {
+    db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
+    db.prepare("UPDATE users SET home_city = 'תל אביב - יפו' WHERE chat_id = 1001").run();
+    db.prepare('INSERT INTO users (chat_id) VALUES (1002)').run();         // NULL home_city
+    db.prepare('INSERT INTO users (chat_id) VALUES (1003)').run();
+    db.prepare("UPDATE users SET home_city = '' WHERE chat_id = 1003").run(); // empty string
+
+    const result = getUsersWithHomeCity(db);
+    assert.equal(result.length, 1);
+    assert.equal(result[0].chat_id, 1001);
+    assert.equal(result[0].home_city, 'תל אביב - יפו');
+  });
+
+  it('decodes boolean fields correctly', () => {
+    db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
+    db.prepare(
+      "UPDATE users SET home_city = 'חיפה', quiet_hours_enabled = 1, is_dm_active = 1 WHERE chat_id = 1001"
+    ).run();
+
+    const [user] = getUsersWithHomeCity(db);
+    assert.equal(user.quiet_hours_enabled, true);
+    assert.equal(user.is_dm_active, true);
+  });
+
+  it('returns empty array when no users have home_city set', () => {
+    db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
+    assert.equal(getUsersWithHomeCity(db).length, 0);
   });
 });

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,7 +24,6 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
-import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/db/userRepository.ts
+++ b/src/db/userRepository.ts
@@ -1,3 +1,4 @@
+import type Database from 'better-sqlite3';
 import { getDb } from './schema.js';
 
 export type NotificationFormat = 'short' | 'detailed';
@@ -200,4 +201,16 @@ export function findUserByConnectionCode(code: string): User | undefined {
     .get(code) as RawUserRow | undefined;
   if (!raw) return undefined;
   return mapRowToUser(raw);
+}
+
+/**
+ * Returns all users who have a home city set.
+ * Accepts an explicit `db` for testability (consistent with Epic A repositories).
+ * Used by the safety prompt service to dispatch prompts after real alerts.
+ */
+export function getUsersWithHomeCity(db: Database.Database): User[] {
+  const rows = db
+    .prepare(`SELECT * FROM users WHERE home_city IS NOT NULL AND home_city != ''`)
+    .all() as RawUserRow[];
+  return rows.map(mapRowToUser);
 }


### PR DESCRIPTION
## Summary
- Adds `getUsersWithHomeCity(db: Database.Database): User[]` to `src/db/userRepository.ts`
- Takes explicit `db` param (consistent with Epic A repositories — testable without `DB_PATH` trick)
- Filters users where `home_city IS NOT NULL AND home_city != ''`
- Reuses existing `mapRowToUser` for correct boolean decoding

## Test plan
- [ ] 3 new tests in `getUsersWithHomeCity` describe block pass (non-null city, boolean decode, empty array)
- [ ] All 24 userRepository tests pass with zero regressions