### PR TITLE
test: critical-gap test coverage (PR 1 of audit plan)

### DIFF
--- a/src/__tests__/connectHandler.toctou.test.ts
+++ b/src/__tests__/connectHandler.toctou.test.ts
@@ -1,0 +1,282 @@
+// TOCTOU regression tests for the cx:confirm callback in connectHandler.
+//
+// Context: The /connect flow has two steps:
+//   1. `/connect {code}` — validates the target exists, not a duplicate, etc,
+//      then stores state in the in-memory `pendingPermissions` Map and shows
+//      the permission toggle screen.
+//   2. `cx:confirm` — callback that reads the pendingPermissions state and
+//      creates the real `contacts` row via `createContactWithPermissions`.
+//
+// Between those two steps the DB state can change — e.g. user A accepts
+// user B's incoming request from another device while still staring at the
+// permission screen on the first device, or a second rapid-fire `cx:confirm`
+// lands after the first one already created the contact row. The handler
+// MUST re-run the duplicate-pair and pending-count checks at confirm time
+// and reject gracefully, not crash or corrupt the contact_permissions table.
+//
+// The existing connectHandler.test.ts has 32 tests, none of which simulate
+// state changes between pendingPermissions being populated and cx:confirm
+// firing. These tests lock that guard down.
+//
+// Simulation strategy: we directly seed `pendingPermissions.set(...)` with a
+// valid state, then synchronously mutate the DB to inject the race, then
+// fire the `cx:confirm` callback. No concurrency primitives needed — the
+// handler is fully synchronous once it starts.
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initDb, getDb } from '../db/schema.js';
+import { upsertUser } from '../db/userRepository.js';
+import {
+  createContact,
+  createContactWithPermissions,
+  getContactByPair,
+  getPermissions,
+} from '../db/contactRepository.js';
+import {
+  registerConnectHandler,
+  pendingPermissions,
+  failureCounts,
+  lookupCooldownMap,
+} from '../bot/connectHandler.js';
+import type { Bot, Context } from 'grammy';
+
+// Constants mirroring connectHandler internals. MAX_PENDING_REQUESTS is
+// currently 10 — if this changes, fail loudly.
+const MAX_PENDING_REQUESTS_ASSUMED = 10;
+
+const REQUESTER = 5_001;
+const TARGET = 5_002;
+
+before(() => {
+  process.env['DB_PATH'] = ':memory:';
+  initDb();
+});
+
+beforeEach(() => {
+  // Clean DB + module state between tests. Same pattern as the primary
+  // connectHandler.test.ts suite.
+  const db = getDb();
+  db.prepare('DELETE FROM contact_permissions').run();
+  db.prepare('DELETE FROM contacts').run();
+  db.prepare('DELETE FROM users').run();
+  db.prepare('DELETE FROM settings').run();
+  failureCounts.clear();
+  lookupCooldownMap.clear();
+  pendingPermissions.clear();
+});
+
+function buildMockBot() {
+  const callbacks: Array<[string | RegExp, (ctx: Context) => Promise<void>]> = [];
+  return {
+    command: () => {},
+    callbackQuery: (pat: string | RegExp, handler: (ctx: Context) => Promise<void>) => {
+      callbacks.push([pat, handler]);
+    },
+    on: () => {},
+    catch: () => {},
+    _fireCb: async (data: string, ctx: Context) => {
+      for (const [pat, handler] of callbacks) {
+        if (typeof pat === 'string' && pat === data) { await handler(ctx); return; }
+        if (pat instanceof RegExp && pat.test(data)) {
+          (ctx as unknown as { match: RegExpMatchArray | null }).match = data.match(pat);
+          await handler(ctx);
+          return;
+        }
+      }
+    },
+  };
+}
+
+interface TestCtx extends Context {
+  _editCalls: [string, unknown?][];
+  _replyCalls: [string, unknown?][];
+  _answerCalls: unknown[];
+  _sendCalls: unknown[];
+}
+
+function makeCtx(chatId: number): TestCtx {
+  const editCalls: [string, unknown?][] = [];
+  const replyCalls: [string, unknown?][] = [];
+  const answerCalls: unknown[] = [];
+  const sendCalls: unknown[] = [];
+  const ctx = {
+    chat: { id: chatId, type: 'private' },
+    message: { text: '' },
+    match: null,
+    reply: async (text: string, opts?: unknown) => { replyCalls.push([text, opts]); },
+    editMessageText: async (text: string, opts?: unknown) => { editCalls.push([text, opts]); },
+    answerCallbackQuery: async (...args: unknown[]) => { answerCalls.push(args); },
+    api: {
+      sendMessage: async (...args: unknown[]) => { sendCalls.push(args); },
+    },
+    _editCalls: editCalls,
+    _replyCalls: replyCalls,
+    _answerCalls: answerCalls,
+    _sendCalls: sendCalls,
+  };
+  return ctx as unknown as TestCtx;
+}
+
+function primePendingState(chatId: number, targetId: number): void {
+  pendingPermissions.set(chatId, {
+    targetId,
+    targetName: 'Test Target',
+    safety_status: true,
+    home_city: false,
+    update_time: true,
+    expiresAt: Date.now() + 10 * 60_000,
+  });
+}
+
+describe('connectHandler — cx:confirm TOCTOU guards', () => {
+  it('rejects when a forward contact was inserted between invite and confirm', async () => {
+    upsertUser(REQUESTER);
+    upsertUser(TARGET);
+
+    const bot = buildMockBot();
+    registerConnectHandler(bot as unknown as Bot);
+
+    // Requester is mid-flow: /connect already ran and seeded pendingPermissions.
+    primePendingState(REQUESTER, TARGET);
+
+    // RACE: a forward contact appears before cx:confirm fires.
+    // (In production this would be caused by a second device issuing /connect
+    // + cx:confirm ahead of the first one, or an accepted reverse request.)
+    createContact(REQUESTER, TARGET);
+
+    const ctx = makeCtx(REQUESTER);
+    await bot._fireCb('cx:confirm', ctx);
+
+    // Verdict: editMessageText with the "already connected" copy, NO new
+    // contact row, NO permissions row leaked.
+    assert.equal(ctx._editCalls.length, 1, 'must edit the bot message once with rejection copy');
+    assert.match(ctx._editCalls[0]![0], /כבר מחוברים/, 'copy must explain already-connected');
+    assert.equal(
+      pendingPermissions.get(REQUESTER),
+      undefined,
+      'pendingPermissions must be cleared on rejection'
+    );
+
+    // Only ONE contact row must exist (the one we injected) — the handler
+    // must not insert a duplicate.
+    const allRows = getDb().prepare('SELECT COUNT(*) as c FROM contacts').get() as { c: number };
+    assert.equal(allRows.c, 1, 'handler must NOT insert a duplicate contact row');
+
+    // The pre-existing contact was created via createContact() which does
+    // NOT write a permissions row — so the permissions table must still be
+    // empty. If the cx:confirm handler leaked a row, this would be 1.
+    const perms = getDb().prepare('SELECT COUNT(*) as c FROM contact_permissions').get() as { c: number };
+    assert.equal(perms.c, 0, 'no orphan permissions row leaked on rejected confirm');
+  });
+
+  it('rejects when a REVERSE contact was inserted between invite and confirm', async () => {
+    upsertUser(REQUESTER);
+    upsertUser(TARGET);
+
+    const bot = buildMockBot();
+    registerConnectHandler(bot as unknown as Bot);
+
+    primePendingState(REQUESTER, TARGET);
+    // RACE: reverse direction gets a row (target → requester). Either
+    // direction counts as "already connected".
+    createContact(TARGET, REQUESTER);
+
+    const ctx = makeCtx(REQUESTER);
+    await bot._fireCb('cx:confirm', ctx);
+
+    assert.equal(ctx._editCalls.length, 1);
+    assert.match(ctx._editCalls[0]![0], /כבר מחוברים/);
+    assert.equal(pendingPermissions.get(REQUESTER), undefined);
+    // One row (the reverse we inserted). Handler must not add a second.
+    const allRows = getDb().prepare('SELECT COUNT(*) as c FROM contacts').get() as { c: number };
+    assert.equal(allRows.c, 1);
+  });
+
+  it('rejects when target reached MAX_PENDING_REQUESTS between invite and confirm', async () => {
+    upsertUser(REQUESTER);
+    upsertUser(TARGET);
+    const bot = buildMockBot();
+    registerConnectHandler(bot as unknown as Bot);
+
+    primePendingState(REQUESTER, TARGET);
+
+    // RACE: fill the target's inbox with MAX_PENDING_REQUESTS pending invites
+    // from other random requesters — now the target is over cap by the time
+    // cx:confirm fires.
+    for (let i = 0; i < MAX_PENDING_REQUESTS_ASSUMED; i++) {
+      const otherRequester = 6_000 + i;
+      upsertUser(otherRequester);
+      createContact(otherRequester, TARGET);
+    }
+
+    const ctx = makeCtx(REQUESTER);
+    await bot._fireCb('cx:confirm', ctx);
+
+    assert.equal(ctx._editCalls.length, 1);
+    assert.match(
+      ctx._editCalls[0]![0],
+      /יותר מדי בקשות ממתינות/,
+      'copy must explain pending cap reached'
+    );
+    assert.equal(pendingPermissions.get(REQUESTER), undefined);
+
+    // Requester must NOT have a contact row — the handler must not create one.
+    assert.equal(getContactByPair(REQUESTER, TARGET), undefined);
+  });
+
+  it('leaves no orphan permission rows when cx:confirm rejects after a race', async () => {
+    upsertUser(REQUESTER);
+    upsertUser(TARGET);
+    const bot = buildMockBot();
+    registerConnectHandler(bot as unknown as Bot);
+
+    // Seed a "prior success" state: a different contact exists with its own
+    // permissions row, so we can assert that the rejected attempt doesn't
+    // leak an orphan or corrupt the existing row. Both user rows must exist
+    // first — contacts table has FK constraints on user_id + contact_id.
+    upsertUser(9_999);
+    upsertUser(9_998);
+    const prior = createContactWithPermissions(9_999, 9_998, {
+      safety_status: true, home_city: true, update_time: true,
+    });
+    assert.ok(prior.id);
+
+    primePendingState(REQUESTER, TARGET);
+    createContact(REQUESTER, TARGET); // race
+
+    const ctx = makeCtx(REQUESTER);
+    await bot._fireCb('cx:confirm', ctx);
+
+    // Only the pre-existing permissions row should remain. If the handler
+    // wrongly inserted another, perms.c would be 2.
+    const perms = getDb().prepare('SELECT COUNT(*) as c FROM contact_permissions').get() as { c: number };
+    assert.equal(perms.c, 1, 'only the pre-existing permissions row remains after rejected confirm');
+
+    // And the pre-existing row's values are unchanged.
+    const priorPerms = getPermissions(prior.id);
+    assert.deepEqual(priorPerms, { safety_status: true, home_city: true, update_time: true });
+  });
+
+  it('normal happy path still works — no race, confirm creates contact + permissions', async () => {
+    // Sanity check: the TOCTOU guard must not break the non-racing case.
+    upsertUser(REQUESTER);
+    upsertUser(TARGET);
+    const bot = buildMockBot();
+    registerConnectHandler(bot as unknown as Bot);
+
+    primePendingState(REQUESTER, TARGET);
+
+    const ctx = makeCtx(REQUESTER);
+    await bot._fireCb('cx:confirm', ctx);
+
+    const contact = getContactByPair(REQUESTER, TARGET);
+    assert.ok(contact, 'contact must be created in the non-racing case');
+    assert.equal(pendingPermissions.get(REQUESTER), undefined, 'state cleared on success too');
+
+    const perms = getPermissions(contact!.id);
+    assert.ok(perms, 'permissions row must be created on happy path');
+    assert.equal(perms!.safety_status, true);
+    assert.equal(perms!.home_city, false);
+    assert.equal(perms!.update_time, true);
+  });
+});

