### PR TITLE
tests + small fixes: PR 2 of audit plan (IMPORTANT gaps I1-I9)

### DIFF
--- a/src/__tests__/dashboard/routes/landing.test.ts
+++ b/src/__tests__/dashboard/routes/landing.test.ts
@@ -161,4 +161,97 @@ describe('POST /api/landing/deploy', () => {
       if (origRepo !== undefined) process.env['GITHUB_REPO'] = origRepo;
     }
   });
+
+  // I7 — POST /deploy error paths that the existing tests don't exercise.
+  // These need global.fetch mocking because the route fires a real HTTPS
+  // request to the GitHub Actions workflow_dispatch endpoint.
+  describe('with mocked global.fetch', () => {
+    let origFetch: typeof globalThis.fetch;
+    let origPat: string | undefined;
+    let origRepo: string | undefined;
+
+    beforeEach(() => {
+      origFetch = globalThis.fetch;
+      origPat = process.env['GITHUB_PAT'];
+      origRepo = process.env['GITHUB_REPO'];
+      process.env['GITHUB_PAT'] = 'fake-pat-for-test';
+      process.env['GITHUB_REPO'] = 'yonatan2021/pikud-haoref-bot';
+    });
+
+    after(() => {
+      // Restore env after the entire suite runs (per-test restore handled below).
+      globalThis.fetch = origFetch;
+      if (origPat !== undefined) process.env['GITHUB_PAT'] = origPat; else delete process.env['GITHUB_PAT'];
+      if (origRepo !== undefined) process.env['GITHUB_REPO'] = origRepo;
+    });
+
+    it('returns 502 when GitHub API responds with 4xx', async () => {
+      globalThis.fetch = (async () =>
+        new Response('Bad credentials', { status: 401, statusText: 'Unauthorized' })
+      ) as typeof globalThis.fetch;
+
+      const res = await request(app).post('/api/landing/deploy');
+      assert.equal(res.status, 502);
+      assert.ok(res.body.error);
+      assert.equal(res.body.status, 401, 'must surface the upstream status code');
+
+      // last_landing_deploy must NOT be written on failure.
+      const row = db.prepare("SELECT value FROM settings WHERE key = 'last_landing_deploy'").get();
+      assert.equal(row, undefined, 'last_landing_deploy must NOT be persisted on failure');
+    });
+
+    it('returns 502 when GitHub API responds with 5xx', async () => {
+      globalThis.fetch = (async () =>
+        new Response('Internal Server Error', { status: 500, statusText: 'ISE' })
+      ) as typeof globalThis.fetch;
+
+      const res = await request(app).post('/api/landing/deploy');
+      assert.equal(res.status, 502);
+      assert.equal(res.body.status, 500);
+    });
+
+    it('returns 500 when fetch throws (network error)', async () => {
+      globalThis.fetch = (async () => {
+        throw new TypeError('fetch failed: ECONNREFUSED');
+      }) as typeof globalThis.fetch;
+
+      const res = await request(app).post('/api/landing/deploy');
+      assert.equal(res.status, 500);
+      assert.ok(res.body.error);
+      // last_landing_deploy must NOT be written on network failure either.
+      const row = db.prepare("SELECT value FROM settings WHERE key = 'last_landing_deploy'").get();
+      assert.equal(row, undefined);
+    });
+
+    it('returns 200 ok and persists last_landing_deploy on success', async () => {
+      // GitHub workflow_dispatch returns 204 No Content on success — `response.ok`
+      // is true for any 2xx.
+      globalThis.fetch = (async () =>
+        new Response(null, { status: 204, statusText: 'No Content' })
+      ) as typeof globalThis.fetch;
+
+      const res = await request(app).post('/api/landing/deploy');
+      assert.equal(res.status, 200);
+      assert.equal(res.body.ok, true);
+
+      const row = db
+        .prepare("SELECT value FROM settings WHERE key = 'last_landing_deploy'")
+        .get() as { value: string } | undefined;
+      assert.ok(row, 'last_landing_deploy must be persisted on success');
+      // Sanity check: the value parses as an ISO date.
+      assert.ok(!isNaN(new Date(row!.value).getTime()), 'must be an ISO date string');
+    });
+
+    it('returns 400 for malformed GITHUB_REPO format (no slash)', async () => {
+      const orig = process.env['GITHUB_REPO'];
+      process.env['GITHUB_REPO'] = 'no-slash-here';
+      try {
+        const res = await request(app).post('/api/landing/deploy');
+        assert.equal(res.status, 400);
+        assert.ok(res.body.error.includes('GITHUB_REPO'));
+      } finally {
+        process.env['GITHUB_REPO'] = orig;
+      }
+    });
+  });
 });

--- a/src/__tests__/dashboard/routes/settings.test.ts
+++ b/src/__tests__/dashboard/routes/settings.test.ts
@@ -86,3 +86,88 @@ describe('PATCH /api/settings', () => {
     assert.equal(res.body.ok, true);
   });
 });
+
+// I2 — per-key value validation. Before this guard the only enum-validated
+// key was `all_clear_mode`. Numeric, boolean, and JSON keys all accepted any
+// string and the bad value was silently stored, breaking downstream code at
+// runtime. These tests lock down the validators that now run before
+// setSetting() is called.
+describe('PATCH /api/settings — value validation', () => {
+  // Clear settings between tests so the "no partial write" assertion isn't
+  // confused by leftover state from earlier suites in this file. The shared
+  // db singleton above is reused across describe blocks.
+  beforeEach(() => {
+    db.prepare('DELETE FROM settings').run();
+    settingsMutateLimiter.clearStore();
+  });
+
+  it('rejects non-numeric mapbox_monthly_limit with 400', async () => {
+    const res = await request(app).patch('/api/settings').send({ mapbox_monthly_limit: 'abc' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('mapbox_monthly_limit'));
+    // No partial write — the setting must NOT be in the DB.
+    const row = db.prepare("SELECT value FROM settings WHERE key = 'mapbox_monthly_limit'").get();
+    assert.equal(row, undefined);
+  });
+
+  it('rejects negative alert_window_seconds with 400', async () => {
+    const res = await request(app).patch('/api/settings').send({ alert_window_seconds: '-5' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('alert_window_seconds'));
+  });
+
+  it('rejects malformed JSON in privacy_defaults with 400', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ privacy_defaults: '{not-valid-json' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('privacy_defaults'));
+    assert.ok(res.body.error.includes('JSON'));
+  });
+
+  it('accepts well-formed JSON in privacy_defaults', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ privacy_defaults: '{"safety_status":1,"home_city":0}' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+  });
+
+  it('rejects non-boolean mapbox_skip_drills with 400', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ mapbox_skip_drills: 'maybe' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('mapbox_skip_drills'));
+  });
+
+  it('rejects float values in numeric keys (must be integer)', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ whatsapp_map_debounce_seconds: '15.5' });
+    assert.equal(res.status, 400);
+  });
+
+  it('does NOT partially apply when one key in a multi-key PATCH is invalid', async () => {
+    // Both keys are allowed, but the second one fails validation. The first
+    // key must NOT be persisted (validation runs as a separate pass before
+    // any setSetting() call).
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ alert_window_seconds: '120', mapbox_monthly_limit: 'BAD' });
+    assert.equal(res.status, 400);
+    const row1 = db.prepare("SELECT value FROM settings WHERE key = 'alert_window_seconds'").get();
+    const row2 = db.prepare("SELECT value FROM settings WHERE key = 'mapbox_monthly_limit'").get();
+    assert.equal(row1, undefined, 'first key must NOT have been written before validation failed');
+    assert.equal(row2, undefined);
+  });
+
+  it('still rejects all_clear_mode enum violations (regression)', async () => {
+    // The pre-existing all_clear_mode enum check must still fire.
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ all_clear_mode: 'invalid' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('all_clear_mode'));
+  });
+});

