### PR TITLE
feat: add getSafetyPromptById and updateSafetyPromptMessageId (Epic B Task 2)

### DIFF
--- a/src/__tests__/safetyPromptRepository.test.ts
+++ b/src/__tests__/safetyPromptRepository.test.ts
@@ -5,8 +5,10 @@ import { initSchema } from '../db/schema.js';
 import {
   insertSafetyPrompt,
   getSafetyPrompt,
+  getSafetyPromptById,
   markPromptResponded,
   hasPromptBeenSent,
+  updateSafetyPromptMessageId,
   deleteSafetyPromptsForUser,
   deleteUnrespondedPromptsByAlertType,
   pruneOldPrompts,
@@ -204,6 +206,47 @@ describe('safetyPromptRepository — pruneOldPrompts', () => {
     insertSafetyPrompt(db, 1, 'fp1');
     db.prepare(`UPDATE safety_prompts SET sent_at = datetime('now', '-2 hours') WHERE fingerprint = 'fp1'`).run();
     assert.equal(pruneOldPrompts(db, 1), 1, '2h-old row should be pruned with 1h cutoff');
+  });
+});
+
+describe('safetyPromptRepository — getSafetyPromptById', () => {
+  it('returns null for unknown ID', () => {
+    const db = makeDb();
+    assert.equal(getSafetyPromptById(db, 9999), null);
+  });
+
+  it('returns the prompt by primary key ID', () => {
+    const db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
+    const id = insertSafetyPrompt(db, 1001, 'missiles:city1', undefined, 'missiles');
+    assert.ok(id !== null);
+
+    const result = getSafetyPromptById(db, id!);
+    assert.ok(result !== null);
+    assert.equal(result!.fingerprint, 'missiles:city1');
+    assert.equal(result!.chat_id, 1001);
+  });
+
+  it('decodes responded as boolean', () => {
+    const db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
+    const id = insertSafetyPrompt(db, 1001, 'missiles:city1', undefined, 'missiles')!;
+    markPromptResponded(db, 1001, 'missiles:city1');
+
+    const result = getSafetyPromptById(db, id);
+    assert.equal(result!.responded, true);
+  });
+});
+
+describe('safetyPromptRepository — updateSafetyPromptMessageId', () => {
+  it('updates message_id on the row', () => {
+    const db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
+    const id = insertSafetyPrompt(db, 1001, 'missiles:city1', undefined, 'missiles')!;
+    updateSafetyPromptMessageId(db, id, 555);
+
+    const result = getSafetyPromptById(db, id);
+    assert.equal(result!.message_id, 555);
   });
 });
 

--- a/src/db/safetyPromptRepository.ts
+++ b/src/db/safetyPromptRepository.ts
@@ -67,6 +67,33 @@ export function markPromptResponded(
   ).run(chatId, fingerprint);
 }
 
+/**
+ * Looks up a safety prompt by its primary key.
+ * Used by safetyStatusHandler — the prompt ID is embedded in callback_data
+ * (e.g. "safety:ok:42") to avoid ambiguity when a user has multiple prompts.
+ */
+export function getSafetyPromptById(
+  db: Database.Database,
+  id: number
+): SafetyPromptRow | null {
+  const raw = db
+    .prepare('SELECT * FROM safety_prompts WHERE id = ?')
+    .get(id) as RawRow | undefined;
+  return raw ? decodeRow(raw) : null;
+}
+
+/**
+ * Updates the message_id of a prompt row after the Telegram message is sent.
+ * Called by dispatchSafetyPrompts: insert first (to get ID for keyboard), send, then update.
+ */
+export function updateSafetyPromptMessageId(
+  db: Database.Database,
+  promptId: number,
+  messageId: number
+): void {
+  db.prepare('UPDATE safety_prompts SET message_id = ? WHERE id = ?').run(messageId, promptId);
+}
+
 export function hasPromptBeenSent(
   db: Database.Database,
   chatId: number,


### PR DESCRIPTION
## Summary
- Adds `getSafetyPromptById(db, id)` — looks up a prompt by primary key (used by handler when `safety:ok:42` callback arrives)
- Adds `updateSafetyPromptMessageId(db, promptId, messageId)` — updates message_id after Telegram send

**Design fix:** Embedding the prompt integer ID in `callback_data` (`safety:ok:42`) prevents multi-prompt ambiguity — if a user receives 2 prompts from 2 alerts, tapping prompt #1's button after responding to prompt #2 would resolve to the wrong row with a "latest prompt" lookup.

## Test plan
- [ ] 4 new tests: getSafetyPromptById (null for unknown, lookup by PK, boolean decode) + updateSafetyPromptMessageId (updates message_id)
- [ ] All 27 safetyPromptRepository tests pass, zero regressions