--- a/src/__tests__/dashboard/routes/messages.testfire.test.ts
+++ b/src/__tests__/dashboard/routes/messages.testfire.test.ts
@@ -1,0 +1,212 @@
+// Regression tests for POST /api/messages/test-fire platform handling.
+//
+// Context: src/dashboard/routes/messages.ts:317-427 accepts a `platform`
+// field in the body ('telegram' | 'whatsapp' | 'both', default 'telegram')
+// and routes the test send accordingly. The existing messages.test.ts
+// covers template CRUD + history + rollback but NOT this endpoint. These
+// tests lock down the branching so a future refactor cannot break the
+// graceful-degradation behavior when WhatsApp is unavailable.
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import express from 'express';
+import request from 'supertest';
+import { initSchema, getDb } from '../../../db/schema.js';
+import {
+  createMessagesRouter,
+  testFireLimiter,
+  type WhatsAppDeps,
+} from '../../../dashboard/routes/messages.js';
+import { loadTemplateCache } from '../../../config/templateCache.js';
+
+interface TelegramSendCall {
+  chatId: string | number;
+  text: string;
+  opts?: unknown;
+}
+
+let db: Database.Database;
+const telegramSends: TelegramSendCall[] = [];
+
+const mockBot = {
+  api: {
+    sendMessage: async (chatId: string | number, text: string, opts?: unknown) => {
+      telegramSends.push({ chatId, text, opts });
+      return { message_id: telegramSends.length };
+    },
+  },
+};
+
+// Per-test state so tests can toggle WhatsApp status/client independently.
+let waStatus: 'ready' | 'disconnected' = 'ready';
+let waClientPresent = true;
+let waEnabledGroups: string[] = ['group-1@g.us'];
+const waSendCalls: string[] = [];
+
+const mockWhatsAppDeps: WhatsAppDeps = {
+  getStatus: () => waStatus,
+  getClient: () =>
+    waClientPresent
+      ? {
+          getChatById: async (id: string) => ({
+            sendMessage: async (text: string) => {
+              waSendCalls.push(`${id}:${text}`);
+              return {};
+            },
+          }),
+        }
+      : null,
+  getEnabledGroups: () => [...waEnabledGroups],
+};
+
+// Two apps — one WITH injected WhatsApp deps, one WITHOUT. That mirrors
+// the real wiring in index.ts (WhatsApp is optional).
+let appWithWa: express.Express;
+let appWithoutWa: express.Express;
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+
+  // templateCache uses the global singleton — make sure it exists + is loaded.
+  initSchema(getDb());
+  loadTemplateCache(getDb());
+
+  // Seed TELEGRAM_CHAT_ID so the telegram branch can resolve a target.
+  db.prepare('INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)')
+    .run('telegram_chat_id', '-100123456789');
+
+  appWithWa = express();
+  appWithWa.use(express.json());
+  appWithWa.use(
+    '/api/messages',
+    createMessagesRouter(
+      db,
+      mockBot as unknown as Parameters<typeof createMessagesRouter>[1],
+      mockWhatsAppDeps
+    )
+  );
+
+  appWithoutWa = express();
+  appWithoutWa.use(express.json());
+  appWithoutWa.use(
+    '/api/messages',
+    createMessagesRouter(
+      db,
+      mockBot as unknown as Parameters<typeof createMessagesRouter>[1]
+      // no whatsappDeps
+    )
+  );
+});
+
+after(() => db.close());
+
+beforeEach(() => {
+  telegramSends.length = 0;
+  waSendCalls.length = 0;
+  waStatus = 'ready';
+  waClientPresent = true;
+  waEnabledGroups = ['group-1@g.us'];
+  testFireLimiter.clearStore();
+});
+
+describe('POST /api/messages/test-fire — platform handling', () => {
+  it('platform=telegram fires only the Telegram send', async () => {
+    const res = await request(appWithWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'missiles', cities: ['אבו גוש'], platform: 'telegram' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(typeof res.body.telegram, 'number', 'must return telegram message_id');
+    assert.equal(telegramSends.length, 1, 'exactly one Telegram send');
+    assert.equal(waSendCalls.length, 0, 'must NOT touch WhatsApp when platform=telegram');
+  });
+
+  it('platform=whatsapp + no injected WhatsApp deps returns 400', async () => {
+    // This is the app constructed without whatsappDeps — the route has
+    // no choice but to reject with 400 "WhatsApp לא זמין".
+    const res = await request(appWithoutWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'missiles', cities: ['אבו גוש'], platform: 'whatsapp' });
+
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('WhatsApp'));
+    assert.equal(telegramSends.length, 0, 'must NOT send to Telegram on this branch');
+    assert.equal(waSendCalls.length, 0);
+  });
+
+  it('platform=whatsapp + WhatsApp not ready returns 500 with error', async () => {
+    waStatus = 'disconnected';
+    const res = await request(appWithWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'missiles', cities: ['אבו גוש'], platform: 'whatsapp' });
+
+    // Route pushes to errors, then: if errors.length > 0 && results empty → 500.
+    assert.equal(res.status, 500);
+    assert.ok(res.body.error.includes('WhatsApp'), 'error must mention WhatsApp');
+    assert.equal(waSendCalls.length, 0);
+  });
+
+  it('platform=whatsapp + ready client sends to enabled groups', async () => {
+    const res = await request(appWithWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'missiles', cities: ['אבו גוש'], platform: 'whatsapp' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(res.body.whatsappGroups, 1);
+    assert.equal(waSendCalls.length, 1, 'sends to the one enabled group');
+    assert.equal(telegramSends.length, 0, 'must NOT send to Telegram');
+  });
+
+  it('platform=both fires both sends', async () => {
+    const res = await request(appWithWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'missiles', cities: ['אבו גוש'], platform: 'both' });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(typeof res.body.telegram, 'number');
+    assert.equal(res.body.whatsappGroups, 1);
+    assert.equal(telegramSends.length, 1);
+    assert.equal(waSendCalls.length, 1);
+  });
+
+  it('platform=both + WhatsApp failure does not fail the whole request — returns 200 with warnings', async () => {
+    waClientPresent = false; // client === null
+    const res = await request(appWithWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'missiles', cities: ['אבו גוש'], platform: 'both' });
+
+    // Telegram succeeded → results.telegram set → final check passes,
+    // errors array surfaced as warnings.
+    assert.equal(res.status, 200, 'partial failure must NOT cause 500 when at least one path succeeded');
+    assert.equal(res.body.ok, true);
+    assert.equal(typeof res.body.telegram, 'number');
+    assert.ok(
+      Array.isArray(res.body.warnings) && res.body.warnings.length > 0,
+      'warnings array must be populated when WA fails'
+    );
+  });
+
+  it('unknown platform value returns 400', async () => {
+    const res = await request(appWithWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'missiles', cities: ['אבו גוש'], platform: 'email' });
+
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('platform'));
+    assert.equal(telegramSends.length, 0);
+    assert.equal(waSendCalls.length, 0);
+  });
+
+  it('unknown alertType returns 400 regardless of platform', async () => {
+    const res = await request(appWithWa)
+      .post('/api/messages/test-fire')
+      .send({ alertType: 'notARealType', cities: [], platform: 'telegram' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error);
+    assert.equal(telegramSends.length, 0);
+  });
+});