--- a/src/__tests__/dashboard/routes/subscribers.test.ts
+++ b/src/__tests__/dashboard/routes/subscribers.test.ts
@@ -219,4 +219,79 @@ describe('GET /api/subscribers/export/csv', () => {
     assert.ok(header.includes('connection_code'));
     assert.ok(header.includes('contact_count'));
   });
+
+  // I1 — escCsv must (a) double embedded quotes per RFC 4180 and (b) prefix
+  // any value starting with =, +, -, or @ with a single quote to neutralise
+  // CSV formula injection in Excel/Sheets/Numbers. The original escCsv only
+  // did (a). The gotchas doc claimed escCsv was the mitigation but the code
+  // was incomplete. These tests lock down both invariants.
+
+  it('CSV: escapes embedded double quotes by doubling (RFC 4180)', async () => {
+    db.prepare("UPDATE users SET display_name = ? WHERE chat_id = 111").run('עם "ציטוט" באמצע');
+    const res = await request(app).get('/api/subscribers/export/csv');
+    const dataLine = res.text.split('\n')[1]!;
+    assert.ok(
+      dataLine.includes('"עם ""ציטוט"" באמצע"'),
+      'embedded quotes must be doubled and the field wrapped in quotes'
+    );
+  });
+
+  it('CSV: prefixes formula-injection chars (=, +, -, @) with apostrophe', async () => {
+    // Try every dangerous lead character one by one — each must be neutralised.
+    for (const lead of ['=', '+', '-', '@']) {
+      db.prepare("DELETE FROM subscriptions WHERE chat_id = 111").run();
+      db.prepare("DELETE FROM users WHERE chat_id = 111").run();
+      db.prepare("INSERT INTO users (chat_id, format, display_name) VALUES (?, ?, ?)")
+        .run(111, 'short', `${lead}cmd|/c calc`);
+
+      const res = await request(app).get('/api/subscribers/export/csv');
+      const dataLine = res.text.split('\n')[1]!;
+      assert.ok(
+        dataLine.includes(`"'${lead}cmd|/c calc"`),
+        `field starting with "${lead}" must be prefixed with apostrophe — got: ${dataLine}`
+      );
+    }
+  });
+
+  it('CSV: handles null display_name and home_city without crashing', async () => {
+    db.prepare("UPDATE users SET display_name = NULL, home_city = NULL WHERE chat_id = 111").run();
+    const res = await request(app).get('/api/subscribers/export/csv');
+    assert.equal(res.status, 200);
+    const dataLine = res.text.split('\n')[1]!;
+    // Null fields should render as empty quoted strings — never the literal "null".
+    assert.ok(
+      dataLine.includes('"",""'),
+      'null display_name/home_city must render as empty quoted fields'
+    );
+    assert.ok(!dataLine.includes('null'), 'literal "null" must not appear in CSV');
+  });
+
+  it('CSV: dangerous chars combined with quotes are escaped in both directions', async () => {
+    db.prepare("UPDATE users SET display_name = ? WHERE chat_id = 111").run('=HYPERLINK("evil","go")');
+    const res = await request(app).get('/api/subscribers/export/csv');
+    const dataLine = res.text.split('\n')[1]!;
+    // Both: leading apostrophe + doubled quotes inside.
+    assert.ok(
+      dataLine.includes(`"'=HYPERLINK(""evil"",""go"")"`),
+      `must apply both escapes — got: ${dataLine}`
+    );
+  });
+
+  it('CSV: header field count matches body field count (no escape misalignment)', async () => {
+    db.prepare("UPDATE users SET display_name = ?, home_city = ? WHERE chat_id = 111")
+      .run('A,B,C', '=1+1');
+    const res = await request(app).get('/api/subscribers/export/csv');
+    const lines = res.text.split('\n');
+    const headerCols = lines[0]!.split(',').length;
+    // Count columns in the data line by parsing properly: commas inside
+    // quoted fields don't count. Use a tiny regex that splits on commas
+    // outside of double-quoted segments.
+    const dataLine = lines[1]!;
+    const dataCols = dataLine.match(/(?:[^,"]+|"[^"]*")+/g)?.length ?? 0;
+    assert.equal(
+      dataCols,
+      headerCols,
+      `body column count (${dataCols}) must equal header column count (${headerCols}) even with embedded commas`
+    );
+  });
 });

--- a/src/__tests__/dashboard/routes/whatsapp.test.ts
+++ b/src/__tests__/dashboard/routes/whatsapp.test.ts
@@ -220,6 +220,47 @@ describe('PATCH /api/whatsapp/groups/:id', () => {
     assert.equal(res.status, 400);
     assert.ok(res.body.error);
   });
