### PR TITLE
feat: /status command — textUtils helpers + command handler + setMyCommands (#176)

### DIFF
--- a/src/__tests__/botSetup.test.ts
+++ b/src/__tests__/botSetup.test.ts
@@ -69,7 +69,7 @@ describe('setupBotHandlers', () => {
     assert.equal(typeof bot._getCatchHandler(), 'function', 'catch handler should be a function');
   });
 
-  it('calls bot.api.setMyCommands with all 8 commands', async () => {
+  it('calls bot.api.setMyCommands with all 14 commands', async () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 

--- a/src/__tests__/botSetup.test.ts
+++ b/src/__tests__/botSetup.test.ts
@@ -36,8 +36,8 @@ describe('setupBotHandlers', () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
-    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend'];
-    assert.equal(bot._registeredCommands.length, expected.length, 'should register exactly 13 commands');
+    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend', 'status'];
+    assert.equal(bot._registeredCommands.length, expected.length, 'should register exactly 14 commands');
     for (const cmd of expected) {
       assert.ok(
         bot._registeredCommands.includes(cmd),
@@ -75,10 +75,10 @@ describe('setupBotHandlers', () => {
 
     const cmds = bot._getSetMyCommandsArg() as Array<{ command: string; description: string }>;
     assert.ok(Array.isArray(cmds), 'setMyCommands should receive an array');
-    assert.equal(cmds.length, 13, 'setMyCommands should receive exactly 13 commands');
+    assert.equal(cmds.length, 14, 'setMyCommands should receive exactly 14 commands');
 
     const commandNames = cmds.map((c) => c.command);
-    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend']) {
+    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend', 'status']) {
       assert.ok(commandNames.includes(name), `setMyCommands should include /${name}`);
     }
     // Each command must have a non-empty Hebrew description

--- a/src/__tests__/safetyStatusHandler.test.ts
+++ b/src/__tests__/safetyStatusHandler.test.ts
@@ -18,13 +18,15 @@ function makeDb(): Database.Database {
   return db;
 }
 
-/** Captures the grammY callback handler registered via bot.callbackQuery */
+/** Captures the grammY callback handler registered via bot.callbackQuery for the regex pattern */
 function captureHandler(db: Database.Database): (ctx: unknown) => Promise<void> {
   setSafetyStatusHandlerDeps(db);
-  const bot = { callbackQuery: mock.fn() } as unknown as Bot;
+  const bot = { command: mock.fn(), callbackQuery: mock.fn() } as unknown as Bot;
   registerSafetyStatusHandler(bot);
   const calls = (bot.callbackQuery as unknown as ReturnType<typeof mock.fn>).mock.calls;
-  return calls[0].arguments[1] as (ctx: unknown) => Promise<void>;
+  // Find the call registered with the regex pattern (not a plain string)
+  const regexCall = calls.find((c: { arguments: unknown[] }) => c.arguments[0] instanceof RegExp);
+  return regexCall!.arguments[1] as (ctx: unknown) => Promise<void>;
 }
 
 function makeCtx(data: string, chatId = 1001) {

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,6 +24,7 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
+import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -24,7 +24,6 @@ import {
   setMutedUntil,
   deleteUser,
 } from '../db/userRepository';
-import { initSchema } from '../db/schema';
 
 describe('userRepository — v0.4.1 profile fields', () => {
   before(() => { initDb(); });

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -31,6 +31,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerPrivacyHandler(bot);
   registerTodayHandler(bot);
   registerLegendHandler(bot);
+  registerSafetyStatusHandler(bot);
 
   bot.catch((err) => {
     log('error', 'Bot', `Unhandled error: ${String(err)}`);

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -51,5 +51,6 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
     { command: 'privacy',  description: 'הגדרות פרטיות' },
     { command: 'today',    description: 'סיכום יומי' },
     { command: 'legend',   description: 'מקרא אזורי ההתראה' },
+    { command: 'status',   description: 'סטטוס ביטחוני שלך ואנשי קשר' },
   ]);
 }

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -31,7 +31,6 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerPrivacyHandler(bot);
   registerTodayHandler(bot);
   registerLegendHandler(bot);
-  registerSafetyStatusHandler(bot);
 
   bot.catch((err) => {
     log('error', 'Bot', `Unhandled error: ${String(err)}`);

--- a/src/bot/safetyStatusHandler.ts
+++ b/src/bot/safetyStatusHandler.ts
@@ -3,8 +3,6 @@ import type Database from 'better-sqlite3';
 import { upsertSafetyStatus, getSafetyStatus } from '../db/safetyStatusRepository.js';
 import type { SafetyStatusRow } from '../db/safetyStatusRepository.js';
 import { markPromptResponded, getSafetyPromptById } from '../db/safetyPromptRepository.js';
-import { listContacts, getPermissions } from '../db/contactRepository.js';
-import { getUser } from '../db/userRepository.js';
 import { createUserCooldown } from './userCooldown.js';
 import { formatRelativeTime, formatTimeUntil } from '../textUtils.js';
 import { log } from '../logger.js';
@@ -147,12 +145,12 @@ export function registerSafetyStatusHandler(bot: Bot): void {
   });
 }
 
-/** Stub — Epic C will implement contact notifications. */
+/** Stub — full implementation in Issue #177. */
 export async function notifyContactsOfStatusChange(
   _db: Database.Database,
   _bot: Bot,
   _chatId: number,
   _status: string
 ): Promise<void> {
-  // TODO: implement in Epic C
+  // TODO: implement in Issue #177
 }

--- a/src/bot/safetyStatusHandler.ts
+++ b/src/bot/safetyStatusHandler.ts
@@ -1,8 +1,12 @@
 import type { Bot } from 'grammy';
 import type Database from 'better-sqlite3';
-import { upsertSafetyStatus } from '../db/safetyStatusRepository.js';
+import { upsertSafetyStatus, getSafetyStatus } from '../db/safetyStatusRepository.js';
+import type { SafetyStatusRow } from '../db/safetyStatusRepository.js';
 import { markPromptResponded, getSafetyPromptById } from '../db/safetyPromptRepository.js';
+import { listContacts, getPermissions } from '../db/contactRepository.js';
+import { getUser } from '../db/userRepository.js';
 import { createUserCooldown } from './userCooldown.js';
+import { formatRelativeTime, formatTimeUntil } from '../textUtils.js';
 import { log } from '../logger.js';
 
 // Set before registering (called from index.ts after initDb).
@@ -20,6 +24,46 @@ const CONFIRMATION: Record<SafetyStatus, string> = {
   dismissed: '🔇 <b>ההתראה נסגרה.</b>',
 };
 
+function buildOwnStatusText(status: SafetyStatusRow): string {
+  const emoji = status.status === 'ok' ? '✅' :
+                status.status === 'help' ? '⚠️' : '🔇';
+  const label = status.status === 'ok' ? 'בסדר' :
+                status.status === 'help' ? 'זקוק לעזרה' : 'התעלם';
+  return (
+    `🛡️ <b>הסטטוס שלך</b>\n\n` +
+    `${emoji} ${label}  ·  ${formatRelativeTime(status.updated_at)}` +
+    `  ·  פג תוקף ${formatTimeUntil(status.expires_at)}`
+  );
+}
+
+function statusEmoji(s: string): string {
+  return s === 'ok' ? '✅' : s === 'help' ? '⚠️' : '🔇';
+}
+
+function statusLabel(s: string): string {
+  return s === 'ok' ? 'בסדר' : s === 'help' ? 'זקוק לעזרה' : 'התעלם';
+}
+
+function backKeyboard() {
+  return {
+    inline_keyboard: [[{ text: '◀️ חזרה', callback_data: 'safety:back' }]],
+  };
+}
+
+function mainStatusKeyboard() {
+  return {
+    inline_keyboard: [
+      [
+        { text: '✅ בסדר',          callback_data: 'safety:ok:0'    },
+        { text: '⚠️ זקוק לעזרה',   callback_data: 'safety:help:0'  },
+      ],
+      [
+        { text: '👥 סטטוס אנשי קשר', callback_data: 'safety:contacts' },
+      ],
+    ],
+  };
+}
+
 function parseCallback(data: string): { status: SafetyStatus; promptId: number } | null {
   const m = data.match(/^safety:(ok|help|dismiss):(\d+)$/);
   if (!m) return null;
@@ -31,6 +75,32 @@ function parseCallback(data: string): { status: SafetyStatus; promptId: number }
 
 export function registerSafetyStatusHandler(bot: Bot): void {
   const cooldown = createUserCooldown(1000);
+
+  bot.command('status', async (ctx) => {
+    const chatId = ctx.from?.id;
+    if (!chatId || !_db) return;
+
+    const status = getSafetyStatus(_db, chatId);
+    const text = status
+      ? buildOwnStatusText(status)
+      : '🛡️ <b>הסטטוס שלך</b>\n\nאין סטטוס פעיל כרגע.';
+
+    await ctx.reply(text, { parse_mode: 'HTML', reply_markup: mainStatusKeyboard() });
+  });
+
+  bot.callbackQuery('safety:contacts', async (ctx) => {
+    const chatId = ctx.from?.id;
+    if (!chatId || !_db) { await ctx.answerCallbackQuery(); return; }
+    // Full implementation in Issue #177
+    await ctx.answerCallbackQuery();
+  });
+
+  bot.callbackQuery('safety:back', async (ctx) => {
+    const chatId = ctx.from?.id;
+    if (!chatId || !_db) { await ctx.answerCallbackQuery(); return; }
+    // Full implementation in Issue #177
+    await ctx.answerCallbackQuery();
+  });
 
   bot.callbackQuery(/^safety:(ok|help|dismiss):\d+$/, async (ctx) => {
     const chatId = ctx.from?.id;

--- a/src/textUtils.ts
+++ b/src/textUtils.ts
@@ -4,3 +4,31 @@ export { escapeHtml } from './telegramBot.js';
 export function stripHtml(text: string): string {
   return text.replace(/<[^>]*>/g, '');
 }
+
+/**
+ * Returns a Hebrew relative-time string for a past SQLite datetime string.
+ * SQLite stores UTC without 'Z' — we normalise before parsing.
+ */
+export function formatRelativeTime(isoDateStr: string): string {
+  const normalized = isoDateStr.endsWith('Z') ? isoDateStr : `${isoDateStr}Z`;
+  const diffMs = Date.now() - new Date(normalized).getTime();
+  const s = Math.floor(diffMs / 1000);
+  if (s < 60)    return 'עכשיו';
+  if (s < 3600)  return `לפני ${Math.floor(s / 60)} דקות`;
+  if (s < 86400) return `לפני ${Math.floor(s / 3600)} שעות`;
+  if (s < 172800) return 'לפני יום';
+  return `לפני ${Math.floor(s / 86400)} ימים`;
+}
+
+/**
+ * Returns a Hebrew string for how long until a future SQLite datetime string.
+ */
+export function formatTimeUntil(isoDateStr: string): string {
+  const normalized = isoDateStr.endsWith('Z') ? isoDateStr : `${isoDateStr}Z`;
+  const diffMs = new Date(normalized).getTime() - Date.now();
+  const s = Math.ceil(diffMs / 1000);
+  if (s <= 0)   return 'פג תוקף';
+  if (s < 60)   return 'עוד פחות מדקה';
+  if (s < 3600) return `עוד ${Math.ceil(s / 60)} דקות`;
+  return `עוד ${Math.ceil(s / 3600)} שעות`;
+}


### PR DESCRIPTION
## Summary
- Adds `formatRelativeTime` and `formatTimeUntil` Hebrew time helpers to `textUtils.ts` (UTC-safe SQLite datetime parsing)
- Adds `/status` command to `safetyStatusHandler.ts` — shows own status with emoji, relative time, and TTL; uses `safety:ok:0`/`safety:help:0` to reuse existing prompt-callback regex
- Adds `safety:contacts` and `safety:back` stubs (implemented in #177)
- Registers `/status` in `setMyCommands` with Hebrew description

## Test plan
- [ ] `npx tsx --test src/__tests__/textUtils.test.ts` — all pass
- [ ] `npx tsx --test src/__tests__/safetyStatusHandler.test.ts` — 5 existing tests pass
- [ ] `npx tsx --test src/__tests__/botSetup.test.ts` — 4 tests pass (now expects 14 commands)