--- a/src/__tests__/dashboard/routes/messages.testfire.test.ts
+++ b/src/__tests__/dashboard/routes/messages.testfire.test.ts
@@ -69,8 +69,9 @@ before(() => {
   initSchema(db);
 
   // templateCache uses the global singleton — make sure it exists + is loaded.
+  // loadTemplateCache() reads the getDb() singleton internally, no argument.
   initSchema(getDb());
-  loadTemplateCache(getDb());
+  loadTemplateCache();
 
   // Seed TELEGRAM_CHAT_ID so the telegram branch can resolve a target.
   db.prepare('INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)')

--- a/src/__tests__/dashboard/routes/operations.broadcast.test.ts
+++ b/src/__tests__/dashboard/routes/operations.broadcast.test.ts
@@ -1,0 +1,168 @@
+// Regression tests for POST /api/operations/broadcast partial-failure path.
+//
+// Context: the broadcast endpoint fires-and-forgets a background loop that
+// iterates over every target chatId and calls bot.api.sendMessage with a
+// per-chat try/catch. A Telegram 403 ("bot was blocked") or 429
+// ("Too Many Requests") for one user must NOT abort the loop for the
+// remaining users. The existing operations.test.ts happy-path tests did
+// not exercise this — these tests lock it down.
+//
+// The HTTP response is `res.json({ queued: N })` immediately, so we have
+// to flush microtasks / await the background loop before asserting the
+// mock bot call log.
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import express from 'express';
+import request from 'supertest';
+import { initSchema } from '../../../db/schema.js';
+import { createOperationsRouter, broadcastLimiter } from '../../../dashboard/routes/operations.js';
+
+interface CallLogEntry {
+  chatId: number;
+  text: string;
+  error?: Error;
+}
+
+let db: Database.Database;
+let app: express.Express;
+const sendLog: CallLogEntry[] = [];
+
+// Mock bot: records every sendMessage call and throws for chatIds that
+// the current test has opted into failing. Reset inside `beforeEach`.
+const failingChatIds = new Map<number, Error>();
+
+const mockBot = {
+  api: {
+    sendMessage: async (chatId: number, text: string) => {
+      const err = failingChatIds.get(chatId);
+      sendLog.push({ chatId, text, error: err });
+      if (err) throw err;
+      return {};
+    },
+  },
+};
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+  app = express();
+  app.use(express.json());
+  app.use('/api/operations', createOperationsRouter(db, mockBot as unknown as Parameters<typeof createOperationsRouter>[1]));
+});
+
+after(() => db.close());
+
+beforeEach(() => {
+  sendLog.length = 0;
+  failingChatIds.clear();
+  broadcastLimiter.clearStore();
+});
+
+// Wait just long enough for the background send loop to drain. Each
+// iteration awaits a resolved/rejected promise, so a single macrotask
+// tick is enough for a short chatId list.
+async function flushBackground(): Promise<void> {
+  await new Promise<void>(resolve => setTimeout(resolve, 25));
+}
+
+describe('POST /api/operations/broadcast — partial-failure path', () => {
+  it('continues sending after a 403 bot-blocked error on one chatId', async () => {
+    failingChatIds.set(222, Object.assign(new Error('Forbidden: bot was blocked by the user'), { error_code: 403 }));
+
+    const res = await request(app)
+      .post('/api/operations/broadcast')
+      .send({ text: 'שלום', chatIds: [111, 222, 333] });
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.queued, 3, 'responds immediately with all queued');
+
+    await flushBackground();
+
+    const attempted = sendLog.map(e => e.chatId).sort((a, b) => a - b);
+    assert.deepEqual(
+      attempted,
+      [111, 222, 333],
+      'every chatId must be attempted even though 222 throws'
+    );
+    const failed = sendLog.filter(e => e.error).map(e => e.chatId);
+    assert.deepEqual(failed, [222], 'only 222 should be recorded as failed');
+  });
+
+  it('continues sending after a 429 rate-limit error', async () => {
+    failingChatIds.set(
+      111,
+      Object.assign(new Error('Too Many Requests: retry after 5'), {
+        error_code: 429,
+        parameters: { retry_after: 5 },
+      })
+    );
+
+    const res = await request(app)
+      .post('/api/operations/broadcast')
+      .send({ text: 'שלום', chatIds: [111, 222] });
+
+    assert.equal(res.status, 200);
+    await flushBackground();
+
+    const attempted = sendLog.map(e => e.chatId);
+    assert.deepEqual(attempted, [111, 222], 'sequential order preserved, both attempted');
+    assert.equal(sendLog[0]!.error?.message.includes('Too Many Requests'), true);
+    assert.equal(sendLog[1]!.error, undefined, '222 must succeed');
+  });
+
+  it('a single failure in a long list does not abort the remaining sends', async () => {
+    // 10 recipients, 5th throws — all 10 must still be attempted.
+    const chatIds = [1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010];
+    failingChatIds.set(1005, new Error('Forbidden: user is deactivated'));
+
+    const res = await request(app)
+      .post('/api/operations/broadcast')
+      .send({ text: 'שלום', chatIds });
+
+    assert.equal(res.body.queued, 10);
+    await flushBackground();
+
+    const attempted = sendLog.map(e => e.chatId);
+    assert.deepEqual(
+      attempted,
+      chatIds,
+      'all 10 chatIds must be attempted in order despite the mid-loop failure'
+    );
+  });
+
+  it('returns 200 even when every recipient fails — loop survives total failure', async () => {
+    // All 3 chatIds throw — the endpoint must still return { queued: 3 }
+    // and the background loop must attempt every one of them.
+    //
+    // NB: we deliberately don't assert on sendLog.length BEFORE flushing.
+    // With a synchronous mock, the background loop drains on the same
+    // macrotask as supertest's response callback, so there's no reliable
+    // "before" observation point. The important behavior — every chatId
+    // gets attempted — is asserted post-flush.
+    const chatIds = [2001, 2002, 2003];
+    for (const id of chatIds) {
+      failingChatIds.set(id, new Error('simulated failure'));
+    }
+
+    const res = await request(app)
+      .post('/api/operations/broadcast')
+      .send({ text: 'שלום', chatIds });
+
+    assert.equal(res.status, 200, 'endpoint returns 200 even when all sends will fail');
+    assert.equal(res.body.queued, 3);
+
+    await flushBackground();
+    assert.equal(sendLog.length, 3, 'all 3 sends must have been attempted');
+    assert.equal(
+      sendLog.every(e => e.error),
+      true,
+      'every send must have recorded its rejection'
+    );
+    assert.deepEqual(
+      sendLog.map(e => e.chatId),
+      chatIds,
+      'loop visits every chatId in order'
+    );
+  });
+});