+
+  // I6 — fill the remaining edges. Most PATCH validation is already
+  // tested above. These add: non-string element in array, empty-array
+  // (valid), and "no DB mutation when validation fails".
+  it('returns 400 when alertTypes contains a non-string element', async () => {
+    // Array.isArray is true but one element is a number — the
+    // .every(t => typeof t === 'string') check must catch it.
+    const res = await request(app)
+      .patch('/api/whatsapp/groups/111%40g.us')
+      .send({ enabled: true, alertTypes: ['missiles', 42, 'earthQuake'] });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error);
+  });
+
+  it('accepts empty alertTypes array (group disabled for all types)', async () => {
+    upsertGroup(db, '444@g.us', 'קבוצה ד', true, ['missiles']);
+    const res = await request(app)
+      .patch('/api/whatsapp/groups/444%40g.us')
+      .send({ enabled: false, alertTypes: [] });
+    assert.equal(res.status, 200);
+    const groups = getAllGroups(db);
+    const group = groups.find(g => g.groupId === '444@g.us');
+    assert.ok(group);
+    assert.deepEqual(group.alertTypes, []);
+  });
+
+  it('does NOT mutate the DB row when validation fails', async () => {
+    // Seed a known good state.
+    upsertGroup(db, '555@g.us', 'קבוצה ה', true, ['missiles', 'earthQuake']);
+
+    // Attempt PATCH with an unknown alert type — must reject AND not touch the row.
+    const res = await request(app)
+      .patch('/api/whatsapp/groups/555%40g.us')
+      .send({ enabled: false, alertTypes: ['notARealType'] });
+    assert.equal(res.status, 400);
+
+    const group = getAllGroups(db).find(g => g.groupId === '555@g.us');
+    assert.ok(group);
+    assert.equal(group.enabled, true, 'enabled must remain true after rejected PATCH');
+    assert.deepEqual(group.alertTypes, ['missiles', 'earthQuake'], 'alertTypes must remain unchanged');
+  });
 });
 
 describe('POST /api/whatsapp/clear-session', () => {

--- a/src/__tests__/dmQueue.test.ts
+++ b/src/__tests__/dmQueue.test.ts
@@ -132,6 +132,25 @@ describe('DmQueue', () => {
     assert.equal(extractRetryAfter(null), null);
   });
 
+  // I3 — float retry_after values (sub-second cooldowns). The structured
+  // params path passes the number through Math.min directly so a float
+  // survives. The message-string path uses parseFloat so "retry after 0.5"
+  // is also a valid input. Both must return the float value (NOT NaN, NOT 0).
+  it('extractRetryAfter: passes through float retry_after from structured params', () => {
+    const err = Object.assign(new Error('Too Many Requests'), {
+      parameters: { retry_after: 0.5 },
+    });
+    assert.equal(extractRetryAfter(err), 0.5, 'sub-second retry_after must survive');
+  });
+
+  it('extractRetryAfter: parses float from message string ("retry after 0.5")', () => {
+    assert.equal(extractRetryAfter(new Error('retry after 0.5')), 0.5);
+  });
+
+  it('extractRetryAfter: parses float from message string ("retry after 1.75")', () => {
+    assert.equal(extractRetryAfter(new Error('retry after 1.75')), 1.75);
+  });
+
   // Issue 4 — missing error path tests
   it('does not retry "user is deactivated" — drops task and continues', async () => {
     let sendCount = 0;

--- a/src/__tests__/onboardingHandler.test.ts
+++ b/src/__tests__/onboardingHandler.test.ts
@@ -174,4 +174,113 @@ describe('onboardingHandler', () => {
       assert.equal(getProfile(9021)?.display_name, longName);
     });
   });
+
+  // I5 — invalid city ID in ob:city callback. The handler regex matches
+  // \d+ but doesn't verify the city actually exists in cities.json. The
+  // null-check at src/bot/onboardingHandler.ts:179 is the safety net.
+  // Existing tests never exercised this branch via the real callback path.
+  describe('ob:city callback — invalid city ID handling', () => {
+    function buildMockBot() {
+      const callbacks: Array<[string | RegExp, (ctx: import('grammy').Context) => Promise<void>]> = [];
+      return {
+        command: () => {},
+        callbackQuery: (pat: string | RegExp, h: (ctx: import('grammy').Context) => Promise<void>) => {
+          callbacks.push([pat, h]);
+        },
+        on: () => {},
+        catch: () => {},
+        _fireCb: async (data: string, ctx: import('grammy').Context) => {
+          for (const [pat, h] of callbacks) {
+            if (typeof pat === 'string' && pat === data) { await h(ctx); return; }
+            if (pat instanceof RegExp && pat.test(data)) {
+              (ctx as unknown as { match: RegExpMatchArray | null }).match = data.match(pat);
+              await h(ctx);
+              return;
+            }
+          }
+        },
+      };
+    }
+
+    function makeCtx(chatId: number, callbackData: string) {
+      const replyCalls: [string, unknown?][] = [];
+      const editCalls: [string, unknown?][] = [];
+      const ctx: unknown = {
+        chat: { id: chatId, type: 'private' },
+        message: { message_id: 1 },
+        callbackQuery: { data: callbackData, id: 'cb-1' },
+        match: null,
+        reply: async (t: string, opts?: unknown) => { replyCalls.push([t, opts]); },
+        editMessageText: async (t: string, opts?: unknown) => { editCalls.push([t, opts]); },
+        answerCallbackQuery: async () => undefined,
+        api: { sendMessage: async () => ({ message_id: 1 }) },
+        _replyCalls: replyCalls,
+        _editCalls: editCalls,
+      };
+      return ctx as import('grammy').Context;
+    }
+
+    it('ob:city with non-existent city ID replies with error and does NOT advance step', async () => {
+      const { registerOnboardingHandler } = await import('../bot/onboardingHandler.js');
+      const chatId = 9_100;
+      upsertUser(chatId);
+      setOnboardingStep(chatId, 'city');
+
+      const bot = buildMockBot();
+      registerOnboardingHandler(bot as unknown as import('grammy').Bot);
+
+      // 999_999 is far outside any real city ID range — getCityById returns undefined.
+      const ctx = makeCtx(chatId, 'ob:city:999999');
+      await bot._fireCb('ob:city:999999', ctx);
+
+      const replyCalls = (ctx as unknown as { _replyCalls: [string, unknown?][] })._replyCalls;
+      assert.ok(replyCalls.length >= 1, 'must reply with the "city not found" error');
+      assert.match(replyCalls[0]![0], /עיר לא נמצאה/);
+
+      // Profile must NOT have a home_city set, and the step must still be 'city'.
+      assert.equal(getProfile(chatId)?.home_city, null);
+      assert.equal(getProfile(chatId)?.onboarding_step, 'city', 'step must NOT advance to confirm');
+    });
+
+    it('ob:city with a real city ID (511 = אבו גוש) sets home_city and advances to confirm', async () => {
+      const { registerOnboardingHandler } = await import('../bot/onboardingHandler.js');
+      const chatId = 9_101;
+      upsertUser(chatId);
+      setOnboardingStep(chatId, 'city');
+
+      const bot = buildMockBot();
+      registerOnboardingHandler(bot as unknown as import('grammy').Bot);
+
+      const ctx = makeCtx(chatId, 'ob:city:511');
+      await bot._fireCb('ob:city:511', ctx);
+
+      assert.equal(getProfile(chatId)?.home_city, 'אבו גוש');
+      assert.equal(getProfile(chatId)?.onboarding_step, 'confirm');
+    });
+
+    it('ob:confirm with a stale home_city (no longer in cities.json) still completes onboarding', async () => {
+      // Edge case: a user's stored home_city points to a city that has been
+      // removed from cities.json since they set it. The auto-subscription
+      // should silently skip but onboarding must still complete.
+      const { registerOnboardingHandler } = await import('../bot/onboardingHandler.js');
+      const chatId = 9_102;
+      upsertUser(chatId);
+      // Force a bogus home_city directly into the DB.
+      updateProfile(chatId, { home_city: 'עיר שלא קיימת בשום מקום' });
+      setOnboardingStep(chatId, 'confirm');
+
+      const bot = buildMockBot();
+      registerOnboardingHandler(bot as unknown as import('grammy').Bot);
+
+      const ctx = makeCtx(chatId, 'ob:confirm');
+      await bot._fireCb('ob:confirm', ctx);
+
+      // Onboarding must be marked complete despite the stale home_city.
+      assert.equal(
+        isOnboardingCompleted(chatId),
+        true,
+        'completeOnboarding must run even when home_city resolution fails'
+      );
+    });
+  });
 });

--- a/src/__tests__/profileHandler.test.ts
+++ b/src/__tests__/profileHandler.test.ts
@@ -124,4 +124,134 @@ describe('profileHandler', () => {
       assert.ok(text.includes('&lt;script&gt;'), 'should HTML-escape special chars');
     });
   });
