### PR TITLE
feat: wire dispatchSafetyPrompts into alertHandler deps (Epic B Task 5)

### DIFF
--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,6 +24,7 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
+import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,7 +24,6 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
-import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/alertHandler.ts
+++ b/src/alertHandler.ts
@@ -28,6 +28,7 @@ export interface AlertHandlerDeps {
   getTopicId: (alertType: string) => number | undefined;
   insertAlertHistory: (alert: Alert) => void;
   broadcastToWhatsApp?: (alert: Alert, imageBuffer?: Buffer | null) => Promise<void>;
+  dispatchSafetyPrompts?: (alert: Alert) => Promise<void>;
   getNextSerial?: () => number;
   getDensityHint?: () => 'חריג' | 'רגיל' | null;
 }
@@ -45,6 +46,7 @@ export async function handleNewAlert(alert: Alert, deps: AlertHandlerDeps): Prom
     getTopicId,
     insertAlertHistory,
     broadcastToWhatsApp,
+    dispatchSafetyPrompts,
     getNextSerial,
     getDensityHint,
   } = deps;
@@ -183,6 +185,8 @@ export async function handleNewAlert(alert: Alert, deps: AlertHandlerDeps): Prom
       log('warn', 'AlertHandler', `DM נשלח למרות כישלון ערוץ — type=${alert.type}, ${dmCities.length} ערים`);
     }
     notifySubscribers({ ...alert, cities: dmCities });
+    dispatchSafetyPrompts?.({ ...alert, cities: dmCities })
+      .catch((err) => log('error', 'AlertHandler', `[safetyPrompts] ${err}`));
   }
 
   if (broadcastToWhatsApp) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { setupBotHandlers } from './bot/botSetup';
 import { notifySubscribers, shouldSkipForQuietHours } from './services/dmDispatcher';
 import { dmQueue } from './services/dmQueue.js';
 import { shouldSkipMap } from './alertHelpers';
+import { dispatchSafetyPrompts } from './services/safetyPromptService';
 import { handleNewAlert } from './alertHandler';
 import { insertAlert as insertAlertHistory, countAlertsToday, getDailyCountsForMonth } from './db/alertHistoryRepository.js';
 import { startHealthServer } from './healthServer.js';
@@ -319,6 +320,7 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
       getTopicId,
       insertAlertHistory,
       broadcastToWhatsApp,
+      dispatchSafetyPrompts: (alert) => dispatchSafetyPrompts(getDb(), alert, bot),
       getNextSerial: getNextAlertSerial,
       getDensityHint: () => getDensityLabel(countAlertsToday(), getDailyCountsForMonth()),
     });


### PR DESCRIPTION
## Summary
- Adds optional `dispatchSafetyPrompts?: (alert: Alert) => Promise<void>` to `AlertHandlerDeps`
- Called after `notifySubscribers` with `.catch()` so a safety-prompt failure never blocks DM dispatch
- Wired in `src/index.ts`: `dispatchSafetyPrompts: (alert) => dispatchSafetyPrompts(getDb(), alert, bot)`

## Test plan
- [ ] All 28 existing alertHandler tests pass (optional dep — tests that omit it are unaffected)
- [ ] `tsc --noEmit` clean