--- a/src/__tests__/dashboard/routes/stats.overview.test.ts
+++ b/src/__tests__/dashboard/routes/stats.overview.test.ts
@@ -1,0 +1,110 @@
+// Regression tests for GET /api/stats/overview mapboxRow undefined branch.
+//
+// Context: src/dashboard/routes/stats.ts:66-68 queries mapbox_usage for the
+// current month via `strftime('%Y-%m', 'now')`. If no row exists for the
+// current month (first request of a new month), `mapboxRow` is `undefined`
+// and the `?? 0` guard on line 84 is what prevents a TypeError on
+// `.request_count`. The existing stats.test.ts happy-path tests do not
+// seed this table so they hit the guard by accident without any assertion
+// on the behavior. These tests lock it down explicitly.
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import express from 'express';
+import request from 'supertest';
+import { initSchema } from '../../../db/schema.js';
+import { createStatsRouter } from '../../../dashboard/routes/stats.js';
+import { clearStatsCache } from '../../../dashboard/statsCache.js';
+
+let db: Database.Database;
+let app: express.Express;
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+  app = express();
+  app.use(express.json());
+  app.use('/api/stats', createStatsRouter(db));
+});
+
+after(() => db.close());
+
+beforeEach(() => {
+  // Each test owns its own mapbox_usage state + a clean cache so the
+  // 60s TTL on /overview doesn't leak stale data between tests.
+  db.prepare('DELETE FROM mapbox_usage').run();
+  clearStatsCache();
+});
+
+// Matches SQLite's `strftime('%Y-%m', 'now')` which uses UTC. Tests assume
+// wall-clock doesn't cross a month boundary mid-run (safe for unit tests).
+function currentMonth(): string {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+function previousMonth(): string {
+  const d = new Date();
+  d.setUTCDate(1);
+  d.setUTCMonth(d.getUTCMonth() - 1);
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  return `${y}-${m}`;
+}
+
+describe('GET /api/stats/overview — mapboxRow undefined branch', () => {
+  it('returns mapboxMonth: 0 when no mapbox_usage row exists at all', async () => {
+    // Empty table — the strftime query must return no row.
+    const rowCount = db.prepare('SELECT COUNT(*) as c FROM mapbox_usage').get() as { c: number };
+    assert.equal(rowCount.c, 0, 'precondition: mapbox_usage must be empty');
+
+    const res = await request(app).get('/api/stats/overview');
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.body.mapboxMonth,
+      0,
+      'mapboxMonth must default to 0 when the table is empty (no TypeError on undefined.request_count)'
+    );
+  });
+
+  it('returns mapboxMonth: 0 when only a previous-month row exists', async () => {
+    // Rollover case: last month has data but current month does not yet.
+    db.prepare('INSERT INTO mapbox_usage (month, request_count) VALUES (?, ?)')
+      .run(previousMonth(), 1234);
+
+    const res = await request(app).get('/api/stats/overview');
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.body.mapboxMonth,
+      0,
+      'previous-month row must NOT leak into current-month count'
+    );
+  });
+
+  it('returns the actual count when a current-month row exists', async () => {
+    db.prepare('INSERT INTO mapbox_usage (month, request_count) VALUES (?, ?)')
+      .run(currentMonth(), 42);
+
+    const res = await request(app).get('/api/stats/overview');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.mapboxMonth, 42, 'must read request_count from the current-month row');
+  });
+
+  it('does not crash when the whole DB is empty (no users, no alerts, no mapbox_usage)', async () => {
+    // Cross-branch safety net: every COUNT query returns 0 AND the mapbox
+    // guard fires. This is the "day 1" empty-install scenario.
+    db.prepare('DELETE FROM users').run();
+    db.prepare('DELETE FROM subscriptions').run();
+    db.prepare('DELETE FROM alert_history').run();
+    db.prepare('DELETE FROM mapbox_usage').run();
+
+    const res = await request(app).get('/api/stats/overview');
+    assert.equal(res.status, 200, 'must not 500 on an empty DB');
+    assert.equal(res.body.totalSubscribers, 0);
+    assert.equal(res.body.totalSubscriptions, 0);
+    assert.equal(res.body.alertsToday, 0);
+    assert.equal(res.body.mapboxMonth, 0);
+  });
+});