+
+  // I4 — name input edge cases via the bot's text handler. The handler at
+  // src/bot/profileHandler.ts:170-178 stripHtmls the input, trims it, then
+  // rejects empty/over-50-char results. Existing tests only verified
+  // updateProfile() at the repository level, not the validation flow.
+  describe('name input via bot.on(message:text) handler', () => {
+    // Tiny mock bot that only records what we need: the name-edit callback
+    // setter and the text handler.
+    function buildMockBot() {
+      const callbacks: Array<[string | RegExp, (ctx: import('grammy').Context) => Promise<void>]> = [];
+      let textHandler: ((ctx: import('grammy').Context, next: () => Promise<void>) => Promise<void>) | null = null;
+      return {
+        command: () => {},
+        callbackQuery: (pat: string | RegExp, h: (ctx: import('grammy').Context) => Promise<void>) => {
+          callbacks.push([pat, h]);
+        },
+        on: (_evt: string, h: (ctx: import('grammy').Context, next: () => Promise<void>) => Promise<void>) => {
+          textHandler = h;
+        },
+        catch: () => {},
+        _fireCb: async (data: string, ctx: import('grammy').Context) => {
+          for (const [pat, h] of callbacks) {
+            if (typeof pat === 'string' && pat === data) { await h(ctx); return; }
+            if (pat instanceof RegExp && pat.test(data)) {
+              (ctx as unknown as { match: RegExpMatchArray | null }).match = data.match(pat);
+              await h(ctx);
+              return;
+            }
+          }
+        },
+        _fireText: async (ctx: import('grammy').Context) => {
+          if (textHandler) await textHandler(ctx, async () => undefined);
+        },
+      };
+    }
+
+    function makeCtx(chatId: number, text: string) {
+      const replyCalls: [string, unknown?][] = [];
+      const editCalls: [string, unknown?][] = [];
+      const ctx: unknown = {
+        chat: { id: chatId, type: 'private' },
+        message: { text, message_id: 1 },
+        match: null,
+        reply: async (t: string, opts?: unknown) => { replyCalls.push([t, opts]); },
+        editMessageText: async (t: string, opts?: unknown) => { editCalls.push([t, opts]); },
+        answerCallbackQuery: async () => undefined,
+        api: { sendMessage: async () => ({ message_id: 1 }) },
+        _replyCalls: replyCalls,
+        _editCalls: editCalls,
+      };
+      return ctx as import('grammy').Context;
+    }
+
+    async function setupNameEdit(chatId: number) {
+      const { registerProfileHandler } = await import('../bot/profileHandler.js');
+      const bot = buildMockBot();
+      registerProfileHandler(bot as unknown as import('grammy').Bot);
+      upsertUser(chatId);
+      // Put user into "name edit" pending state by firing the callback.
+      const ctx = makeCtx(chatId, '');
+      await bot._fireCb('pf:edit_name', ctx);
+      return bot;
+    }
+
+    it('rejects name longer than 50 characters with the validation reply', async () => {
+      const chatId = 8101;
+      const bot = await setupNameEdit(chatId);
+      const longName = 'א'.repeat(51);
+      const ctx = makeCtx(chatId, longName);
+      await bot._fireText(ctx);
+
+      const replyCalls = (ctx as unknown as { _replyCalls: [string, unknown?][] })._replyCalls;
+      assert.ok(replyCalls.length >= 1, 'must reply with validation error');
+      assert.match(replyCalls[0]![0], /1 ל-50/, 'reply must mention the 1-50 character limit');
+      assert.equal(getProfile(chatId)?.display_name, null, 'profile must NOT be updated');
+    });
+
+    it('rejects empty name (whitespace-only after strip+trim)', async () => {
+      const chatId = 8102;
+      const bot = await setupNameEdit(chatId);
+      const ctx = makeCtx(chatId, '   ');
+      await bot._fireText(ctx);
+
+      const replyCalls = (ctx as unknown as { _replyCalls: [string, unknown?][] })._replyCalls;
+      assert.match(replyCalls[0]![0], /1 ל-50/);
+      assert.equal(getProfile(chatId)?.display_name, null);
+    });
+
+    it('rejects name that becomes empty after stripHtml (HTML-only input)', async () => {
+      const chatId = 8103;
+      const bot = await setupNameEdit(chatId);
+      // Pure HTML markup — stripHtml leaves nothing.
+      const ctx = makeCtx(chatId, '<b></b>');
+      await bot._fireText(ctx);
+
+      const replyCalls = (ctx as unknown as { _replyCalls: [string, unknown?][] })._replyCalls;
+      assert.match(replyCalls[0]![0], /1 ל-50/);
+      assert.equal(getProfile(chatId)?.display_name, null);
+    });
+
+    it('strips HTML tags from name input but keeps the visible text', async () => {
+      const chatId = 8104;
+      const bot = await setupNameEdit(chatId);
+      const ctx = makeCtx(chatId, '<b>יונתן</b>');
+      await bot._fireText(ctx);
+
+      assert.equal(
+        getProfile(chatId)?.display_name,
+        'יונתן',
+        'tags must be stripped, the visible text kept'
+      );
+    });
+
+    it('accepts a valid 50-character name (boundary value)', async () => {
+      const chatId = 8105;
+      const bot = await setupNameEdit(chatId);
+      const exactlyFifty = 'א'.repeat(50);
+      const ctx = makeCtx(chatId, exactlyFifty);
+      await bot._fireText(ctx);
+      assert.equal(getProfile(chatId)?.display_name, exactlyFifty);
+    });
+
+    it('accepts a 1-character name (lower boundary)', async () => {
+      const chatId = 8106;
+      const bot = await setupNameEdit(chatId);
+      const ctx = makeCtx(chatId, 'א');
+      await bot._fireText(ctx);
+      assert.equal(getProfile(chatId)?.display_name, 'א');
+    });
+  });
 });

