### PR TITLE
feat: add dispatchSafetyPrompts tests (Epic B Task 4)

### DIFF
--- a/src/__tests__/safetyPromptService.test.ts
+++ b/src/__tests__/safetyPromptService.test.ts
@@ -1,8 +1,13 @@
-import { describe, it } from 'node:test';
+import { describe, it, mock } from 'node:test';
 import assert from 'node:assert/strict';
-import { shouldSendSafetyPrompt } from '../services/safetyPromptService.js';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import { shouldSendSafetyPrompt, dispatchSafetyPrompts } from '../services/safetyPromptService.js';
+import { hasPromptBeenSent } from '../db/safetyPromptRepository.js';
+import { computeAlertFingerprint } from '../alertHelpers.js';
 import type { User } from '../db/userRepository.js';
 import type { Alert } from '../types.js';
+import type { Bot } from 'grammy';
 
 // ─── helpers ────────────────────────────────────────────────────────────────
 
@@ -91,6 +96,111 @@ describe('shouldSendSafetyPrompt', () => {
     assert.equal(
       shouldSendSafetyPrompt(makeUser({ is_dm_active: false }), makeAlert()),
       false
+    );
+  });
+});
+
+// ─── dispatchSafetyPrompts ─────────────────────────────────────────────────
+
+describe('dispatchSafetyPrompts', () => {
+  function makeDb(): Database.Database {
+    const db = new Database(':memory:');
+    initSchema(db);
+    return db;
+  }
+
+  function makeMockBot(messageId = 999) {
+    return {
+      api: {
+        sendMessage: mock.fn(async () => ({ message_id: messageId })),
+      },
+    };
+  }
+
+  function insertUserWithHomeCity(db: Database.Database, chatId: number, city: string): void {
+    db.prepare('INSERT INTO users (chat_id) VALUES (?)').run(chatId);
+    db.prepare('UPDATE users SET home_city = ?, is_dm_active = 1 WHERE chat_id = ?').run(city, chatId);
+  }
+
+  it('8 — sends prompt to a matching user', async () => {
+    const db = makeDb();
+    const bot = makeMockBot();
+    insertUserWithHomeCity(db, 1001, 'תל אביב - יפו');
+
+    const alert: Alert = { type: 'missiles', cities: ['תל אביב - יפו'], receivedAt: Date.now() };
+    await dispatchSafetyPrompts(db, alert, bot as unknown as Bot);
+
+    assert.equal(
+      (bot.api.sendMessage as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      1
+    );
+  });
+
+  it('9 — dedup: second call with same fingerprint sends nothing', async () => {
+    const db = makeDb();
+    const bot = makeMockBot();
+    insertUserWithHomeCity(db, 1001, 'תל אביב - יפו');
+
+    const alert: Alert = { type: 'missiles', cities: ['תל אביב - יפו'], receivedAt: Date.now() };
+    await dispatchSafetyPrompts(db, alert, bot as unknown as Bot);
+    await dispatchSafetyPrompts(db, alert, bot as unknown as Bot); // same fingerprint
+
+    assert.equal(
+      (bot.api.sendMessage as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      1
+    );
+  });
+
+  it('10 — uses bot.api.sendMessage with HTML parse_mode and inline keyboard', async () => {
+    const db = makeDb();
+    const bot = makeMockBot();
+    insertUserWithHomeCity(db, 1001, 'תל אביב - יפו');
+
+    const alert: Alert = { type: 'missiles', cities: ['תל אביב - יפו'], receivedAt: Date.now() };
+    await dispatchSafetyPrompts(db, alert, bot as unknown as Bot);
+
+    const calls = (bot.api.sendMessage as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(calls.length, 1);
+    const [chatIdArg, , optsArg] = calls[0].arguments as [number, string, Record<string, unknown>];
+    assert.equal(chatIdArg, 1001);
+    assert.equal(optsArg['parse_mode'], 'HTML');
+    assert.ok(optsArg['reply_markup'], 'reply_markup (inline keyboard) must be passed');
+  });
+
+  it('11 — stores the prompt in DB after successful send', async () => {
+    const db = makeDb();
+    const bot = makeMockBot(42);
+    insertUserWithHomeCity(db, 1001, 'תל אביב - יפו');
+
+    const alert: Alert = { type: 'missiles', cities: ['תל אביב - יפו'], receivedAt: Date.now() };
+    await dispatchSafetyPrompts(db, alert, bot as unknown as Bot);
+
+    const fingerprint = computeAlertFingerprint('missiles', ['תל אביב - יפו']);
+    assert.equal(hasPromptBeenSent(db, 1001, fingerprint), true);
+  });
+
+  it('12 — partial failure: one user throws, others still processed', async () => {
+    const db = makeDb();
+    let callCount = 0;
+    const bot = {
+      api: {
+        sendMessage: mock.fn(async () => {
+          callCount++;
+          if (callCount === 1) throw new Error('Telegram API down');
+          return { message_id: 999 };
+        }),
+      },
+    };
+    insertUserWithHomeCity(db, 1001, 'תל אביב - יפו');
+    insertUserWithHomeCity(db, 1002, 'תל אביב - יפו');
+
+    const alert: Alert = { type: 'missiles', cities: ['תל אביב - יפו'], receivedAt: Date.now() };
+
+    await assert.doesNotReject(() => dispatchSafetyPrompts(db, alert, bot as unknown as Bot));
+
+    assert.equal(
+      (bot.api.sendMessage as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      2
     );
   });
 });

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,6 +24,7 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
+import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,7 +24,6 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
-import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });


### PR DESCRIPTION
## Summary
- Adds 5 `dispatchSafetyPrompts` tests (tests 8–12) to `safetyPromptService.test.ts`
- Total: 12 spec tests as required by issue #175

Key behaviors verified:
- Sends to matching user
- Deduplicates on same fingerprint (INSERT OR IGNORE)
- Uses `bot.api.sendMessage` with `parse_mode: 'HTML'` + inline keyboard
- Stores prompt in DB after successful send
- Partial failure: one user error doesn't abort others (`Promise.allSettled`)

## Test plan
- [ ] All 12 safetyPromptService tests pass