--- a/src/__tests__/db/schema.test.ts
+++ b/src/__tests__/db/schema.test.ts
@@ -1,0 +1,182 @@
+// Tests for src/db/schema.ts — addColumnIfMissing helper and initSchema
+// idempotency.
+//
+// Context: schema.ts is currently untested. `addColumnIfMissing` catches
+// only errors whose message includes 'duplicate column name' and rethrows
+// everything else — a typo in a future ALTER statement would only surface
+// at runtime. `initSchema` is also the migration runner: running it twice
+// on the same DB (e.g. on startup after a schema change) must be a no-op.
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema, addColumnIfMissing } from '../../db/schema.js';
+
+// Every test uses its own fresh in-memory DB. Having a shared top-level db
+// would make the "fresh-schema" assertions meaningless across tests.
+let db: Database.Database;
+
+before(() => {
+  db = new Database(':memory:');
+});
+
+after(() => db.close());
+
+beforeEach(() => {
+  // Drop everything touched by tests and re-open a clean DB. better-sqlite3
+  // `:memory:` databases are per-connection, so closing and reopening is the
+  // simplest way to guarantee a pristine state.
+  try { db.close(); } catch { /* already closed */ }
+  db = new Database(':memory:');
+});
+
+describe('addColumnIfMissing', () => {
+  it('adds a new column to an existing table', () => {
+    db.exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`);
+    addColumnIfMissing(db, 'ALTER TABLE t ADD COLUMN name TEXT');
+
+    const cols = db.prepare("PRAGMA table_info('t')").all() as { name: string }[];
+    const colNames = cols.map(c => c.name).sort();
+    assert.deepEqual(colNames, ['id', 'name']);
+  });
+
+  it('is idempotent — a second call with the same ALTER does not throw', () => {
+    db.exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`);
+    addColumnIfMissing(db, 'ALTER TABLE t ADD COLUMN name TEXT');
+    // Second call — SQLite raises "duplicate column name: name" which the
+    // helper must swallow.
+    assert.doesNotThrow(() => addColumnIfMissing(db, 'ALTER TABLE t ADD COLUMN name TEXT'));
+
+    // Column count must be unchanged.
+    const cols = db.prepare("PRAGMA table_info('t')").all() as { name: string }[];
+    assert.equal(cols.length, 2, 'must not add a duplicate column');
+  });
+
+  it('rethrows errors that are NOT duplicate-column-name', () => {
+    // Table does not exist — the prepare step throws "no such table".
+    // That error message does NOT include "duplicate column name" so the
+    // helper must propagate it.
+    assert.throws(
+      () => addColumnIfMissing(db, 'ALTER TABLE does_not_exist ADD COLUMN x TEXT'),
+      /no such table/,
+      'must rethrow "no such table" errors instead of silently swallowing'
+    );
+  });
+
+  it('rethrows syntax errors in the ALTER statement (any non-duplicate error)', () => {
+    db.exec(`CREATE TABLE t (id INTEGER PRIMARY KEY)`);
+    // Malformed SQL — not a duplicate-column-name error, must throw.
+    // We deliberately do NOT match the error message: better-sqlite3 wraps
+    // the error with a SQLITE_ERROR code and the wording varies by version.
+    // The important invariant is that *some* error escapes the helper.
+    let caught: unknown = undefined;
+    try {
+      addColumnIfMissing(db, 'ALTER TABLE t ADD COLUMN x NOT_A_VALID_TYPE_EXPRESSION DEFAULT');
+    } catch (e) {
+      caught = e;
+    }
+    assert.ok(caught, 'must rethrow SQL errors that are NOT duplicate-column-name');
+    assert.ok(
+      !(caught instanceof Error && caught.message.includes('duplicate column name')),
+      'the caught error must not be a duplicate-column-name error (that would mean the helper wrongly swallowed something else)'
+    );
+  });
+});
+
+describe('initSchema', () => {
+  it('creates all expected tables on a fresh database', () => {
+    initSchema(db);
+
+    const rows = db
+      .prepare(`SELECT name FROM sqlite_master WHERE type='table' ORDER BY name`)
+      .all() as { name: string }[];
+    const tableNames = rows.map(r => r.name);
+
+    // Spot-check the tables that matter most for production correctness.
+    const expected = [
+      'users',
+      'subscriptions',
+      'alert_history',
+      'alert_window',
+      'mapbox_usage',
+      'settings',
+      'mapbox_image_cache',
+      'message_templates',
+      'message_template_history',
+      'sessions',
+      'login_attempts',
+      'whatsapp_groups',
+      'whatsapp_listeners',
+      'telegram_listeners',
+      'telegram_known_chats',
+      'telegram_known_topics',
+      'contacts',
+      'contact_permissions',
+      'safety_status',
+      'safety_prompts',
+    ];
+    for (const name of expected) {
+      assert.ok(tableNames.includes(name), `table "${name}" must be created by initSchema`);
+    }
+  });
+
+  it('is idempotent — running twice on the same DB does not throw', () => {
+    initSchema(db);
+    // All the ALTER TABLE statements inside initSchema will fire again — each
+    // one should hit the "duplicate column name" branch and be swallowed.
+    assert.doesNotThrow(() => initSchema(db), 'second initSchema call must be a no-op');
+  });
+
+  it('users table has all the profile/onboarding columns after init', () => {
+    initSchema(db);
+    const cols = db.prepare("PRAGMA table_info('users')").all() as { name: string }[];
+    const colNames = new Set(cols.map(c => c.name));
+
+    // Columns added via addColumnIfMissing must all be present after init.
+    for (const name of [
+      'quiet_hours_enabled',
+      'muted_until',
+      'display_name',
+      'home_city',
+      'locale',
+      'onboarding_completed',
+      'connection_code',
+      'onboarding_step',
+      'is_dm_active',
+    ]) {
+      assert.ok(colNames.has(name), `users.${name} column must exist after initSchema`);
+    }
+  });
+
+  it('v0.4.1 backfill marks existing subscribed users as onboarded', () => {
+    // Simulate a pre-v0.4.1 DB: users table and subscriptions exist, but
+    // the user row was created before the onboarding_completed column did.
+    initSchema(db);
+
+    // Insert a user + one subscription, then force onboarding_completed=0
+    // as if they were upgraded from an older version.
+    db.prepare('INSERT INTO users (chat_id, format) VALUES (?, ?)').run(9000, 'short');
+    db.prepare('INSERT INTO subscriptions (chat_id, city_name) VALUES (?, ?)').run(9000, 'אבו גוש');
+    db.prepare('UPDATE users SET onboarding_completed = 0 WHERE chat_id = ?').run(9000);
+
+    // Re-running initSchema executes the backfill UPDATE at the bottom of
+    // initSchema — the user should now be marked as onboarded.
+    initSchema(db);
+    const row = db
+      .prepare('SELECT onboarding_completed FROM users WHERE chat_id = ?')
+      .get(9000) as { onboarding_completed: number };
+    assert.equal(row.onboarding_completed, 1, 'existing subscriber must be backfilled to onboarded');
+  });
+
+  it('all_clear template is seeded on first init but not overwritten on re-init', () => {
+    initSchema(db);
+    // Customise the seed value
+    db.prepare(`UPDATE message_templates SET emoji = '💚' WHERE alert_type = 'all_clear'`).run();
+
+    // Re-initialising must NOT revert the customisation (INSERT OR IGNORE).
+    initSchema(db);
+    const row = db
+      .prepare('SELECT emoji FROM message_templates WHERE alert_type = ?')
+      .get('all_clear') as { emoji: string };
+    assert.equal(row.emoji, '💚', 'admin customisation must survive re-init');
+  });
+});