--- a/src/__tests__/shutdown.test.ts
+++ b/src/__tests__/shutdown.test.ts
@@ -1,0 +1,207 @@
+// Tests for src/shutdown.ts — locks down the 8-step graceful shutdown
+// sequence documented in the saved memory pattern_graceful_shutdown.md.
+//
+// Why this test exists: prior incidents hung or crashed the bot when a
+// shutdown step was missed or reordered. Until the I9 refactor, shutdown
+// lived inside the index.ts IIFE with closures over a dozen locals and
+// could not be tested. The refactor extracts it to src/shutdown.ts as a
+// factory over an injectable handles interface.
+//
+// The "step order is load-bearing" claim is verified concretely here: each
+// mock handle method pushes its name into a shared recorder, and we assert
+// the recorder ends up with the exact expected sequence.
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  createShutdown,
+  _resetShutdownState,
+  type ShutdownHandles,
+} from '../shutdown.js';
+
+interface RecorderHandles extends ShutdownHandles {
+  steps: string[];
+  exitCalls: number[];
+}
+
+function buildHandles(opts: {
+  whatsappEnabled?: boolean;
+  tgListenerEnabled?: boolean;
+  hasDashboard?: boolean;
+  botStopThrows?: boolean;
+  closeDbThrows?: boolean;
+  waDisconnectThrows?: boolean;
+} = {}): RecorderHandles {
+  const steps: string[] = [];
+  const exitCalls: number[] = [];
+
+  // The interval handles need to be real Node.js Timeout objects so
+  // clearInterval() doesn't throw. Use real ones with .unref() so they
+  // don't keep the test process alive.
+  const ci = setInterval(() => undefined, 60_000); ci.unref();
+  const sp = setInterval(() => undefined, 60_000); sp.unref();
+
+  return {
+    steps,
+    exitCalls,
+    contactCleanupInterval: ci,
+    safetyPruneInterval: sp,
+    allClearTracker: { clearAll: () => { steps.push('allClearTracker.clearAll'); } },
+    poller: { stop: () => { steps.push('poller.stop'); } },
+    bot: {
+      stop: async () => {
+        steps.push('bot.stop');
+        if (opts.botStopThrows) throw new Error('bot.stop kaboom');
+      },
+    },
+    healthServer: { close: () => { steps.push('healthServer.close'); } },
+    dashboardHttpServer: opts.hasDashboard !== false
+      ? { close: () => { steps.push('dashboardHttpServer.close'); } }
+      : null,
+    whatsappEnabled: opts.whatsappEnabled ?? false,
+    disconnectWhatsApp: async () => {
+      steps.push('disconnectWhatsApp');
+      if (opts.waDisconnectThrows) throw new Error('wa kaboom');
+    },
+    tgListenerEnabled: opts.tgListenerEnabled ?? false,
+    disconnectTelegramListener: async () => { steps.push('disconnectTelegramListener'); },
+    closeDb: () => {
+      steps.push('closeDb');
+      if (opts.closeDbThrows) throw new Error('closeDb kaboom');
+    },
+  };
+}
+
+const noopLog = () => undefined;
+
+beforeEach(() => {
+  // The shuttingDown guard is module-level. Reset between tests so each
+  // test sees a fresh shutdown lifecycle.
+  _resetShutdownState();
+});
+
+describe('createShutdown — step ordering', () => {
+  it('runs the 8 steps in the documented order on a minimal config', async () => {
+    const h = buildHandles();
+    const shutdown = createShutdown(h, {
+      forceExitMs: 0,
+      exit: (code) => { h.exitCalls.push(code); },
+      log: noopLog,
+    });
+
+    await shutdown('SIGTERM');
+
+    // Steps that always fire, in the load-bearing order:
+    //   timers cleared (no observable side effect — implicit)
+    //   → allClearTracker.clearAll
+    //   → poller.stop
+    //   → bot.stop
+    //   → healthServer.close
+    //   → dashboardHttpServer.close
+    //   → closeDb (last — every prior step may have written to it)
+    assert.deepEqual(h.steps, [
+      'allClearTracker.clearAll',
+      'poller.stop',
+      'bot.stop',
+      'healthServer.close',
+      'dashboardHttpServer.close',
+      'closeDb',
+    ]);
+    assert.deepEqual(h.exitCalls, [0], 'must call exit(0) on clean shutdown');
+  });
+
+  it('includes WhatsApp disconnect when enabled, in the right slot', async () => {
+    const h = buildHandles({ whatsappEnabled: true });
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: () => undefined, log: noopLog });
+    await shutdown('SIGTERM');
+
+    // disconnectWhatsApp must come AFTER healthServer/dashboard close and
+    // BEFORE closeDb.
+    const idxWa = h.steps.indexOf('disconnectWhatsApp');
+    const idxDashboard = h.steps.indexOf('dashboardHttpServer.close');
+    const idxCloseDb = h.steps.indexOf('closeDb');
+    assert.ok(idxWa > idxDashboard, 'WA disconnect must run AFTER dashboardHttpServer.close');
+    assert.ok(idxWa < idxCloseDb, 'WA disconnect must run BEFORE closeDb');
+  });
+
+  it('includes Telegram listener disconnect when enabled, in the right slot', async () => {
+    const h = buildHandles({ tgListenerEnabled: true });
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: () => undefined, log: noopLog });
+    await shutdown('SIGTERM');
+
+    const idxTg = h.steps.indexOf('disconnectTelegramListener');
+    const idxDashboard = h.steps.indexOf('dashboardHttpServer.close');
+    const idxCloseDb = h.steps.indexOf('closeDb');
+    assert.ok(idxTg > idxDashboard);
+    assert.ok(idxTg < idxCloseDb);
+  });
+
+  it('skips dashboardHttpServer.close when no dashboard is configured', async () => {
+    const h = buildHandles({ hasDashboard: false });
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: () => undefined, log: noopLog });
+    await shutdown('SIGTERM');
+
+    assert.ok(!h.steps.includes('dashboardHttpServer.close'));
+    // closeDb must still run last.
+    assert.equal(h.steps[h.steps.length - 1], 'closeDb');
+  });
+
+  it('closes DB last regardless of which optional integrations are enabled', async () => {
+    const h = buildHandles({ whatsappEnabled: true, tgListenerEnabled: true });
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: () => undefined, log: noopLog });
+    await shutdown('SIGTERM');
+
+    assert.equal(
+      h.steps[h.steps.length - 1],
+      'closeDb',
+      'closeDb must always be the LAST step — every prior step may write to it'
+    );
+  });
+});
+
+describe('createShutdown — error tolerance', () => {
+  it('continues shutdown even when bot.stop() throws', async () => {
+    const h = buildHandles({ botStopThrows: true });
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: (c) => { h.exitCalls.push(c); }, log: noopLog });
+    await shutdown('SIGTERM');
+
+    // bot.stop fired, then later steps still ran:
+    assert.ok(h.steps.includes('bot.stop'));
+    assert.ok(h.steps.includes('healthServer.close'), 'healthServer.close must still run after bot.stop throws');
+    assert.ok(h.steps.includes('closeDb'));
+    assert.deepEqual(h.exitCalls, [0], 'shutdown still exits cleanly after a non-fatal error');
+  });
+
+  it('continues shutdown even when WhatsApp disconnect throws', async () => {
+    const h = buildHandles({ whatsappEnabled: true, waDisconnectThrows: true });
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: (c) => { h.exitCalls.push(c); }, log: noopLog });
+    await shutdown('SIGTERM');
+
+    assert.ok(h.steps.includes('disconnectWhatsApp'));
+    assert.ok(h.steps.includes('closeDb'), 'closeDb must still run after WA disconnect throws');
+    assert.deepEqual(h.exitCalls, [0]);
+  });
+
+  it('continues to exit(0) even when closeDb throws', async () => {
+    const h = buildHandles({ closeDbThrows: true });
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: (c) => { h.exitCalls.push(c); }, log: noopLog });
+    await shutdown('SIGTERM');
+
+    assert.ok(h.steps.includes('closeDb'));
+    assert.deepEqual(h.exitCalls, [0], 'must still exit(0) — closeDb errors are non-fatal');
+  });
+});
+
+describe('createShutdown — re-entrancy', () => {
+  it('is idempotent — second shutdown call is a no-op', async () => {
+    const h = buildHandles();
+    const shutdown = createShutdown(h, { forceExitMs: 0, exit: (c) => { h.exitCalls.push(c); }, log: noopLog });
+
+    await shutdown('SIGTERM');
+    const firstStepCount = h.steps.length;
+    const firstExitCount = h.exitCalls.length;
+
+    await shutdown('SIGINT');
+    assert.equal(h.steps.length, firstStepCount, 'second shutdown must NOT re-run any steps');
+    assert.equal(h.exitCalls.length, firstExitCount, 'second shutdown must NOT call exit() again');
+  });
+});

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -244,6 +244,49 @@ describe('userRepository — v0.4.1 profile fields', () => {
       assert.equal(user.display_name, 'Coded');
       assert.equal(user.connection_code, '654321');
     });
