### PR TITLE
feat: add safetyStatusHandler with prompt-ID callback_data (Epic B Task 6)

### DIFF
--- a/src/__tests__/safetyStatusHandler.test.ts
+++ b/src/__tests__/safetyStatusHandler.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, before, after, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import { insertSafetyPrompt } from '../db/safetyPromptRepository.js';
+import { getSafetyStatus } from '../db/safetyStatusRepository.js';
+import {
+  setSafetyStatusHandlerDeps,
+  registerSafetyStatusHandler,
+} from '../bot/safetyStatusHandler.js';
+import type { Bot } from 'grammy';
+
+// ─── helpers ────────────────────────────────────────────────────────────────
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  initSchema(db);
+  return db;
+}
+
+/** Captures the grammY callback handler registered via bot.callbackQuery */
+function captureHandler(db: Database.Database): (ctx: unknown) => Promise<void> {
+  setSafetyStatusHandlerDeps(db);
+  const bot = { callbackQuery: mock.fn() } as unknown as Bot;
+  registerSafetyStatusHandler(bot);
+  const calls = (bot.callbackQuery as unknown as ReturnType<typeof mock.fn>).mock.calls;
+  return calls[0].arguments[1] as (ctx: unknown) => Promise<void>;
+}
+
+function makeCtx(data: string, chatId = 1001) {
+  return {
+    callbackQuery: { data },
+    from: { id: chatId },
+    answerCallbackQuery: mock.fn(async (_text?: string) => {}),
+    editMessageText: mock.fn(async () => {}),
+  };
+}
+
+// ─── tests ──────────────────────────────────────────────────────────────────
+
+describe('safetyStatusHandler', () => {
+  let db: Database.Database;
+  let promptId: number;
+
+  before(() => {
+    db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
+    const id = insertSafetyPrompt(db, 1001, 'missiles:city1', 123, 'missiles');
+    promptId = id!;
+  });
+
+  after(() => { db.close(); });
+
+  beforeEach(() => {
+    db.prepare('DELETE FROM safety_status').run();
+    db.prepare('UPDATE safety_prompts SET responded = 0 WHERE chat_id = 1001').run();
+  });
+
+  it('safety:ok stores status "ok" and edits the message', async () => {
+    const handler = captureHandler(db);
+    const ctx = makeCtx(`safety:ok:${promptId}`);
+    await handler(ctx);
+
+    const status = getSafetyStatus(db, 1001);
+    assert.ok(status !== null);
+    assert.equal(status!.status, 'ok');
+    assert.equal(
+      (ctx.editMessageText as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      1
+    );
+  });
+
+  it('safety:help stores status "help"', async () => {
+    const handler = captureHandler(db);
+    const ctx = makeCtx(`safety:help:${promptId}`);
+    await handler(ctx);
+
+    assert.equal(getSafetyStatus(db, 1001)!.status, 'help');
+  });
+
+  it('safety:dismiss stores status "dismissed" (not "dismiss")', async () => {
+    const handler = captureHandler(db);
+    const ctx = makeCtx(`safety:dismiss:${promptId}`);
+    await handler(ctx);
+
+    assert.equal(getSafetyStatus(db, 1001)!.status, 'dismissed');
+  });
+
+  it('answerCallbackQuery is always called (finally block)', async () => {
+    const handler = captureHandler(db);
+    const ctx = makeCtx(`safety:ok:${promptId}`);
+    await handler(ctx);
+
+    const calls = (ctx.answerCallbackQuery as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.ok(calls.length >= 1, 'answerCallbackQuery must be called at least once');
+  });
+
+  it('stale tap: editMessageText NOT called when already responded', async () => {
+    db.prepare(
+      'UPDATE safety_prompts SET responded = 1 WHERE chat_id = 1001'
+    ).run();
+
+    const handler = captureHandler(db);
+    const ctx = makeCtx(`safety:ok:${promptId}`);
+    await handler(ctx);
+
+    assert.equal(
+      (ctx.editMessageText as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+      0,
+      'Must not edit message on stale tap'
+    );
+
+    const answerCalls = (ctx.answerCallbackQuery as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.ok(String(answerCalls[0].arguments[0]).includes('כבר עדכנת'));
+  });
+});

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,6 +24,7 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
+import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,7 +24,6 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
-import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/bot/safetyStatusHandler.ts
+++ b/src/bot/safetyStatusHandler.ts
@@ -1,0 +1,88 @@
+import type { Bot } from 'grammy';
+import type Database from 'better-sqlite3';
+import { upsertSafetyStatus } from '../db/safetyStatusRepository.js';
+import { markPromptResponded, getSafetyPromptById } from '../db/safetyPromptRepository.js';
+import { createUserCooldown } from './userCooldown.js';
+import { log } from '../logger.js';
+
+// Set before registering (called from index.ts after initDb).
+let _db: Database.Database | null = null;
+
+export function setSafetyStatusHandlerDeps(db: Database.Database): void {
+  _db = db;
+}
+
+type SafetyStatus = 'ok' | 'help' | 'dismissed';
+
+const CONFIRMATION: Record<SafetyStatus, string> = {
+  ok:        '✅ <b>מצוין! שמחים שאתה בסדר.</b>\nאנשי הקשר המורשים עודכנו.',
+  help:      '⚠️ <b>אנחנו כאן.</b>\nאנשי הקשר המורשים עודכנו ויוכלו לסייע.',
+  dismissed: '🔇 <b>ההתראה נסגרה.</b>',
+};
+
+function parseCallback(data: string): { status: SafetyStatus; promptId: number } | null {
+  const m = data.match(/^safety:(ok|help|dismiss):(\d+)$/);
+  if (!m) return null;
+  const key = m[1];
+  const promptId = Number(m[2]);
+  const status: SafetyStatus = key === 'ok' ? 'ok' : key === 'help' ? 'help' : 'dismissed';
+  return { status, promptId };
+}
+
+export function registerSafetyStatusHandler(bot: Bot): void {
+  const cooldown = createUserCooldown(1000);
+
+  bot.callbackQuery(/^safety:(ok|help|dismiss):\d+$/, async (ctx) => {
+    const chatId = ctx.from?.id;
+    if (!chatId || !_db) {
+      await ctx.answerCallbackQuery();
+      return;
+    }
+
+    if (cooldown.isOnCooldown(chatId)) {
+      await ctx.answerCallbackQuery('אנא המתן רגע');
+      return;
+    }
+    cooldown.setCooldown(chatId);
+
+    let answered = false;
+    try {
+      const parsed = parseCallback(ctx.callbackQuery.data);
+      if (!parsed) return;
+
+      const { status, promptId } = parsed;
+      const prompt = getSafetyPromptById(_db, promptId);
+
+      if (prompt?.responded === true) {
+        await ctx.answerCallbackQuery('כבר עדכנת את הסטטוס שלך');
+        answered = true;
+        return;
+      }
+
+      upsertSafetyStatus(_db, chatId, status);
+
+      if (prompt) {
+        markPromptResponded(_db, prompt.chat_id, prompt.fingerprint);
+      }
+
+      await ctx.editMessageText(CONFIRMATION[status], { parse_mode: 'HTML' });
+      await notifyContactsOfStatusChange(_db, bot, chatId, status);
+    } catch (err) {
+      log('error', 'SafetyStatus', `כישלון בטיפול בסטטוס בטיחות: ${err}`);
+    } finally {
+      if (!answered) {
+        await ctx.answerCallbackQuery().catch(() => {});
+      }
+    }
+  });
+}
+
+/** Stub — Epic C will implement contact notifications. */
+export async function notifyContactsOfStatusChange(
+  _db: Database.Database,
+  _bot: Bot,
+  _chatId: number,
+  _status: string
+): Promise<void> {
+  // TODO: implement in Epic C
+}


### PR DESCRIPTION
## Summary
- Creates `src/bot/safetyStatusHandler.ts`:
  - `setSafetyStatusHandlerDeps(db)` — module-level setter, called from index.ts before bot setup
  - `registerSafetyStatusHandler(bot)` — registers `/^safety:(ok|help|dismiss):\d+$/` callback
  - `parseCallback` maps `safety:dismiss:42` → `{ status: 'dismissed', promptId: 42 }` (no enum mismatch)
  - Cooldown scoped inside `registerSafetyStatusHandler` (not module-level) so tests get a fresh instance
  - Stale tap guard: if `prompt.responded === true`, answers with toast, skips edit
  - `answered` flag in `finally` ensures `answerCallbackQuery` called exactly once
  - `notifyContactsOfStatusChange` stubbed with `// TODO: implement in Epic C`

## Test plan
- [ ] 5 handler tests pass: ok/help/dismiss, answerCallbackQuery always called, stale tap guard
- [ ] `tsc --noEmit` clean