--- a/src/__tests__/menuHandler.backfill.test.ts
+++ b/src/__tests__/menuHandler.backfill.test.ts
@@ -1,0 +1,159 @@
+// Regression tests for the legacy-user onboarding backfill in menuHandler.ts.
+//
+// Context: v0.4.1 introduced onboarding gating. Pre-v0.4.1 users had
+// onboarding_completed = 0 by default, so /start was sending them back into
+// the onboarding wizard even though they were already real users with
+// subscriptions. The fix (commit da2665e on branch fix/onboarding-backfill,
+// merged as PR #208) added a "safety valve" branch at
+// src/bot/menuHandler.ts:60-71: if !isOnboardingCompleted(chatId) AND
+// getSubscriptionCount(chatId) > 0, call completeOnboarding(chatId) and
+// show the main menu instead of the onboarding prompt.
+//
+// These tests lock down that branch so the bug cannot regress. They are
+// tests-only — the fix is already in the source file.
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Bot, Context } from 'grammy';
+import { registerMenuHandler } from '../bot/menuHandler';
+import { initDb } from '../db/schema.js';
+import { upsertUser, isOnboardingCompleted, completeOnboarding } from '../db/userRepository.js';
+import { addSubscription } from '../db/subscriptionRepository.js';
+
+before(() => {
+  process.env['DB_PATH'] = ':memory:';
+  initDb();
+});
+
+function buildMockBot() {
+  const commands: Record<string, (ctx: Context) => Promise<void>> = {};
+  return {
+    command: (name: string, handler: (ctx: Context) => Promise<void>) => {
+      commands[name] = handler;
+    },
+    callbackQuery: () => {},
+    on: () => {},
+    catch: () => {},
+    _fireCmd: async (name: string, ctx: Context) => commands[name]?.(ctx),
+  };
+}
+
+function makeCtx(chatId: number): Context {
+  const replyCalls: [string, unknown][] = [];
+  const ctx: unknown = {
+    chat: { id: chatId, type: 'private' },
+    message: { message_id: 1 },
+    me: { username: 'pikud_bot' },
+    reply: async (text: string, opts?: unknown) => { replyCalls.push([text, opts]); },
+    _replyCalls: replyCalls,
+  };
+  return ctx as Context;
+}
+
+// Distinct chatId range to avoid colliding with other test files that
+// share the in-memory DB singleton across tests in the same process.
+const LEGACY_USER = 7_201;
+const NEW_USER = 7_202;
+const ALREADY_ONBOARDED = 7_203;
+
+describe('menuHandler — legacy onboarding backfill', () => {
+  it('backfills onboarding_completed for legacy user with subscriptions', async () => {
+    // Seed: legacy user — row exists, onboarding_completed = 0, has one sub
+    upsertUser(LEGACY_USER);
+    addSubscription(LEGACY_USER, 'אבו גוש');
+    assert.equal(
+      isOnboardingCompleted(LEGACY_USER),
+      false,
+      'precondition: legacy user must NOT be marked as onboarded'
+    );
+
+    const bot = buildMockBot();
+    registerMenuHandler(bot as unknown as Bot);
+    const ctx = makeCtx(LEGACY_USER);
+    await bot._fireCmd('start', ctx);
+
+    // Postcondition: the DB flag was flipped by completeOnboarding()
+    assert.equal(
+      isOnboardingCompleted(LEGACY_USER),
+      true,
+      'legacy user should be marked as onboarded after /start'
+    );
+  });
+
+  it('shows main menu (not onboarding prompt) after backfill', async () => {
+    // Fresh legacy user for this test
+    const chatId = 7_210;
+    upsertUser(chatId);
+    addSubscription(chatId, 'אבו גוש');
+
+    const bot = buildMockBot();
+    registerMenuHandler(bot as unknown as Bot);
+    const ctx = makeCtx(chatId);
+    await bot._fireCmd('start', ctx);
+
+    const replyCalls = (ctx as unknown as { _replyCalls: [string, { reply_markup?: unknown }][] })._replyCalls;
+    assert.equal(replyCalls.length, 1, 'should reply exactly once');
+    const [text, opts] = replyCalls[0]!;
+    assert.ok(
+      text.includes('בוט פיקוד העורף'),
+      'reply must show the main menu title, not the onboarding name prompt'
+    );
+    assert.ok(
+      !text.includes('ברוך הבא'),
+      'reply must NOT include the onboarding welcome text'
+    );
+    assert.ok(opts.reply_markup, 'main menu must include the inline keyboard');
+  });
+
+  it('does NOT backfill when user has zero subscriptions', async () => {
+    // A brand-new user with no subs must still go through onboarding.
+    upsertUser(NEW_USER);
+    assert.equal(isOnboardingCompleted(NEW_USER), false, 'precondition');
+
+    const bot = buildMockBot();
+    registerMenuHandler(bot as unknown as Bot);
+    const ctx = makeCtx(NEW_USER);
+    await bot._fireCmd('start', ctx);
+
+    // Flag stays false — user goes to onboarding, not main menu
+    assert.equal(
+      isOnboardingCompleted(NEW_USER),
+      false,
+      'user with zero subs must NOT be auto-marked as onboarded'
+    );
+    const replyCalls = (ctx as unknown as { _replyCalls: [string, unknown][] })._replyCalls;
+    assert.equal(replyCalls.length, 1, 'should reply with onboarding prompt');
+    assert.ok(
+      replyCalls[0]![0].includes('ברוך הבא'),
+      'must show the onboarding welcome text'
+    );
+  });
+
+  it('is idempotent — second /start from a backfilled user does not re-enter onboarding', async () => {
+    // Already-onboarded user (either genuinely or via a prior backfill)
+    upsertUser(ALREADY_ONBOARDED);
+    addSubscription(ALREADY_ONBOARDED, 'אבו גוש');
+    completeOnboarding(ALREADY_ONBOARDED);
+
+    const bot = buildMockBot();
+    registerMenuHandler(bot as unknown as Bot);
+    const ctx = makeCtx(ALREADY_ONBOARDED);
+
+    await bot._fireCmd('start', ctx);
+    await bot._fireCmd('start', ctx);
+
+    const replyCalls = (ctx as unknown as { _replyCalls: [string, unknown][] })._replyCalls;
+    assert.equal(replyCalls.length, 2, 'both /start calls reply');
+    for (const [text] of replyCalls) {
+      assert.ok(
+        text.includes('בוט פיקוד העורף'),
+        'every reply must be the main menu, not onboarding'
+      );
+      assert.ok(!text.includes('ברוך הבא'));
+    }
+    assert.equal(
+      isOnboardingCompleted(ALREADY_ONBOARDED),
+      true,
+      'flag must remain true across repeated /start calls'
+    );
+  });
+});