+
+    // I8 — unique constraint enforcement. schema.ts:257 declares
+    //   CREATE UNIQUE INDEX idx_users_connection_code ON users(connection_code)
+    //   WHERE connection_code IS NOT NULL
+    // so two distinct users cannot share a connection_code, BUT multiple users
+    // CAN have a NULL connection_code (the partial WHERE clause). The
+    // /connect flow's collision-retry logic in connectHandler.ts depends on
+    // this constraint actually firing — these tests lock it down.
+
+    it('setConnectionCode throws when another user already owns the same code', () => {
+      upsertUser(801);
+      upsertUser(802);
+      setConnectionCode(801, '424242');
+
+      assert.throws(
+        () => setConnectionCode(802, '424242'),
+        /UNIQUE|constraint/i,
+        'second user must NOT be able to claim the same code'
+      );
+
+      // Postcondition: 801 still owns it, 802 has no code.
+      assert.equal(getUser(801)?.connection_code, '424242');
+      assert.equal(getUser(802)?.connection_code, null);
+    });
+
+    it('multiple users can simultaneously have a NULL connection_code', () => {
+      // The partial index excludes NULL rows, so this must NOT throw.
+      upsertUser(811);
+      upsertUser(812);
+      upsertUser(813);
+
+      assert.equal(getUser(811)?.connection_code, null);
+      assert.equal(getUser(812)?.connection_code, null);
+      assert.equal(getUser(813)?.connection_code, null);
+    });
+
+    it('setConnectionCode allows the same user to update their own code', () => {
+      upsertUser(821);
+      setConnectionCode(821, '111222');
+      // Same user, new code — must NOT collide with itself.
+      assert.doesNotThrow(() => setConnectionCode(821, '333444'));
+      assert.equal(getUser(821)?.connection_code, '333444');
+    });
   });
 
   describe('deleteUser cascade', () => {

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -37,6 +37,54 @@ const ALLOWED_KEYS = new Set([
   'dm_relevance_not_area',
 ]);
 
+// ─── Per-key value validators ─────────────────────────────────────────────
+//
+// Each validator returns null on success, or a Hebrew error string on
+// failure. Keys not present in this map accept any string (free-text fields
+// like ga4_measurement_id, landing_url, dm_relevance_*, etc).
+//
+// Before this guard the only validation was on `all_clear_mode`. A user
+// could PATCH `mapbox_monthly_limit: "abc"`, `alert_window_seconds: "-5"`,
+// or `privacy_defaults: "{not-json"` and the value would be silently stored,
+// breaking downstream code at runtime.
+
+function validateNonNegativeInt(value: string): string | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    return `הערך חייב להיות מספר שלם אי-שלילי, התקבל: ${value}`;
+  }
+  return null;
+}
+
+function validateBoolish(value: string): string | null {
+  return value === 'true' || value === 'false'
+    ? null
+    : `הערך חייב להיות 'true' או 'false', התקבל: ${value}`;
+}
+
+function validateJson(value: string): string | null {
+  try { JSON.parse(value); return null; }
+  catch { return `הערך חייב להיות JSON תקין`; }
+}
+
+const VALIDATORS: Record<string, (value: string) => string | null> = {
+  alert_window_seconds:          validateNonNegativeInt,
+  mapbox_monthly_limit:          validateNonNegativeInt,
+  mapbox_image_cache_size:       validateNonNegativeInt,
+  whatsapp_map_debounce_seconds: validateNonNegativeInt,
+  topic_id_security:             validateNonNegativeInt,
+  topic_id_nature:               validateNonNegativeInt,
+  topic_id_environmental:        validateNonNegativeInt,
+  topic_id_drills:               validateNonNegativeInt,
+  topic_id_general:              validateNonNegativeInt,
+  topic_id_whatsapp:             validateNonNegativeInt,
+  all_clear_topic_id:            validateNonNegativeInt,
+  mapbox_skip_drills:            validateBoolish,
+  quiet_hours_global:            validateBoolish,
+  whatsapp_enabled:              validateBoolish,
+  privacy_defaults:              validateJson,
+};
+
 export function createSettingsRouter(db: Database.Database): Router {
   const router = Router();
 
@@ -68,6 +116,9 @@ export function createSettingsRouter(db: Database.Database): Router {
       res.status(400).json({ error: `מפתחות לא חוקיים: ${invalid.join(', ')}` });
       return;
     }
+
+    // ── Per-key value validation (runs BEFORE any DB write so a partial
+    // update can't leak through when one key in a multi-key PATCH is bad).
     const allClearModeUpdate = updates['all_clear_mode'];
     if (allClearModeUpdate !== undefined) {
       const valid = ['dm', 'channel', 'both'];
@@ -76,6 +127,16 @@ export function createSettingsRouter(db: Database.Database): Router {
         return;
       }
     }
+    for (const [key, value] of Object.entries(updates)) {
+      const validator = VALIDATORS[key];
+      if (!validator) continue;
+      const err = validator(String(value));
+      if (err) {
+        res.status(400).json({ error: `${key}: ${err}` });
+        return;
+      }
+    }
+
     for (const [key, value] of Object.entries(updates)) {
       setSetting(db, key, String(value));
     }

--- a/src/dashboard/routes/subscribers.ts
+++ b/src/dashboard/routes/subscribers.ts
@@ -50,7 +50,17 @@ export function createSubscribersRouter(db: Database.Database): Router {
         contact_count: number;
       }>;
 
-      const escCsv = (s: string) => s.replace(/"/g, '""');
+      // Escape every CSV string field. Two responsibilities:
+      //   1. Double any embedded `"` (RFC 4180 quoting)
+      //   2. Prepend a single quote to neutralise CSV formula injection when
+      //      the value starts with =, +, -, or @ — Excel/Sheets/Numbers will
+      //      otherwise interpret it as a formula. The project's gotchas doc
+      //      already documents this as a known risk; the original escCsv()
+      //      only did (1) and silently left this hole open.
+      const escCsv = (s: string) => {
+        const quoted = s.replace(/"/g, '""');
+        return /^[=+\-@]/.test(quoted) ? `'${quoted}` : quoted;
+      };
       const header = 'chat_id,display_name,home_city,connection_code,contact_count,format,quiet_hours,onboarding,locale,created_at,cities\n';
       const body = rows.map(r =>
         `${r.chat_id},"${escCsv(r.display_name ?? '')}","${escCsv(r.home_city ?? '')}","${escCsv(r.connection_code ?? '')}",${r.contact_count},"${escCsv(r.format)}",${r.quiet_hours_enabled},${r.onboarding_completed},"${escCsv(r.locale)}","${escCsv(r.created_at)}","${escCsv(r.cities ?? '')}"`

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import { shouldSkipMap } from './alertHelpers';
 import { dispatchSafetyPrompts } from './services/safetyPromptService';
 import { setSafetyStatusHandlerDeps } from './bot/safetyStatusHandler';
 import { handleNewAlert } from './alertHandler';
+import { createShutdown } from './shutdown.js';
 import { insertAlert as insertAlertHistory, countAlertsToday, getDailyCountsForMonth } from './db/alertHistoryRepository.js';
 import { startHealthServer } from './healthServer.js';
 import { updateLastAlertAt } from './metrics.js';
@@ -257,38 +258,10 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
     },
   });
 
-  // Graceful shutdown — stop accepting work, drain in-flight, close storage
-  let shuttingDown = false;
-  async function shutdown(signal: string): Promise<void> {
-    if (shuttingDown) return;
-    shuttingDown = true;
-
-    // Force exit after 10s if cleanup hangs (e.g. stuck WA or bot.stop())
-    const forceTimer = setTimeout(() => {
-      log('warn', 'Init', 'Shutdown timeout — יוצא בכוח');
-      process.exit(1);
-    }, 10_000);
-    forceTimer.unref();
-
-    log('info', 'Init', `${signal} — מבצע כיבוי מסודר...`);
-    clearInterval(contactCleanupInterval);
-    clearInterval(safetyPruneInterval);
-    allClearTracker.clearAll();
-    poller.stop();
-    try { await bot.stop(); } catch { /* ignore */ }
-    healthServer.close();
-    if (dashboardHttpServer) { dashboardHttpServer.close(); }
-    if (process.env.WHATSAPP_ENABLED === 'true') {
-      try { await disconnectWhatsApp(); } catch { /* ignore */ }
-    }
-    if (tgListenerEnabled) {
-      try { await disconnectTelegramListener(getDb()); } catch { /* ignore */ }
-    }
-    try { closeDb(); } catch { /* ignore */ }
-    process.exit(0);
-  }
-  process.once('SIGTERM', () => { void shutdown('SIGTERM'); });
-  process.once('SIGINT',  () => { void shutdown('SIGINT');  });
+  // (Graceful shutdown wiring is registered AFTER the interval handles
+  //  declared further down, so the shutdown function captures real values
+  //  rather than uninitialised bindings — see lines after the
+  //  safetyPruneInterval declaration below.)
 
   poller.on('newAlert', async (alert: Alert) => {
     updateLastAlertAt();
@@ -351,6 +324,29 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
       log('info', 'SAFETY', `נוקו ${statusCount} סטטוסים ו-${promptCount} פרומפטים ישנים`);
     }
   }, 6 * 60 * 60 * 1000);
