### PR TITLE
feat: add safetyPromptService with shouldSendSafetyPrompt (Epic B Task 3)

### DIFF
--- a/src/__tests__/safetyPromptService.test.ts
+++ b/src/__tests__/safetyPromptService.test.ts
@@ -1,0 +1,96 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { shouldSendSafetyPrompt } from '../services/safetyPromptService.js';
+import type { User } from '../db/userRepository.js';
+import type { Alert } from '../types.js';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    chat_id: 1001,
+    format: 'short',
+    quiet_hours_enabled: false,
+    muted_until: null,
+    display_name: 'Test User',
+    home_city: 'תל אביב - יפו',
+    locale: 'he',
+    onboarding_completed: true,
+    connection_code: null,
+    onboarding_step: null,
+    is_dm_active: true,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeAlert(overrides: Partial<Alert> = {}): Alert {
+  return {
+    type: 'missiles',
+    cities: ['תל אביב - יפו'],
+    receivedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+// ─── shouldSendSafetyPrompt ─────────────────────────────────────────────────
+
+describe('shouldSendSafetyPrompt', () => {
+  it('1 — returns true when all conditions are met', () => {
+    assert.equal(shouldSendSafetyPrompt(makeUser(), makeAlert()), true);
+  });
+
+  it('2 — returns false for drill alerts', () => {
+    // isDrillAlert('rocketsDrill') → true
+    assert.equal(
+      shouldSendSafetyPrompt(makeUser(), makeAlert({ type: 'rocketsDrill' })),
+      false
+    );
+  });
+
+  it('3 — returns false when user.home_city is null', () => {
+    assert.equal(
+      shouldSendSafetyPrompt(makeUser({ home_city: null }), makeAlert()),
+      false
+    );
+  });
+
+  it('4 — returns false when home_city is not in alert.cities', () => {
+    assert.equal(
+      shouldSendSafetyPrompt(
+        makeUser({ home_city: 'ירושלים' }),
+        makeAlert({ cities: ['תל אביב - יפו'] })
+      ),
+      false
+    );
+  });
+
+  it('5 — returns false during quiet hours for general-category alerts', () => {
+    // 'newsFlash' is a general-category type — suppressed during quiet hours.
+    // 23:30 Israel time = 21:30 UTC (Israel is UTC+2 in winter).
+    const QUIET_NIGHT = new Date('2024-01-15T21:30:00.000Z'); // 23:30 Israel UTC+2
+    assert.equal(
+      shouldSendSafetyPrompt(
+        makeUser({ quiet_hours_enabled: true, home_city: 'ירושלים' }),
+        makeAlert({ type: 'newsFlash', cities: ['ירושלים'] }),
+        QUIET_NIGHT
+      ),
+      false
+    );
+  });
+
+  it('6 — returns false when user.muted_until is in the future', () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    assert.equal(
+      shouldSendSafetyPrompt(makeUser({ muted_until: future }), makeAlert()),
+      false
+    );
+  });
+
+  it('7 — returns false when user.is_dm_active is false', () => {
+    assert.equal(
+      shouldSendSafetyPrompt(makeUser({ is_dm_active: false }), makeAlert()),
+      false
+    );
+  });
+});

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,6 +24,7 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
+import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,7 +24,6 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
-import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/services/safetyPromptService.ts
+++ b/src/services/safetyPromptService.ts
@@ -1,0 +1,78 @@
+import type Database from 'better-sqlite3';
+import type { Bot } from 'grammy';
+import type { Alert } from '../types.js';
+import type { User } from '../db/userRepository.js';
+import { getUsersWithHomeCity } from '../db/userRepository.js';
+import { computeAlertFingerprint, isDrillAlert } from '../alertHelpers.js';
+import { shouldSkipForQuietHours } from './dmDispatcher.js';
+import {
+  hasPromptBeenSent,
+  insertSafetyPrompt,
+  getSafetyPromptById,
+  updateSafetyPromptMessageId,
+} from '../db/safetyPromptRepository.js';
+import { log } from '../logger.js';
+
+/**
+ * Returns true only when ALL conditions are met:
+ * - Not a drill
+ * - User has a home_city and it is in the alert's cities (exact match)
+ * - Not quiet hours (injectable `now` for deterministic tests)
+ * - Not snoozed (muted_until is past or null)
+ * - DM is active for the user
+ *
+ * Note: shouldSkipForQuietHours only suppresses 'drills'/'general' categories.
+ * Security alerts (missiles, aircraft, etc.) always pass quiet-hours check.
+ */
+export function shouldSendSafetyPrompt(
+  user: User,
+  alert: Alert,
+  now: Date = new Date()
+): boolean {
+  if (isDrillAlert(alert.type)) return false;
+  if (!user.home_city) return false;
+  if (!alert.cities.includes(user.home_city)) return false;
+  if (shouldSkipForQuietHours(alert.type, user.quiet_hours_enabled, now)) return false;
+  if (user.muted_until !== null && new Date(user.muted_until) > now) return false;
+  if (!user.is_dm_active) return false;
+  return true;
+}
+
+export async function dispatchSafetyPrompts(
+  db: Database.Database,
+  alert: Alert,
+  bot: Bot
+): Promise<void> {
+  const fingerprint = computeAlertFingerprint(alert.type, alert.cities);
+  const users = getUsersWithHomeCity(db);
+
+  await Promise.allSettled(
+    users.map(async (user) => {
+      if (!shouldSendSafetyPrompt(user, alert)) return;
+
+      // Insert first (messageId=null) to get the row ID for the inline keyboard.
+      // INSERT OR IGNORE returns null if the row already exists (dedup).
+      const promptId = insertSafetyPrompt(db, user.chat_id, fingerprint, undefined, alert.type);
+      if (promptId === null) return; // already sent — dedup
+
+      const text = `🚨 <b>התראה ב${user.home_city}</b>\n\nהאם אתה בסדר?`;
+      const reply_markup = {
+        inline_keyboard: [[
+          { text: '✅ בסדר',        callback_data: `safety:ok:${promptId}` },
+          { text: '⚠️ זקוק לעזרה', callback_data: `safety:help:${promptId}` },
+          { text: '🔇 התעלם',       callback_data: `safety:dismiss:${promptId}` },
+        ]],
+      };
+
+      try {
+        const response = await bot.api.sendMessage(user.chat_id, text, {
+          parse_mode: 'HTML',
+          reply_markup,
+        });
+        updateSafetyPromptMessageId(db, promptId, response.message_id);
+      } catch (err) {
+        log('error', 'SafetyPrompt', `כישלון בשליחה ל-${user.chat_id}: ${err}`);
+      }
+    })
+  );
+}


### PR DESCRIPTION
## Summary
- Creates `src/services/safetyPromptService.ts` with `shouldSendSafetyPrompt(user, alert, now?)`
- Also creates `dispatchSafetyPrompts(db, alert, bot)` in same file (used in Task 4 tests)
- 7 guard checks: drill, no home_city, city mismatch, quiet hours, snooze, inactive DM
- Injectable `now: Date` param for deterministic quiet-hours tests (matches codebase pattern)

## Test plan
- [ ] 7 shouldSendSafetyPrompt tests pass (all conditions verified individually)