--- a/src/dashboard/routes/operations.ts
+++ b/src/dashboard/routes/operations.ts
@@ -6,7 +6,9 @@ import { getTopicId } from '../../topicRouter.js';
 import { log } from '../../logger.js';
 import { createRateLimitMiddleware } from '../rateLimiter.js';
 
-const broadcastLimiter = createRateLimitMiddleware({
+// Exported for test isolation — tests that send multiple broadcast requests
+// must call `broadcastLimiter.clearStore()` in `beforeEach` (2/min cap).
+export const broadcastLimiter = createRateLimitMiddleware({
   maxRequests: 2,
   windowMs: 60_000,
   message: 'יותר מדי שידורים — נסה שוב בעוד דקה',

--- a/src/dashboard/statsCache.ts
+++ b/src/dashboard/statsCache.ts
@@ -17,3 +17,10 @@ export function getCached<T>(key: string): T | null {
 export function setCached<T>(key: string, data: T, ttlMs: number): void {
   store.set(key, { data, expiresAt: Date.now() + ttlMs });
 }
+
+// Test-only helper — call in `beforeEach` when a test suite makes multiple
+// requests to the same /stats endpoint, otherwise the second request returns
+// a stale cached response from the first.
+export function clearStatsCache(): void {
+  store.clear();
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -24,7 +24,10 @@ export function closeDb(): void {
   }
 }
 
-function addColumnIfMissing(database: Database.Database, sql: string): void {
+// Exported so tests can verify the duplicate-column-name suppression and the
+// rethrow behavior for other errors. Production callers should only use it
+// inside `initSchema()` below.
+export function addColumnIfMissing(database: Database.Database, sql: string): void {
   try {
     database.prepare(sql).run();
   } catch (e: unknown) {


### PR DESCRIPTION
## Summary

PR 1 of 3 from the test coverage audit (plan: `fancy-wiggling-bunny`). Addresses the six CRITICAL gaps identified in the audit — each one is a confirmed untested code path where a production bug could regress silently. **Tests only**; no production behavior changes.

Stacked on #208 (`fix/onboarding-backfill`) because C1's backfill branch lives there. When #208 merges to `main`, rebase this onto `main`.

### Critical gaps covered (6 files, 34 new tests)

- **C1** `src/__tests__/menuHandler.backfill.test.ts` (4 tests) — locks down the v0.4.1 legacy-user onboarding backfill in `menuHandler.ts:60-71`. Prevents regression of the bug #208 fixes.
- **C2** `src/__tests__/dashboard/routes/operations.broadcast.test.ts` (4 tests) — verifies `POST /api/operations/broadcast` background loop survives per-recipient Telegram 403/429 errors.
- **C3** `src/__tests__/dashboard/routes/stats.overview.test.ts` (4 tests) — locks down the `mapboxRow ?? 0` guard in `stats.ts:66-84` (first-request-of-new-month edge case).
- **C4** `src/__tests__/db/schema.test.ts` (9 tests) — first-ever tests for `addColumnIfMissing` and `initSchema` idempotency. Prevents silent ALTER TABLE typo regressions.
- **C5** `src/__tests__/dashboard/routes/messages.testfire.test.ts` (8 tests) — `POST /api/messages/test-fire` platform branching (`telegram` / `whatsapp` / `both`), including graceful degradation when WhatsApp is unavailable.
- **C6** `src/__tests__/connectHandler.toctou.test.ts` (5 tests) — simulated race between `/connect` and `cx:confirm` callbacks; asserts the TOCTOU re-validation at `connectHandler.ts:401-414` rejects cleanly with no orphan permission rows.

### Test-isolation helpers (1 commit)

Three small exports to enable the tests above:
- `operations.ts`: `broadcastLimiter` exported so tests can call `clearStore()` (2/min cap).
- `statsCache.ts`: new `clearStatsCache()` helper (same pattern as rate limiter `clearStore()`).
- `schema.ts`: `addColumnIfMissing` exported for direct unit testing.

No production behavior change from any of these — they are pure test-enablement.

### Test results

```
npm test                                                     1172 pass  0 fail
DB_PATH=:memory: npx tsx --test 'src/__tests__/dashboard/...'  293 pass  0 fail
npx tsx --test src/__tests__/db/schema.test.ts                   9 pass  0 fail
────────────────────────────────────────────────────────────  ────
Total                                                         1474 pass  0 fail
```

All 34 new tests pass. Zero regressions.

## Test plan

- [x] `npm test` — 1172/1172 passing
- [x] `DB_PATH=:memory: npx tsx --test 'src/__tests__/dashboard/**/*.test.ts'` — 293/293 passing
- [x] `npx tsx --test src/__tests__/db/schema.test.ts` — 9/9 passing
- [x] Each test file was verified to *actually* exercise its target branch (confirmed via log-line side effects, not just pass/fail summaries)
- [x] C1 specifically: verified the `[Menu] Backfilled onboarding_completed for legacy user 7201` log line appears in test output, proving the real backfill branch ran (not a false positive)

## Follow-ups (out of scope for this PR)

- PR 2 — IMPORTANT gaps (I1–I9, including a small `settings.ts` validation code change and an `index.ts` → `shutdown.ts` extraction for I9)
- PR 3 — NICE-TO-HAVE (deferred unless requested)

Full audit report: see the approved plan at `~/.claude/plans/fancy-wiggling-bunny.md`.