+
+  // Graceful shutdown — stop accepting work, drain in-flight, close storage.
+  // Wired AFTER both interval handles are declared so the createShutdown
+  // call captures real values, not uninitialised bindings. The actual
+  // step sequence lives in src/shutdown.ts and is unit-tested in
+  // src/__tests__/shutdown.test.ts. Step order is load-bearing — see the
+  // saved memory pattern_graceful_shutdown.md.
+  const shutdown = createShutdown({
+    contactCleanupInterval,
+    safetyPruneInterval,
+    allClearTracker,
+    poller,
+    bot,
+    healthServer,
+    dashboardHttpServer,
+    whatsappEnabled: process.env.WHATSAPP_ENABLED === 'true',
+    disconnectWhatsApp,
+    tgListenerEnabled,
+    disconnectTelegramListener: () => disconnectTelegramListener(getDb()),
+    closeDb,
+  });
+  process.once('SIGTERM', () => { void shutdown('SIGTERM'); });
+  process.once('SIGINT',  () => { void shutdown('SIGINT');  });
 
   logStartupHeader('0.5.0', [
     { name: 'Health Server', detail: healthOk ? toVisualRtl(`פורט ${resolvedHealthPort}`) : toVisualRtl('נכשל בהפעלה'), ok: healthOk, url: healthOk ? `http://localhost:${resolvedHealthPort}/health` : undefined },

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -1,0 +1,116 @@
+// Graceful shutdown logic extracted from index.ts so it can be unit-tested.
+//
+// Why this is its own module: the shutdown sequence has a load-bearing
+// step order — the saved memory `pattern_graceful_shutdown.md` documents
+// how missing or reordering a step has caused real production hangs and
+// crashes. Until now there was no test pinning that order: the shutdown()
+// function lived inside the index.ts IIFE with closures over a dozen local
+// variables, making it impossible to test in isolation.
+//
+// The refactor is intentionally minimal:
+//   1. Move the body to a factory function over a `ShutdownHandles` interface.
+//   2. Make `process.exit` and `log` injectable so tests can observe the
+//      sequence without actually killing the test process.
+//   3. Keep the call site in index.ts a one-liner.
+//
+// The actual semantic behavior (step order, ignored errors, force-exit
+// timer, double-shutdown guard) is unchanged.
+import { log as defaultLog } from './logger.js';
+
+export interface ShutdownHandles {
+  contactCleanupInterval: NodeJS.Timeout;
+  safetyPruneInterval: NodeJS.Timeout;
+  allClearTracker: { clearAll: () => void };
+  poller: { stop: () => void };
+  bot: { stop: () => Promise<void> };
+  healthServer: { close: () => void };
+  dashboardHttpServer: { close: () => void } | null;
+  whatsappEnabled: boolean;
+  disconnectWhatsApp: () => Promise<void>;
+  tgListenerEnabled: boolean;
+  disconnectTelegramListener: () => Promise<void>;
+  closeDb: () => void;
+}
+
+export interface ShutdownOptions {
+  /** Milliseconds to wait before force-exiting (default 10_000). Tests pass a small value or 0 to disable. */
+  forceExitMs?: number;
+  /** Injectable process.exit. Tests pass a recorder so the test process doesn't actually exit. */
+  exit?: (code: number) => void;
+  /** Injectable logger. Tests can pass a no-op to silence output. */
+  log?: typeof defaultLog;
+}
+
+// Module-level guard so a second SIGTERM/SIGINT during an in-progress
+// shutdown is a no-op (matches the original behavior in index.ts).
+let shuttingDown = false;
+
+/** Test-only — reset the shuttingDown guard between test cases. */
+export function _resetShutdownState(): void {
+  shuttingDown = false;
+}
+
+/**
+ * Build a shutdown function bound to a concrete set of runtime handles.
+ *
+ * Step order is load-bearing — see pattern_graceful_shutdown.md memory.
+ * If you reorder these steps, the test in src/__tests__/shutdown.test.ts
+ * will fail, which is the entire point of the test.
+ */
+export function createShutdown(
+  handles: ShutdownHandles,
+  options: ShutdownOptions = {},
+): (signal: string) => Promise<void> {
+  const log = options.log ?? defaultLog;
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const forceExitMs = options.forceExitMs ?? 10_000;
+
+  return async function shutdown(signal: string): Promise<void> {
+    if (shuttingDown) return;
+    shuttingDown = true;
+
+    // Force exit after the configured timeout if cleanup hangs.
+    // Tests can pass forceExitMs: 0 to skip arming the timer entirely.
+    if (forceExitMs > 0) {
+      const forceTimer = setTimeout(() => {
+        log('warn', 'Init', 'Shutdown timeout — יוצא בכוח');
+        exit(1);
+      }, forceExitMs);
+      forceTimer.unref();
+    }
+
+    log('info', 'Init', `${signal} — מבצע כיבוי מסודר...`);
+
+    // ── Step 1: stop background timers
+    clearInterval(handles.contactCleanupInterval);
+    clearInterval(handles.safetyPruneInterval);
+
+    // ── Step 2: cancel pending all-clear timers (so they don't fire mid-shutdown)
+    handles.allClearTracker.clearAll();
+
+    // ── Step 3: stop the alert poller (no new alerts will be processed)
+    handles.poller.stop();
+
+    // ── Step 4: stop the bot (drain in-flight grammy updates)
+    try { await handles.bot.stop(); } catch { /* ignore */ }
+
+    // ── Step 5: close the health HTTP server
+    handles.healthServer.close();
+
+    // ── Step 6: close the dashboard HTTP server (optional)
+    if (handles.dashboardHttpServer) { handles.dashboardHttpServer.close(); }
+
+    // ── Step 7: disconnect external listeners (optional, parallel to each other in spirit)
+    if (handles.whatsappEnabled) {
+      try { await handles.disconnectWhatsApp(); } catch { /* ignore */ }
+    }
+    if (handles.tgListenerEnabled) {
+      try { await handles.disconnectTelegramListener(); } catch { /* ignore */ }
+    }
+
+    // ── Step 8: close the DB last — every prior step may have written to it
+    try { handles.closeDb(); } catch { /* ignore */ }
+
+    exit(0);
+  };
+}


### PR DESCRIPTION
## Summary

PR 2 of 3 from the test coverage audit (plan: \`fancy-wiggling-bunny\`). Addresses the nine IMPORTANT gaps. Stacked conceptually on PR #209 (which is now merged into main as 9b247d5).

This PR is **larger than PR 1** because four of the gaps required production-code changes alongside their tests:

- **I1** — fixes a real CSV formula injection hole (\`escCsv\` was incomplete)
- **I2** — adds per-key value validation to \`PATCH /api/settings\`
- **I9** — extracts \`shutdown()\` from \`index.ts\` into a testable module

The other six are tests-only.

## Gaps covered (9 commits, ~30 new tests, 3 production-code changes)

| Gap | Type | New tests | Notes |
|---|---|---|---|
| **I1** | code + tests | 5 | \`escCsv\` now neutralises formula-injection chars (=, +, -, @). The gotchas doc claimed this was already done; the code didn't actually do it. |
| **I2** | code + tests | 8 | Per-key VALIDATORS map: numeric, boolean, JSON. Validation runs as a separate pass before \`setSetting()\` so partial multi-key PATCHes can't leak. |
| **I3** | tests only | 3 | Float \`retry_after\` (0.5s, 1.75s) — sub-second cooldowns weren't tested. |
| **I4** | tests only | 6 | profileHandler text-input validation via mock bot. Existing tests only hit the repo layer. |
| **I5** | tests only | 3 | \`ob:city\` callback with non-existent city ID; \`ob:confirm\` with stale home_city. |
| **I6** | tests only | 3 | The audit suspected missing PATCH /groups validation; verification showed it already existed. Added the few genuinely missing edges (non-string element, empty array, no DB mutation on failure). |
| **I7** | tests only | 5 | \`POST /api/landing/deploy\` error paths via mocked \`global.fetch\` — 502 on 4xx/5xx, 500 on network error, 200 success path persists \`last_landing_deploy\`. |
| **I8** | tests only | 3 | \`connection_code\` partial-unique-index constraint. The /connect collision-retry depends on this firing. |
| **I9** | refactor + tests | 9 | Extracted \`shutdown()\` from \`index.ts\` into \`src/shutdown.ts\`. Locks down the 8-step graceful shutdown order documented in the saved \`pattern_graceful_shutdown.md\` memory. |

## Production code changes

### \`src/dashboard/routes/subscribers.ts\` — escCsv hardening
\`\`\`diff
- const escCsv = (s: string) => s.replace(/"/g, '""');
+ const escCsv = (s: string) => {
+   const quoted = s.replace(/"/g, '""');
+   return /^[=+\-@]/.test(quoted) ? \`'\${quoted}\` : quoted;
+ };
\`\`\`

### \`src/dashboard/routes/settings.ts\` — VALIDATORS map
Adds three validator helpers (\`validateNonNegativeInt\`, \`validateBoolish\`, \`validateJson\`) and a \`VALIDATORS: Record<string, ...>\` lookup table covering 11 numeric, 3 boolean, and 1 JSON key. Wired into the PATCH handler as a separate pass before any \`setSetting()\` call.

### \`src/shutdown.ts\` (new) + \`src/index.ts\` (refactor)
Extracts the 8-step graceful shutdown logic into \`createShutdown(handles, options)\`. Handles are injectable, exit() and log() are injectable for tests. The index.ts call site is one line; only change is the call site moved past the interval declarations (\`tsc --noEmit\` caught a real "used before declaration" issue when the call was at the original position).

## Test results

\`\`\`
npm test                                                     1196 pass  0 fail
DB_PATH=:memory: npx tsx --test 'src/__tests__/dashboard/...'  314 pass  0 fail
DB_PATH=:memory: npx tsx --test src/__tests__/db/schema...       9 pass  0 fail
npx tsc --noEmit                                                  CLEAN
────────────────────────────────────────────────────────────  ────
Total                                                         1519 pass  0 fail
\`\`\`

## Test plan

- [x] \`npm test\` — 1196/1196 passing
- [x] \`DB_PATH=:memory: npx tsx --test 'src/__tests__/dashboard/**/*.test.ts'\` — 314/314 passing
- [x] \`DB_PATH=:memory: npx tsx --test src/__tests__/db/schema.test.ts\` — 9/9 passing
- [x] \`npx tsc --noEmit\` clean (caught a real "used before declaration" bug during I9 — fixed before commit)
- [x] Each test verified to actually exercise its target branch via log-line side effects, not just pass/fail summaries
- [x] I9 specifically: shutdown.test.ts asserts the exact 8-step ordering via a recorder array — any reorder fails the test loudly

## Lessons applied from PR 1

After PR 1's CI failure on \`tsc --noEmit\` (a \`loadTemplateCache(getDb())\` call with one extra arg), this PR runs \`tsc --noEmit\` BEFORE pushing. It already caught one real bug in the I9 refactor (intervals declared after the createShutdown call) — fixed pre-commit.

## Follow-ups

- PR 3 (NICE-TO-HAVE) — deferred unless requested