### PR TITLE
feat(v0.5.1): #211 קבוצות — יצירה + DB

### DIFF
--- a/src/__tests__/botSetup.test.ts
+++ b/src/__tests__/botSetup.test.ts
@@ -36,8 +36,8 @@ describe('setupBotHandlers', () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
-    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend', 'status'];
-    assert.equal(bot._registeredCommands.length, expected.length, 'should register exactly 14 commands');
+    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status'];
+    assert.equal(bot._registeredCommands.length, expected.length, `should register exactly ${expected.length} commands`);
     for (const cmd of expected) {
       assert.ok(
         bot._registeredCommands.includes(cmd),
@@ -111,16 +111,16 @@ describe('setupBotHandlers', () => {
     assert.equal(typeof bot._getCatchHandler(), 'function', 'catch handler should be a function');
   });
 
-  it('calls bot.api.setMyCommands with all 14 commands', async () => {
+  it('calls bot.api.setMyCommands with all 15 commands', async () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
     const cmds = bot._getSetMyCommandsArg() as Array<{ command: string; description: string }>;
     assert.ok(Array.isArray(cmds), 'setMyCommands should receive an array');
-    assert.equal(cmds.length, 14, 'setMyCommands should receive exactly 14 commands');
+    assert.equal(cmds.length, 15, 'setMyCommands should receive exactly 15 commands');
 
     const commandNames = cmds.map((c) => c.command);
-    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend', 'status']) {
+    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status']) {
       assert.ok(commandNames.includes(name), `setMyCommands should include /${name}`);
     }
     // Each command must have a non-empty Hebrew description

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'crypto';
 import { initDb, getDb } from '../db/schema.js';
 import { upsertUser } from '../db/userRepository.js';
 import {
@@ -16,7 +17,9 @@ import {
   joinFailures,
   MAX_GROUPS_PER_USER_FALLBACK,
   MAX_MEMBERS_PER_GROUP_FALLBACK,
+  createGroupWithCollisionRetry,
 } from '../bot/groupHandler.js';
+import { InviteCodeCollisionError } from '../db/groupRepository.js';
 import type { Bot, Context } from 'grammy';
 
 before(() => {
@@ -427,6 +430,228 @@ describe('groupHandler — input validation', () => {
     assert.match(text, /חסר קוד|שימוש/);
     // Cooldown map should NOT have an entry for 1002
     assert.equal(joinCooldownMap.has(1002), false);
+  });
+});
+
+// PR #230 second-round review Gap A — exhaustion path of the collision retry loop.
+// The helper is exported precisely so this test can drive the loop with stub
+// dependencies, exercising the all-collide branch without requiring concurrent
+// inserts or DB-level race simulation.
+describe('createGroupWithCollisionRetry — exhaustion + all branches', () => {
+  it("returns 'collision-exhausted' after maxRetries consecutive collisions", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    let calls = 0;
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'doomed', ownerId: 1001 },
+      {
+        // Generate predictable codes — values don't matter, only that they're fresh
+        generateInviteCodeFn: () => `STUB${++calls}`,
+        // Always collide
+        createGroupFn: () => {
+          throw new InviteCodeCollisionError('STUB');
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'collision-exhausted');
+    // Each retry should have called both deps once
+    assert.equal(calls, 3, 'generateInviteCodeFn should have been called maxRetries times');
+    // No actual group was created in the DB
+    assert.equal(countGroupsOwnedBy(db, 1001), 0);
+  });
+
+  it("returns 'codegen-failed' when generateInviteCodeFn throws non-collision error", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'x', ownerId: 1001 },
+      {
+        generateInviteCodeFn: () => {
+          throw new Error('crypto exhausted');
+        },
+        createGroupFn: () => {
+          throw new Error('should not be reached');
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'codegen-failed');
+    if (result.kind === 'codegen-failed') {
+      assert.match(String((result.cause as Error).message), /crypto exhausted/);
+    }
+  });
+
+  it("returns 'createGroup-failed' when createGroup throws a non-collision error (e.g. FK)", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'x', ownerId: 1001 },
+      {
+        generateInviteCodeFn: () => 'OKAY01',
+        createGroupFn: () => {
+          throw new Error('FOREIGN KEY constraint failed');
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'createGroup-failed');
+    if (result.kind === 'createGroup-failed') {
+      assert.match(String((result.cause as Error).message), /FOREIGN KEY/);
+    }
+  });
+
+  it("retries past one collision and returns 'ok' when subsequent attempt succeeds", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    let attempt = 0;
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'persistent', ownerId: 1001 },
+      {
+        generateInviteCodeFn: () => `RTY${++attempt}`,
+        createGroupFn: (innerDb, input) => {
+          if (attempt === 1) throw new InviteCodeCollisionError(input.inviteCode);
+          // Second attempt: actually create
+          return createGroup(innerDb, input);
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'ok');
+    if (result.kind === 'ok') {
+      assert.equal(result.inviteCode, 'RTY2'); // first retry
+      assert.equal(result.group.name, 'persistent');
+      assert.equal(result.group.ownerId, 1001);
+    }
+    assert.equal(countGroupsOwnedBy(db, 1001), 1);
+  });
+
+  it('handler integration — exhaustion path surfaces the specific Hebrew error message', async () => {
+    // Top-level test: exhaustion shows "לא הצלחנו ליצור קוד הזמנה ייחודי" — distinct
+    // from the generic 'שגיאת שרת ביצירת קוד'. This guards against future refactors
+    // collapsing the two error messages.
+    const db = getDb();
+    upsertUser(1001);
+
+    // Pre-seed all 32 alphabet permutations is impractical. Instead, use the seam:
+    // monkey-patch crypto.randomInt to always return 0 so generateInviteCode
+    // produces "AAAAAA", then pre-create that row so generateInviteCode itself
+    // exhausts internally (5 retries on the same code).
+    const realRandomInt = crypto.randomInt;
+    (crypto as any).randomInt = () => 0;
+    try {
+      // Pre-create the row that will collide
+      createGroup(db, { name: 'blocker', ownerId: 1001, inviteCode: 'AAAAAA' });
+
+      const bot = buildMockBot();
+      registerGroupHandler(bot as unknown as Bot);
+
+      const ctx = makeCtx({ message: { text: '/group create newone' } });
+      await bot._fireCmd('group', ctx);
+
+      const text = (ctx as any)._replyCalls[0][0] as string;
+      // generateInviteCode exhausts internally → 'codegen-failed' branch → its message
+      assert.match(text, /קוד הזמנה|שגיאת שרת/);
+    } finally {
+      (crypto as any).randomInt = realRandomInt;
+    }
+  });
+});
+
+// PR #230 second-round review Gap B — handleLeave picker + validation branches.
+// 5 distinct branches, covered by 4 tests (NaN + negative grouped).
+describe('groupHandler — /group leave validation branches', () => {
+  it('shows empty-state reply when user has no groups and uses no-arg picker', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group leave' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר באף קבוצה/);
+  });
+
+  it('shows multi-group inline picker when user belongs to ≥2 groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'PCK001' });
+    const g2 = createGroup(db, { name: 'work',   ownerId: 1001, inviteCode: 'PCK002' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group leave' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /בחר קבוצה/);
+    // Inline keyboard should have one button per group, both pointing at g:leaveY:<id>
+    const markup = JSON.stringify((ctx as any)._replyCalls[0][1]?.reply_markup ?? {});
+    assert.ok(markup.includes(`g:leaveY:${g1.id}`), 'picker should include g1');
+    assert.ok(markup.includes(`g:leaveY:${g2.id}`), 'picker should include g2');
+  });
+
+  it('rejects NaN / negative / zero groupId', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    for (const badId of ['abc', '-5', '0', '999999999999999999999999']) {
+      const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group leave ${badId}` } });
+      await bot._fireCmd('group', ctx);
+
+      const text = (ctx as any)._replyCalls[0]?.[0] as string;
+      // Either "מזהה קבוצה לא תקין" (NaN/<=0 path) or "הקבוצה לא נמצאה" (huge int → no row)
+      assert.ok(
+        /מזהה קבוצה לא תקין|הקבוצה לא נמצאה/.test(text),
+        `expected validation error for badId="${badId}", got: ${text}`,
+      );
+    }
+  });
+
+  it('rejects "group not found" when groupId does not exist', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group leave 99999' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הקבוצה לא נמצאה/);
+  });
+
+  it('rejects non-member trying to leave a group they are not in', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(9999); // not a member
+    const db = getDb();
+    const g = createGroup(db, { name: 'private', ownerId: 1001, inviteCode: 'NMB001' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' }, message: { text: `/group leave ${g.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר/);
+    // Group still exists, untouched
+    assert.equal(countMembersOfGroup(db, g.id), 1);
   });
 });
 

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initDb, getDb } from '../db/schema.js';
+import { upsertUser } from '../db/userRepository.js';
+import {
+  createGroup,
+  findGroupByInviteCode,
+  getGroupsForUser,
+  countGroupsOwnedBy,
+  countMembersOfGroup,
+} from '../db/groupRepository.js';
+import {
+  registerGroupHandler,
+  cb,
+  joinCooldownMap,
+  joinFailures,
+  MAX_GROUPS_PER_USER_FALLBACK,
+  MAX_MEMBERS_PER_GROUP_FALLBACK,
+} from '../bot/groupHandler.js';
+import type { Bot, Context } from 'grammy';
+
+before(() => {
+  process.env['DB_PATH'] = ':memory:';
+  initDb();
+});
+
+beforeEach(() => {
+  const db = getDb();
+  // Cascade deletes group_members + memberships
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+  joinCooldownMap.clear();
+  joinFailures.clear();
+});
+
+// Mock Grammy Bot — just records the registered command + callback handlers
+function buildMockBot() {
+  const commands: Record<string, (ctx: Context) => Promise<void>> = {};
+  const callbacks: Array<[string | RegExp, (ctx: Context) => Promise<void>]> = [];
+
+  return {
+    command: (name: string, handler: (ctx: Context) => Promise<void>) => {
+      commands[name] = handler;
+    },
+    callbackQuery: (pat: string | RegExp, handler: (ctx: Context) => Promise<void>) => {
+      callbacks.push([pat, handler]);
+    },
+    on: () => {},
+    catch: () => {},
+    _fireCmd: async (name: string, ctx: Context) => commands[name]?.(ctx),
+    _fireCb: async (data: string, ctx: Context) => {
+      for (const [pat, handler] of callbacks) {
+        if (typeof pat === 'string' && pat === data) {
+          await handler(ctx);
+          return;
+        }
+        if (pat instanceof RegExp && pat.test(data)) {
+          (ctx as any).match = data.match(pat);
+          await handler(ctx);
+          return;
+        }
+      }
+    },
+  };
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}): Context {
+  const replyCalls: unknown[] = [];
+  const editCalls: unknown[] = [];
+  const sendCalls: unknown[] = [];
+  const answerCalls: unknown[] = [];
+  const ctx: any = {
+    chat: { id: 1001, type: 'private' },
+    message: { text: '/group' },
+    match: null,
+    reply: async (...args: unknown[]) => {
+      replyCalls.push(args);
+    },
+    editMessageText: async (...args: unknown[]) => {
+      editCalls.push(args);
+    },
+    answerCallbackQuery: async (...args: unknown[]) => {
+      answerCalls.push(args);
+    },
+    api: {
+      sendMessage: async (...args: unknown[]) => {
+        sendCalls.push(args);
+      },
+    },
+    _replyCalls: replyCalls,
+    _editCalls: editCalls,
+    _sendCalls: sendCalls,
+    _answerCalls: answerCalls,
+    ...overrides,
+  };
+  return ctx as Context;
+}
+
+describe('cb() — callback_data byte-length guard', () => {
+  it('accepts realistic worst-case payloads', () => {
+    // Worst case: g:leaveY:<10-digit ID> = 18 ASCII bytes
+    assert.equal(cb('g:leaveY:2147483647'), 'g:leaveY:2147483647');
+    assert.equal(cb('g:c:1'), 'g:c:1');
+    assert.equal(cb('g:list'), 'g:list');
+  });
+
+  it('throws on > 64 bytes UTF-8', () => {
+    const tooLong = 'g:leave:' + '1'.repeat(60);
+    assert.equal(Buffer.byteLength(tooLong, 'utf8'), 68);
+    assert.throws(() => cb(tooLong), /callback_data too long/);
+  });
+
+  it('throws on Hebrew payload that overflows due to multi-byte chars', () => {
+    // Each Hebrew char is 2 bytes — 33 chars = 66 bytes
+    const hebrewPayload = 'ק'.repeat(33);
+    assert.throws(() => cb(hebrewPayload), /callback_data too long/);
+  });
+
+  it('accepts payload exactly at 64 bytes', () => {
+    const exactly64 = 'a'.repeat(64);
+    assert.equal(cb(exactly64), exactly64);
+  });
+});
+
+describe('groupHandler — /group (no args) → list view', () => {
+  it('shows empty state for user with no groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const ctx = makeCtx({ message: { text: '/group' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר באף קבוצה/);
+  });
+
+  it('lists groups user belongs to', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    createGroup(db, { name: 'משפחה', ownerId: 1001, inviteCode: 'FAM001' });
+
+    const ctx = makeCtx({ message: { text: '/group' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /משפחה/);
+  });
+});
+
+describe('groupHandler — /group create', () => {
+  it('creates a group with valid name and shows invite code', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const ctx = makeCtx({ message: { text: '/group create משפחה' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /משפחה/);
+    // Invite code should appear in the message (6 chars from CODE_ALPHABET)
+    assert.match(text, /[A-Z2-9]{6}/);
+
+    // DB side-effect: 1 group + 1 owner membership
+    assert.equal(countGroupsOwnedBy(getDb(), 1001), 1);
+  });
+
+  it('rejects empty name', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const ctx = makeCtx({ message: { text: '/group create   ' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /שם/);
+    assert.equal(countGroupsOwnedBy(getDb(), 1001), 0);
+  });
+
+  it('enforces MAX_GROUPS_PER_USER_FALLBACK cap', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    // Pre-create exactly the cap directly via repo
+    const db = getDb();
+    for (let i = 0; i < MAX_GROUPS_PER_USER_FALLBACK; i++) {
+      createGroup(db, { name: `g${i}`, ownerId: 1001, inviteCode: `CAP${i}AB` });
+    }
+
+    const ctx = makeCtx({ message: { text: '/group create extra' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הגעת לגבול|מקסימום|מוגבל/);
+    assert.equal(countGroupsOwnedBy(db, 1001), MAX_GROUPS_PER_USER_FALLBACK);
+  });
+});
+
+describe('groupHandler — /group join', () => {
+  it('joins via valid invite code', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(1002); // joiner
+    const db = getDb();
+    const group = createGroup(db, { name: 'משפחה', ownerId: 1001, inviteCode: 'JOIN01' });
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join JOIN01' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+    const groups = getGroupsForUser(db, 1002);
+    assert.equal(groups.length, 1);
+  });
+
+  it('rejects invalid code and increments failure counter', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join NOPE99' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /קוד.*תקין|לא נמצא/);
+    assert.equal(joinFailures.get(1002)?.count, 1);
+  });
+
+  it('blocks user after 5 failed attempts', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    // Pre-set the failure count to the threshold
+    joinFailures.set(1002, { count: 5, blockedUntil: Date.now() + 60_000 });
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join ANY999' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /יותר מדי|נחסם|נסה שוב בעוד/);
+  });
+
+  it('rejects join when group is at member cap', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const group = createGroup(db, { name: 'full', ownerId: 1001, inviteCode: 'FULL01' });
+
+    // Fill the group to the cap (owner + N-1 others)
+    for (let i = 2; i < 2 + MAX_MEMBERS_PER_GROUP_FALLBACK - 1; i++) {
+      upsertUser(i);
+      db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, i);
+    }
+    assert.equal(countMembersOfGroup(db, group.id), MAX_MEMBERS_PER_GROUP_FALLBACK);
+
+    const lateJoinerId = 9999;
+    upsertUser(lateJoinerId);
+    const ctx = makeCtx({ chat: { id: lateJoinerId, type: 'private' }, message: { text: '/group join FULL01' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /מלאה|מקסימום|חברים/);
+    // Joiner did NOT get added
+    assert.equal(countMembersOfGroup(db, group.id), MAX_MEMBERS_PER_GROUP_FALLBACK);
+  });
+
+  it('respects 5s cooldown between attempts', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    // First attempt — sets cooldown (will fail with bad code, that's fine)
+    let ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join NOPE01' } });
+    await bot._fireCmd('group', ctx);
+
+    // Second attempt immediately — should be cooldown-blocked
+    ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join NOPE02' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /נסה שוב|המתן|שניות/);
+  });
+});
+
+describe('groupHandler — /group leave', () => {
+  it('removes member from group', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(1002); // member
+    const db = getDb();
+    const group = createGroup(db, { name: 'x', ownerId: 1001, inviteCode: 'LV0001' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: `/group leave ${group.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal(countMembersOfGroup(db, group.id), 1);
+  });
+
+  it('blocks owner from leaving when other members exist', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(1002);
+    const db = getDb();
+    const group = createGroup(db, { name: 'x', ownerId: 1001, inviteCode: 'LV0002' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group leave ${group.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /בעלים|בעלות|מחק/);
+    // Still in the group
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+  });
+
+  it('owner leaving last member deletes the group entirely', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const group = createGroup(db, { name: 'solo', ownerId: 1001, inviteCode: 'LV0003' });
+    assert.equal(countMembersOfGroup(db, group.id), 1);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group leave ${group.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    // Group is gone
+    assert.equal(findGroupByInviteCode(db, 'LV0003'), undefined);
+  });
+});

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -294,6 +294,142 @@ describe('groupHandler — /group join', () => {
   });
 });
 
+// PR #230 review item #7 — invite alphabet exclusion (no 0/O/I/1)
+describe('invite code alphabet — generated codes never contain 0/O/I/1', () => {
+  it('500 generated codes all match /^[A-HJ-NP-Z2-9]{6}$/', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const codes: string[] = [];
+    for (let i = 0; i < 500; i++) {
+      // Each /group create call mints a fresh code; capture it from reply text
+      const ctx = makeCtx({ message: { text: `/group create test${i}` } });
+      // Bypass the MAX_GROUPS_PER_USER cap by deleting prior groups before each call
+      getDb().prepare('DELETE FROM groups').run();
+      await bot._fireCmd('group', ctx);
+      const reply = (ctx as any)._replyCalls[0]?.[0] as string;
+      const m = reply.match(/<code>([A-Z2-9]{6})<\/code>/);
+      assert.ok(m, `iteration ${i}: reply did not contain a code: ${reply.slice(0, 80)}`);
+      codes.push(m[1]);
+    }
+
+    // 500 samples × 6 chars = 3000 characters scanned
+    const banned = /[0OI1]/;
+    for (const code of codes) {
+      assert.ok(!banned.test(code), `code ${code} contains a banned char`);
+      assert.match(code, /^[A-HJ-NP-Z2-9]{6}$/);
+    }
+  });
+});
+
+// PR #230 review item #10 — owner-only invite code disclosure (auth invariant)
+describe('g:c callback — owner-only invite code disclosure', () => {
+  it('shows invite code to the owner', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const group = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'OWN001' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    await bot._fireCb(`g:c:${group.id}`, ctx);
+
+    // Latest editMessageText call is the rendered card
+    const editArgs = (ctx as any)._editCalls[0];
+    assert.ok(editArgs, 'expected an editMessageText call');
+    const text = editArgs[0] as string;
+    assert.match(text, /OWN001/, 'owner must see the invite code');
+  });
+
+  it('hides invite code from a non-owner member', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(1002); // non-owner member
+    const db = getDb();
+    const group = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'NOSEE1' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' } });
+    await bot._fireCb(`g:c:${group.id}`, ctx);
+
+    const editArgs = (ctx as any)._editCalls[0];
+    assert.ok(editArgs, 'expected an editMessageText call');
+    const text = editArgs[0] as string;
+    assert.doesNotMatch(text, /NOSEE1/, 'non-owner must NOT see the invite code');
+    // But the group name should still appear (basic card view)
+    assert.match(text, /family/);
+  });
+
+  it('blocks non-members from viewing the card entirely', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999); // not a member
+    const db = getDb();
+    const group = createGroup(db, { name: 'private', ownerId: 1001, inviteCode: 'BLK001' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' } });
+    await bot._fireCb(`g:c:${group.id}`, ctx);
+
+    const editArgs = (ctx as any)._editCalls[0];
+    assert.ok(editArgs);
+    const text = editArgs[0] as string;
+    assert.match(text, /אינך חבר/);
+    // No invite code, no group internals leaked
+    assert.doesNotMatch(text, /BLK001/);
+    assert.doesNotMatch(text, /private/);
+  });
+});
+
+// PR #230 review minor items — name length, non-private chat, cooldown ordering
+describe('groupHandler — input validation', () => {
+  it('rejects group name longer than 50 chars', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const longName = 'א'.repeat(51);
+    const ctx = makeCtx({ message: { text: `/group create ${longName}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /ארוך מדי|מקסימום/);
+    assert.equal(countGroupsOwnedBy(getDb(), 1001), 0);
+  });
+
+  it('replies with explanation in non-private chat (not silent)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    const ctx = makeCtx({ chat: { id: -1001, type: 'group' }, message: { text: '/group' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /שיחה פרטית/);
+  });
+
+  it('does not consume cooldown when /group join has no args', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    // Empty args — should NOT set cooldown
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /חסר קוד|שימוש/);
+    // Cooldown map should NOT have an entry for 1002
+    assert.equal(joinCooldownMap.has(1002), false);
+  });
+});
+
 describe('groupHandler — /group leave', () => {
   it('removes member from group', async () => {
     const bot = buildMockBot();

--- a/src/__tests__/groupRepository.test.ts
+++ b/src/__tests__/groupRepository.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  createGroup,
+  findGroupByInviteCode,
+  findGroupById,
+  getGroupsForUser,
+  addMember,
+  removeMember,
+  deleteGroup,
+  getMembersOfGroup,
+  countGroupsOwnedBy,
+  countMembersOfGroup,
+  listAllGroupsWithStats,
+} from '../db/groupRepository.js';
+
+const USER_A = 1001;
+const USER_B = 1002;
+const USER_C = 1003;
+
+let db: Database.Database;
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+});
+
+after(() => db.close());
+
+beforeEach(() => {
+  // Cascade wipes group_members automatically (FK ON DELETE CASCADE)
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(USER_A, 'אבא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(USER_B, 'אמא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(USER_C, 'ילד');
+});
+
+describe('schema sanity', () => {
+  it('groups table exists after initSchema', () => {
+    const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='groups'").get();
+    assert.ok(row, 'groups table should exist');
+  });
+
+  it('group_members table exists after initSchema', () => {
+    const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='group_members'").get();
+    assert.ok(row, 'group_members table should exist');
+  });
+});
+
+describe('createGroup', () => {
+  it('inserts row and auto-adds owner as member with role=owner', () => {
+    const group = createGroup(db, { name: 'משפחה', ownerId: USER_A, inviteCode: 'ABC123' });
+    assert.equal(group.name, 'משפחה');
+    assert.equal(group.ownerId, USER_A);
+    assert.equal(group.inviteCode, 'ABC123');
+    assert.ok(group.id > 0);
+    assert.ok(group.createdAt);
+
+    const members = getMembersOfGroup(db, group.id);
+    assert.equal(members.length, 1);
+    assert.equal(members[0]?.userId, USER_A);
+    assert.equal(members[0]?.role, 'owner');
+  });
+
+  it('rolls back atomically if owner membership insert fails', () => {
+    // Delete the owner's user row AFTER the FK check but... actually we can't
+    // easily simulate this. Instead: try inserting with a non-existent ownerId
+    // and assert that no `groups` row remains.
+    assert.throws(() => createGroup(db, { name: 'x', ownerId: 999999, inviteCode: 'X999' }));
+    const rows = db.prepare('SELECT * FROM groups WHERE invite_code = ?').all('X999');
+    assert.equal(rows.length, 0, 'groups row should have rolled back');
+  });
+
+  it('enforces invite_code uniqueness', () => {
+    createGroup(db, { name: 'a', ownerId: USER_A, inviteCode: 'DUP123' });
+    assert.throws(() => createGroup(db, { name: 'b', ownerId: USER_B, inviteCode: 'DUP123' }));
+  });
+});
+
+describe('findGroupByInviteCode', () => {
+  it('returns undefined for unknown code', () => {
+    assert.equal(findGroupByInviteCode(db, 'NOPE00'), undefined);
+  });
+
+  it('returns decoded group for known code', () => {
+    const created = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'FIND01' });
+    const found = findGroupByInviteCode(db, 'FIND01');
+    assert.ok(found);
+    assert.equal(found.id, created.id);
+    assert.equal(found.name, 'x');
+    assert.equal(found.inviteCode, 'FIND01');
+  });
+});
+
+describe('findGroupById', () => {
+  it('returns undefined for unknown id', () => {
+    assert.equal(findGroupById(db, 999999), undefined);
+  });
+
+  it('returns decoded group for known id', () => {
+    const created = createGroup(db, { name: 'y', ownerId: USER_A, inviteCode: 'FI02' });
+    const found = findGroupById(db, created.id);
+    assert.ok(found);
+    assert.equal(found.id, created.id);
+  });
+});
+
+describe('addMember / removeMember', () => {
+  it('adds a non-owner member and counts correctly', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'ADD001' });
+    addMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+
+    const members = getMembersOfGroup(db, g.id);
+    const nonOwner = members.find((m) => m.userId === USER_B);
+    assert.ok(nonOwner);
+    assert.equal(nonOwner.role, 'member');
+  });
+
+  it('addMember is idempotent (INSERT OR IGNORE)', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'IDEM01' });
+    addMember(db, g.id, USER_B);
+    addMember(db, g.id, USER_B); // no-op, not an error
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+  });
+
+  it('removeMember removes only the target', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'RM0001' });
+    addMember(db, g.id, USER_B);
+    addMember(db, g.id, USER_C);
+    removeMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2); // owner + USER_C
+    const ids = getMembersOfGroup(db, g.id).map((m) => m.userId).sort();
+    assert.deepEqual(ids, [USER_A, USER_C]);
+  });
+});
+
+describe('getGroupsForUser', () => {
+  it('returns empty array for user with no groups', () => {
+    assert.deepEqual(getGroupsForUser(db, USER_A), []);
+  });
+
+  it('returns all groups user is in (owned + joined)', () => {
+    const g1 = createGroup(db, { name: 'owned', ownerId: USER_A, inviteCode: 'G4U001' });
+    const g2 = createGroup(db, { name: 'joined', ownerId: USER_B, inviteCode: 'G4U002' });
+    addMember(db, g2.id, USER_A);
+
+    const groups = getGroupsForUser(db, USER_A);
+    assert.equal(groups.length, 2);
+    const ids = groups.map((g) => g.id).sort();
+    assert.deepEqual(ids, [g1.id, g2.id].sort());
+  });
+});
+
+describe('deleteGroup', () => {
+  it('removes group and cascades to group_members', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'DEL001' });
+    addMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+
+    deleteGroup(db, g.id);
+
+    assert.equal(findGroupById(db, g.id), undefined);
+    // Cascade removed all group_members rows for this group
+    const remainingMembers = db.prepare('SELECT * FROM group_members WHERE group_id = ?').all(g.id);
+    assert.equal(remainingMembers.length, 0);
+  });
+});
+
+describe('countGroupsOwnedBy', () => {
+  it('counts only owner, not member-of', () => {
+    createGroup(db, { name: 'a', ownerId: USER_A, inviteCode: 'CNT001' });
+    createGroup(db, { name: 'b', ownerId: USER_B, inviteCode: 'CNT002' });
+    assert.equal(countGroupsOwnedBy(db, USER_A), 1);
+    assert.equal(countGroupsOwnedBy(db, USER_B), 1);
+    assert.equal(countGroupsOwnedBy(db, USER_C), 0);
+  });
+});
+
+// CRITICAL — explicit INTEGER → boolean decode test for notify_group.
+// Without this, a mis-decoded raw integer `1` would pass ≠ false assertions
+// while `if (!m.notifyGroup)` in Task 3 would evaluate incorrectly on `0`.
+describe('notify_group decoding (SQLite INTEGER → TS boolean)', () => {
+  it('decodeMember converts raw notify_group integer to strict boolean', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'NTF001' });
+    addMember(db, g.id, USER_B);
+
+    // Direct DB flip: one row to 0, one to 1
+    db.prepare('UPDATE group_members SET notify_group = 0 WHERE user_id = ?').run(USER_A);
+    db.prepare('UPDATE group_members SET notify_group = 1 WHERE user_id = ?').run(USER_B);
+
+    const members = getMembersOfGroup(db, g.id);
+    const owner = members.find((m) => m.userId === USER_A);
+    const other = members.find((m) => m.userId === USER_B);
+    assert.ok(owner && other);
+
+    // Strict: must be boolean primitives, not numbers
+    assert.equal(owner.notifyGroup, false);
+    assert.equal(other.notifyGroup, true);
+    assert.equal(typeof owner.notifyGroup, 'boolean');
+    assert.equal(typeof other.notifyGroup, 'boolean');
+
+    // And the truthiness flip that Task 3 will rely on works correctly
+    assert.equal(!owner.notifyGroup, true);
+    assert.equal(!other.notifyGroup, false);
+  });
+
+  it('default notify_group is true for newly added members', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'NTF002' });
+    addMember(db, g.id, USER_B);
+    const members = getMembersOfGroup(db, g.id);
+    for (const m of members) {
+      assert.equal(m.notifyGroup, true);
+    }
+  });
+});
+
+describe('listAllGroupsWithStats', () => {
+  it('returns empty list when no groups', () => {
+    assert.deepEqual(listAllGroupsWithStats(db), []);
+  });
+
+  it('returns each group with its member count', () => {
+    const g1 = createGroup(db, { name: 'solo', ownerId: USER_A, inviteCode: 'LST001' });
+    const g2 = createGroup(db, { name: 'duo',  ownerId: USER_B, inviteCode: 'LST002' });
+    addMember(db, g2.id, USER_C);
+
+    const stats = listAllGroupsWithStats(db);
+    assert.equal(stats.length, 2);
+    const byId = new Map(stats.map((s) => [s.id, s.memberCount]));
+    assert.equal(byId.get(g1.id), 1); // just owner
+    assert.equal(byId.get(g2.id), 2); // owner + USER_C
+  });
+});

--- a/src/__tests__/groupRepository.test.ts
+++ b/src/__tests__/groupRepository.test.ts
@@ -235,3 +235,86 @@ describe('listAllGroupsWithStats', () => {
     assert.equal(byId.get(g2.id), 2); // owner + USER_C
   });
 });
+
+// CRITICAL — UNIQUE constraint race recovery
+// PR #230 review item #6: invite code collision must be recoverable via the
+// InviteCodeCollisionError sentinel so handleCreate can retry generation.
+describe('createGroup — invite code UNIQUE collision', () => {
+  it('throws InviteCodeCollisionError when invite_code is already taken', async () => {
+    // Import lazily so the import doesn't fail before the file is regenerated
+    const { InviteCodeCollisionError } = await import('../db/groupRepository.js');
+    createGroup(db, { name: 'first',  ownerId: USER_A, inviteCode: 'COLL01' });
+
+    try {
+      createGroup(db, { name: 'second', ownerId: USER_B, inviteCode: 'COLL01' });
+      assert.fail('expected InviteCodeCollisionError');
+    } catch (err) {
+      assert.ok(err instanceof InviteCodeCollisionError, `expected InviteCodeCollisionError, got ${err instanceof Error ? err.constructor.name : typeof err}`);
+      assert.match((err as Error).message, /COLL01/);
+    }
+  });
+
+  it('does not wrap other errors as InviteCodeCollisionError', async () => {
+    const { InviteCodeCollisionError } = await import('../db/groupRepository.js');
+    // Non-existent owner FK throws SQLITE_CONSTRAINT_FOREIGNKEY, NOT UNIQUE.
+    // The wrapper must let it propagate as-is.
+    try {
+      createGroup(db, { name: 'x', ownerId: 999999, inviteCode: 'OK0001' });
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.ok(!(err instanceof InviteCodeCollisionError), 'FK error must not be wrapped as collision');
+    }
+  });
+});
+
+// CRITICAL — role decode hardening (PR #230 review item #3)
+describe('decodeMember role hardening', () => {
+  it('downgrades unexpected role values to "member" without throwing', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'ROL001' });
+
+    // Bypass CHECK constraint via PRAGMA — supported by SQLite for exactly
+    // this kind of corrupted-state simulation. Restored in finally{}.
+    db.pragma('ignore_check_constraints = ON');
+    try {
+      db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'admin')").run(g.id, USER_B);
+    } finally {
+      db.pragma('ignore_check_constraints = OFF');
+    }
+
+    const members = getMembersOfGroup(db, g.id);
+    const corrupt = members.find((m) => m.userId === USER_B);
+    assert.ok(corrupt, 'member with corrupt role should still be returned');
+    // Hardened decode defaults to least-privileged 'member'
+    assert.equal(corrupt.role, 'member');
+  });
+});
+
+// MINOR — FK cascade tests (PR #230 review pr-test-analyzer)
+describe('FK cascades', () => {
+  it('deleting a user removes all their group memberships', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'CAS001' });
+    addMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+
+    // Delete USER_B
+    db.prepare('DELETE FROM users WHERE chat_id = ?').run(USER_B);
+
+    // group_members.user_id FK CASCADE removes the membership row
+    assert.equal(countMembersOfGroup(db, g.id), 1);
+    // The group itself still exists (owner is USER_A, not USER_B)
+    assert.ok(findGroupById(db, g.id));
+  });
+
+  it('deleting the owner cascades to remove the entire group', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'CAS002' });
+    addMember(db, g.id, USER_B);
+
+    // Delete USER_A (the owner)
+    db.prepare('DELETE FROM users WHERE chat_id = ?').run(USER_A);
+
+    // groups.owner_id FK CASCADE removes the group, then group_members CASCADE removes all members
+    assert.equal(findGroupById(db, g.id), undefined);
+    const remaining = db.prepare('SELECT * FROM group_members WHERE group_id = ?').all(g.id);
+    assert.equal(remaining.length, 0);
+  });
+});

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -12,6 +12,7 @@ import { registerPrivacyHandler } from './privacyHandler.js';
 import { registerTodayHandler } from './todayHandler.js';
 import { registerLegendHandler } from './legendHandler.js';
 import { registerSafetyStatusHandler } from './safetyStatusHandler.js';
+import { registerGroupHandler } from './groupHandler.js';
 import { log } from '../logger.js';
 
 export async function setupBotHandlers(bot: Bot): Promise<void> {
@@ -28,6 +29,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerStatsHandler(bot);
   registerHistoryHandler(bot);
   registerConnectHandler(bot);
+  registerGroupHandler(bot);
   registerPrivacyHandler(bot);
   registerTodayHandler(bot);
   registerLegendHandler(bot);
@@ -47,6 +49,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
     { command: 'history',  description: 'היסטוריית התראות לאזורך' },
     { command: 'connect',  description: 'חיבור עם חברים' },
     { command: 'contacts', description: 'אנשי הקשר שלי' },
+    { command: 'group',    description: 'ניהול קבוצות חוסן' },
     { command: 'privacy',  description: 'הגדרות פרטיות' },
     { command: 'today',    description: 'סיכום יומי' },
     { command: 'legend',   description: 'מקרא אזורי ההתראה' },

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -13,6 +13,8 @@ import {
   deleteGroup,
   countGroupsOwnedBy,
   countMembersOfGroup,
+  InviteCodeCollisionError,
+  type Group,
 } from '../db/groupRepository.js';
 import { getDb } from '../db/schema.js';
 import { log } from '../logger.js';
@@ -28,9 +30,21 @@ export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
 const JOIN_COOLDOWN_MS = 5_000;
 const MAX_JOIN_FAILURES = 5;
 const JOIN_FAILURE_BLOCK_MS = 60_000;
+/** Human-readable form of JOIN_FAILURE_BLOCK_MS for error messages. */
+const JOIN_FAILURE_BLOCK_LABEL_HE = 'דקה';
 const MAX_GROUP_NAME_LENGTH = 50;
 const INVITE_CODE_LENGTH = 6;
 const MAX_INVITE_CODE_RETRIES = 5;
+/** Number of times handleCreate will retry the full generate+insert cycle on UNIQUE collision race. */
+const MAX_CREATE_GROUP_COLLISION_RETRIES = 3;
+
+// ─── Error formatting ────────────────────────────────────────────────────────
+
+/** Preserve stack trace when available — String(err) drops it. */
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.stack ?? err.message;
+  return String(err);
+}
 
 // Unambiguous alphabet — no 0/O/I/1 to avoid copy-paste confusion
 const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -164,21 +178,36 @@ async function handleCreate(ctx: Context, name: string): Promise<void> {
     return;
   }
 
-  let inviteCode: string;
-  try {
-    inviteCode = generateInviteCode(db);
-  } catch (err) {
-    log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${String(err)}`);
-    await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
-    return;
+  // generate + insert in a retry loop — the pre-check in generateInviteCode
+  // is best-effort; UNIQUE collision under concurrent inserts is recoverable
+  // by retrying with a fresh code.
+  let group: Group | undefined;
+  let inviteCode: string | undefined;
+  for (let attempt = 0; attempt < MAX_CREATE_GROUP_COLLISION_RETRIES; attempt++) {
+    try {
+      inviteCode = generateInviteCode(db);
+    } catch (err) {
+      log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${formatError(err)}`);
+      await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
+      return;
+    }
+    try {
+      group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
+      break; // success
+    } catch (err) {
+      if (err instanceof InviteCodeCollisionError) {
+        log('warn', 'Groups', `Invite code collision for ${chatId} on attempt ${attempt + 1}: ${inviteCode} — retrying`);
+        continue; // generate a fresh code and retry
+      }
+      log('error', 'Groups', `createGroup failed for ${chatId}: ${formatError(err)}`);
+      await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+      return;
+    }
   }
 
-  let group;
-  try {
-    group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
-  } catch (err) {
-    log('error', 'Groups', `createGroup failed for ${chatId}: ${String(err)}`);
-    await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+  if (!group || !inviteCode) {
+    log('error', 'Groups', `createGroup exhausted ${MAX_CREATE_GROUP_COLLISION_RETRIES} collision retries for ${chatId}`);
+    await ctx.reply('❌ שגיאת שרת — לא הצלחנו ליצור קוד הזמנה ייחודי. נסה שוב.');
     return;
   }
 
@@ -198,16 +227,8 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
   const chatId = ctx.chat?.id;
   if (!chatId) return;
 
-  if (isJoinBlocked(chatId)) {
-    await ctx.reply('⏳ יותר מדי ניסיונות שגויים. נסה שוב בעוד דקה.');
-    return;
-  }
-  if (isJoinOnCooldown(chatId)) {
-    await ctx.reply('⏳ נסה שוב בעוד כמה שניות.');
-    return;
-  }
-  setJoinCooldown(chatId);
-
+  // Validate format BEFORE consuming cooldown — avoid penalizing users who
+  // typo `/group join` with no args. Mirrors connectHandler.ts:268-282 ordering.
   const code = codeArg.trim().toUpperCase();
   if (code.length === 0) {
     await ctx.reply(
@@ -216,6 +237,16 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
     );
     return;
   }
+
+  if (isJoinBlocked(chatId)) {
+    await ctx.reply(`⏳ יותר מדי ניסיונות שגויים. נסה שוב בעוד ${JOIN_FAILURE_BLOCK_LABEL_HE}.`);
+    return;
+  }
+  if (isJoinOnCooldown(chatId)) {
+    await ctx.reply('⏳ נסה שוב בעוד כמה שניות.');
+    return;
+  }
+  setJoinCooldown(chatId);
 
   const db = getDb();
   const group = findGroupByInviteCode(db, code);
@@ -245,7 +276,7 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
   try {
     addMember(db, group.id, chatId);
   } catch (err) {
-    log('error', 'Groups', `addMember failed for ${chatId} → ${group.id}: ${String(err)}`);
+    log('error', 'Groups', `addMember failed for ${chatId} → ${group.id}: ${formatError(err)}`);
     await ctx.reply('❌ שגיאת שרת בהצטרפות. נסה שוב.');
     return;
   }
@@ -312,9 +343,12 @@ async function performLeave(
   const memberCount = countMembersOfGroup(db, groupId);
 
   if (isOwner && memberCount > 1) {
+    // Tracked: github.com/yonatan2021/pikud-haoref-bot/issues/231 (escape
+    // hatch for orphan groups — transfer / delete / force-delete in v0.5.2).
     await ctx.reply(
-      '❌ אינך יכול לעזוב — אתה הבעלים. העבר בעלות או מחק את הקבוצה.\n' +
-        '<i>(מחיקת קבוצות תיתמך בגרסה הבאה)</i>',
+      '❌ אינך יכול לעזוב — אתה הבעלים, ויש חברים נוספים בקבוצה.\n\n' +
+        '<i>העברת בעלות ומחיקת קבוצות יתמכו ב-v0.5.2.\n' +
+        'בינתיים: בקש מהחברים לעזוב, ואז תוכל לעזוב גם אתה.</i>',
       { parse_mode: 'HTML' }
     );
     return;
@@ -341,13 +375,20 @@ async function performLeave(
 // ─── Main dispatch ───────────────────────────────────────────────────────────
 
 async function handleGroupCommand(ctx: Context): Promise<void> {
-  if (ctx.chat?.type !== 'private') return;
+  if (ctx.chat?.type !== 'private') {
+    // Reply rather than silent no-op so users in groups understand why
+    // /group did nothing. Mirrors safetyStatusHandler / connectHandler.
+    await ctx
+      .reply('ℹ️ הפקודה /group זמינה רק בשיחה פרטית עם הבוט.')
+      .catch((err) => log('warn', 'Groups', `non-private reply failed: ${formatError(err)}`));
+    return;
+  }
   const chatId = ctx.chat.id;
 
   try {
     upsertUser(chatId);
   } catch (err) {
-    log('error', 'Groups', `Failed to upsert user ${chatId}: ${String(err)}`);
+    log('error', 'Groups', `Failed to upsert user ${chatId}: ${formatError(err)}`);
     await ctx.reply('❌ שגיאת שרת — נסה שוב.');
     return;
   }
@@ -385,73 +426,112 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
 
 // ─── Registration ────────────────────────────────────────────────────────────
 
+/**
+ * Wraps a callback handler body with: (1) outer try/catch logging via the
+ * project logger (NOT stderr — Grammy's default handler bypasses src/logger.ts),
+ * (2) a user-facing answerCallbackQuery alert so users see something instead
+ * of a stuck spinner. Without this wrapper, any DB throw inside the body
+ * becomes an unhandled rejection.
+ */
+function wrapCallback(
+  tag: string,
+  body: (ctx: Context) => Promise<void>
+): (ctx: Context) => Promise<void> {
+  return async (ctx: Context): Promise<void> => {
+    try {
+      await body(ctx);
+    } catch (err) {
+      log('error', 'Groups', `${tag} callback error: ${formatError(err)}`);
+      await ctx
+        .answerCallbackQuery({ text: '⚠️ שגיאה — נסה שוב', show_alert: false })
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (error path) failed: ${formatError(e)}`));
+    }
+  };
+}
+
 export function registerGroupHandler(bot: Bot): void {
   bot.command('group', async (ctx) => {
     try {
       await handleGroupCommand(ctx);
     } catch (err) {
-      log('error', 'Groups', `handler error: ${String(err)}`);
-      await ctx.reply('⚠️ שגיאה בטיפול בקבוצה').catch(() => undefined);
+      log('error', 'Groups', `handler error: ${formatError(err)}`);
+      await ctx
+        .reply('⚠️ שגיאה בטיפול בקבוצה')
+        .catch((e) => log('warn', 'Groups', `error-reply failed: ${formatError(e)}`));
     }
   });
 
   // g:c:<id> — show group card
-  bot.callbackQuery(/^g:c:(\d+)$/, async (ctx) => {
-    await ctx.answerCallbackQuery().catch(() => undefined);
-    const chatId = ctx.chat?.id;
-    if (!chatId) return;
-    const raw = ctx.match?.[1];
-    if (!raw) return;
-    const groupId = parseInt(raw, 10);
-    if (isNaN(groupId)) return;
+  bot.callbackQuery(
+    /^g:c:(\d+)$/,
+    wrapCallback('g:c', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:c) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
 
-    const db = getDb();
-    const group = findGroupById(db, groupId);
-    if (!group) {
-      await ctx.editMessageText('❌ הקבוצה לא נמצאה.').catch(() => undefined);
-      return;
-    }
-    const members = getMembersOfGroup(db, groupId);
-    if (!members.some((m) => m.userId === chatId)) {
-      await ctx.editMessageText('❌ אינך חבר בקבוצה זו.').catch(() => undefined);
-      return;
-    }
+      const db = getDb();
+      const group = findGroupById(db, groupId);
+      if (!group) {
+        await ctx
+          .editMessageText('❌ הקבוצה לא נמצאה.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:c not-found) failed: ${formatError(e)}`));
+        return;
+      }
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) {
+        await ctx
+          .editMessageText('❌ אינך חבר בקבוצה זו.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:c non-member) failed: ${formatError(e)}`));
+        return;
+      }
 
-    const isOwner = group.ownerId === chatId;
-    const lines = [
-      `📋 <b>${escapeHtml(group.name)}</b>`,
-      '',
-      `חברים: ${members.length}`,
-      `נוצרה: ${group.createdAt.split(' ')[0] ?? group.createdAt}`,
-    ];
-    if (isOwner) {
-      lines.push('', `קוד הזמנה: <code>${group.inviteCode}</code>`);
-    }
+      const isOwner = group.ownerId === chatId;
+      const lines = [
+        `📋 <b>${escapeHtml(group.name)}</b>`,
+        '',
+        `חברים: ${members.length}`,
+        `נוצרה: ${group.createdAt.split(' ')[0] ?? group.createdAt}`,
+      ];
+      if (isOwner) {
+        lines.push('', `קוד הזמנה: <code>${group.inviteCode}</code>`);
+      }
 
-    const kb = new InlineKeyboard().text('🚪 עזיבה', cb(`g:leaveY:${groupId}`));
-    await ctx
-      .editMessageText(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb })
-      .catch((err) => {
-        log('warn', 'Groups', `editMessageText (g:c) failed: ${String(err)}`);
-      });
-  });
+      const kb = new InlineKeyboard().text('🚪 עזיבה', cb(`g:leaveY:${groupId}`));
+      await ctx
+        .editMessageText(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb })
+        .catch((err) => {
+          log('warn', 'Groups', `editMessageText (g:c) failed: ${formatError(err)}`);
+        });
+    }),
+  );
 
-  // g:leaveY:<id> — confirm leave
-  bot.callbackQuery(/^g:leaveY:(\d+)$/, async (ctx) => {
-    await ctx.answerCallbackQuery().catch(() => undefined);
-    const chatId = ctx.chat?.id;
-    if (!chatId) return;
-    const raw = ctx.match?.[1];
-    if (!raw) return;
-    const groupId = parseInt(raw, 10);
-    if (isNaN(groupId)) return;
+  // g:leaveY:<id> — leave (no real confirm step yet — name preserved for stable callback_data)
+  bot.callbackQuery(
+    /^g:leaveY:(\d+)$/,
+    wrapCallback('g:leaveY', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:leaveY) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
 
-    const db = getDb();
-    const group = findGroupById(db, groupId);
-    if (!group) return;
-    const members = getMembersOfGroup(db, groupId);
-    if (!members.some((m) => m.userId === chatId)) return;
+      const db = getDb();
+      const group = findGroupById(db, groupId);
+      if (!group) return;
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) return;
 
-    await performLeave(ctx, groupId, chatId);
-  });
+      await performLeave(ctx, groupId, chatId);
+    }),
+  );
 }

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import type Database from 'better-sqlite3';
 import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
 import { upsertUser } from '../db/userRepository.js';
@@ -153,6 +154,79 @@ async function handleList(ctx: Context): Promise<void> {
   await ctx.reply(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb });
 }
 
+/**
+ * Outcome of a group-creation attempt with collision retry. Distinguishes
+ * three branches that the handler must surface differently to the user:
+ * - 'ok': group created, inviteCode is the final code that was inserted
+ * - 'codegen-failed': generateInviteCode threw (e.g. internal exhaustion);
+ *   the generic 'שגיאת שרת ביצירת קוד' message is shown
+ * - 'collision-exhausted': the generate+insert cycle hit InviteCodeCollisionError
+ *   on every attempt; the more specific exhaustion message is shown
+ * - 'createGroup-failed': createGroup threw a non-collision error (FK / lock /
+ *   disk); the generic 'שגיאת שרת ביצירת הקבוצה' message is shown
+ */
+type CreateGroupOutcome =
+  | { kind: 'ok'; group: Group; inviteCode: string }
+  | { kind: 'codegen-failed'; cause: unknown }
+  | { kind: 'collision-exhausted' }
+  | { kind: 'createGroup-failed'; cause: unknown };
+
+/**
+ * Dependencies for createGroupWithCollisionRetry — the seam that lets tests
+ * exercise the exhaustion branch directly without depending on real
+ * crypto.randomInt or actually inserting colliding rows.
+ */
+export interface CreateGroupRetryDeps {
+  generateInviteCodeFn?: (db: Database.Database) => string;
+  createGroupFn?: (db: Database.Database, input: { name: string; ownerId: number; inviteCode: string }) => Group;
+  maxRetries?: number;
+}
+
+/**
+ * Generates an invite code and inserts the group. On UNIQUE collision the
+ * cycle retries up to maxRetries times with a fresh code each time. The
+ * loop is extracted from handleCreate so that:
+ * (1) the exhaustion branch is unit-testable in isolation via injected deps
+ * (2) the return type is a discriminated union — handleCreate no longer
+ *     needs the `if (!group || !inviteCode)` dual-undefined guard
+ *
+ * Exported only for testing — handleCreate is the only production caller.
+ */
+export function createGroupWithCollisionRetry(
+  db: Database.Database,
+  input: { name: string; ownerId: number },
+  deps: CreateGroupRetryDeps = {},
+): CreateGroupOutcome {
+  const generateFn = deps.generateInviteCodeFn ?? generateInviteCode;
+  const createFn = deps.createGroupFn ?? createGroup;
+  const maxRetries = deps.maxRetries ?? MAX_CREATE_GROUP_COLLISION_RETRIES;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    let inviteCode: string;
+    try {
+      inviteCode = generateFn(db);
+    } catch (err) {
+      log('error', 'Groups', `generateInviteCode failed for ${input.ownerId}: ${formatError(err)}`);
+      return { kind: 'codegen-failed', cause: err };
+    }
+
+    try {
+      const group = createFn(db, { name: input.name, ownerId: input.ownerId, inviteCode });
+      return { kind: 'ok', group, inviteCode };
+    } catch (err) {
+      if (err instanceof InviteCodeCollisionError) {
+        log('warn', 'Groups', `Invite code collision for ${input.ownerId} on attempt ${attempt + 1}: ${inviteCode} — retrying`);
+        continue;
+      }
+      log('error', 'Groups', `createGroup failed for ${input.ownerId}: ${formatError(err)}`);
+      return { kind: 'createGroup-failed', cause: err };
+    }
+  }
+
+  log('error', 'Groups', `createGroup exhausted ${maxRetries} collision retries for ${input.ownerId}`);
+  return { kind: 'collision-exhausted' };
+}
+
 async function handleCreate(ctx: Context, name: string): Promise<void> {
   const chatId = ctx.chat?.id;
   if (!chatId) return;
@@ -178,49 +252,33 @@ async function handleCreate(ctx: Context, name: string): Promise<void> {
     return;
   }
 
-  // generate + insert in a retry loop — the pre-check in generateInviteCode
-  // is best-effort; UNIQUE collision under concurrent inserts is recoverable
-  // by retrying with a fresh code.
-  let group: Group | undefined;
-  let inviteCode: string | undefined;
-  for (let attempt = 0; attempt < MAX_CREATE_GROUP_COLLISION_RETRIES; attempt++) {
-    try {
-      inviteCode = generateInviteCode(db);
-    } catch (err) {
-      log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${formatError(err)}`);
+  const outcome = createGroupWithCollisionRetry(db, { name: trimmed, ownerId: chatId });
+
+  switch (outcome.kind) {
+    case 'codegen-failed':
       await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
       return;
-    }
-    try {
-      group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
-      break; // success
-    } catch (err) {
-      if (err instanceof InviteCodeCollisionError) {
-        log('warn', 'Groups', `Invite code collision for ${chatId} on attempt ${attempt + 1}: ${inviteCode} — retrying`);
-        continue; // generate a fresh code and retry
-      }
-      log('error', 'Groups', `createGroup failed for ${chatId}: ${formatError(err)}`);
+    case 'createGroup-failed':
       await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+      return;
+    case 'collision-exhausted':
+      await ctx.reply('❌ שגיאת שרת — לא הצלחנו ליצור קוד הזמנה ייחודי. נסה שוב.');
+      return;
+    case 'ok': {
+      const { group, inviteCode } = outcome;
+      log('info', 'Groups', `User ${chatId} created group ${group.id} (${trimmed})`);
+
+      const kb = new InlineKeyboard().text('📋 כרטיס הקבוצה', cb(`g:c:${group.id}`));
+      await ctx.reply(
+        `✅ <b>קבוצה נוצרה: ${escapeHtml(trimmed)}</b>\n\n` +
+          `קוד הזמנה: <code>${inviteCode}</code>\n\n` +
+          `שתפו את הקוד עם בני המשפחה / חברים — הם יוכלו להצטרף עם:\n` +
+          `<code>/group join ${inviteCode}</code>`,
+        { parse_mode: 'HTML', reply_markup: kb }
+      );
       return;
     }
   }
-
-  if (!group || !inviteCode) {
-    log('error', 'Groups', `createGroup exhausted ${MAX_CREATE_GROUP_COLLISION_RETRIES} collision retries for ${chatId}`);
-    await ctx.reply('❌ שגיאת שרת — לא הצלחנו ליצור קוד הזמנה ייחודי. נסה שוב.');
-    return;
-  }
-
-  log('info', 'Groups', `User ${chatId} created group ${group.id} (${trimmed})`);
-
-  const kb = new InlineKeyboard().text('📋 כרטיס הקבוצה', cb(`g:c:${group.id}`));
-  await ctx.reply(
-    `✅ <b>קבוצה נוצרה: ${escapeHtml(trimmed)}</b>\n\n` +
-      `קוד הזמנה: <code>${inviteCode}</code>\n\n` +
-      `שתפו את הקוד עם בני המשפחה / חברים — הם יוכלו להצטרף עם:\n` +
-      `<code>/group join ${inviteCode}</code>`,
-    { parse_mode: 'HTML', reply_markup: kb }
-  );
 }
 
 async function handleJoin(ctx: Context, codeArg: string): Promise<void> {

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -1,0 +1,457 @@
+import crypto from 'crypto';
+import { Bot, InlineKeyboard } from 'grammy';
+import type { Context } from 'grammy';
+import { upsertUser } from '../db/userRepository.js';
+import {
+  createGroup,
+  findGroupByInviteCode,
+  findGroupById,
+  getGroupsForUser,
+  getMembersOfGroup,
+  addMember,
+  removeMember,
+  deleteGroup,
+  countGroupsOwnedBy,
+  countMembersOfGroup,
+} from '../db/groupRepository.js';
+import { getDb } from '../db/schema.js';
+import { log } from '../logger.js';
+import { escapeHtml } from '../textUtils.js';
+
+// ─── Constants (fallbacks until Task 4 #225 wires configResolver) ────────────
+
+/** Max groups a single user may own. Task 4 will replace with hot-config. */
+export const MAX_GROUPS_PER_USER_FALLBACK = 5;
+/** Max members per group, including owner. Task 4 will replace with hot-config. */
+export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
+
+const JOIN_COOLDOWN_MS = 5_000;
+const MAX_JOIN_FAILURES = 5;
+const JOIN_FAILURE_BLOCK_MS = 60_000;
+const MAX_GROUP_NAME_LENGTH = 50;
+const INVITE_CODE_LENGTH = 6;
+const MAX_INVITE_CODE_RETRIES = 5;
+
+// Unambiguous alphabet — no 0/O/I/1 to avoid copy-paste confusion
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+// ─── Anti-spam state (mirror of connectHandler) ──────────────────────────────
+
+/** chatId → cooldown expiry timestamp. Exposed for test reset. */
+export const joinCooldownMap = new Map<number, number>();
+/** chatId → { count, blockedUntil }. Exposed for test reset. */
+export const joinFailures = new Map<number, { count: number; blockedUntil: number }>();
+
+function isJoinOnCooldown(chatId: number): boolean {
+  const expiry = joinCooldownMap.get(chatId);
+  if (expiry === undefined) return false;
+  if (Date.now() >= expiry) {
+    joinCooldownMap.delete(chatId);
+    return false;
+  }
+  return true;
+}
+
+function setJoinCooldown(chatId: number): void {
+  joinCooldownMap.set(chatId, Date.now() + JOIN_COOLDOWN_MS);
+}
+
+function isJoinBlocked(chatId: number): boolean {
+  const entry = joinFailures.get(chatId);
+  if (!entry) return false;
+  if (Date.now() >= entry.blockedUntil) {
+    joinFailures.delete(chatId);
+    return false;
+  }
+  return entry.count >= MAX_JOIN_FAILURES;
+}
+
+function recordJoinFailure(chatId: number): void {
+  const entry = joinFailures.get(chatId);
+  const count = (entry?.count ?? 0) + 1;
+  joinFailures.set(chatId, {
+    count,
+    blockedUntil:
+      count >= MAX_JOIN_FAILURES
+        ? Date.now() + JOIN_FAILURE_BLOCK_MS
+        : entry?.blockedUntil ?? 0,
+  });
+}
+
+function clearJoinFailures(chatId: number): void {
+  joinFailures.delete(chatId);
+}
+
+// ─── Callback data byte-length guard ─────────────────────────────────────────
+
+/**
+ * Runtime guard — Telegram silently rejects callback_data > 64 bytes UTF-8
+ * with a vague "BUTTON_DATA_INVALID" error. Throw early at button construction
+ * time so any developer mistake (e.g. accidentally embedding a Hebrew name)
+ * fails loud in tests instead of silent in production.
+ */
+export function cb(data: string): string {
+  const bytes = Buffer.byteLength(data, 'utf8');
+  if (bytes > 64) {
+    throw new Error(`callback_data too long (${bytes} bytes): ${data}`);
+  }
+  return data;
+}
+
+// ─── Invite code generator ───────────────────────────────────────────────────
+
+function generateInviteCode(db: ReturnType<typeof getDb>): string {
+  for (let i = 0; i < MAX_INVITE_CODE_RETRIES; i++) {
+    let code = '';
+    for (let j = 0; j < INVITE_CODE_LENGTH; j++) {
+      code += CODE_ALPHABET[crypto.randomInt(0, CODE_ALPHABET.length)];
+    }
+    if (!findGroupByInviteCode(db, code)) return code;
+  }
+  log('error', 'Groups', `Invite code generation exhausted ${MAX_INVITE_CODE_RETRIES} retries`);
+  throw new Error('Failed to generate unique invite code after retries');
+}
+
+// ─── Command handlers ────────────────────────────────────────────────────────
+
+async function handleList(ctx: Context): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+  const db = getDb();
+  const groups = getGroupsForUser(db, chatId);
+
+  if (groups.length === 0) {
+    await ctx.reply(
+      '👥 <b>הקבוצות שלי</b>\n\nאינך חבר באף קבוצה.\nליצירה: <code>/group create &lt;שם&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  const lines = ['👥 <b>הקבוצות שלי</b>', ''];
+  const kb = new InlineKeyboard();
+  for (const g of groups) {
+    const memberCount = countMembersOfGroup(db, g.id);
+    lines.push(`• <b>${escapeHtml(g.name)}</b> — ${memberCount} חברים`);
+    kb.text(`📋 ${g.name}`, cb(`g:c:${g.id}`)).row();
+  }
+
+  await ctx.reply(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb });
+}
+
+async function handleCreate(ctx: Context, name: string): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    await ctx.reply(
+      '❌ חסר שם לקבוצה.\nשימוש: <code>/group create &lt;שם&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+  if (trimmed.length > MAX_GROUP_NAME_LENGTH) {
+    await ctx.reply(`❌ השם ארוך מדי (מקסימום ${MAX_GROUP_NAME_LENGTH} תווים).`);
+    return;
+  }
+
+  const db = getDb();
+  if (countGroupsOwnedBy(db, chatId) >= MAX_GROUPS_PER_USER_FALLBACK) {
+    await ctx.reply(
+      `❌ הגעת לגבול: ניתן ליצור עד ${MAX_GROUPS_PER_USER_FALLBACK} קבוצות.\nמחק קבוצה קיימת לפני יצירת חדשה.`
+    );
+    return;
+  }
+
+  let inviteCode: string;
+  try {
+    inviteCode = generateInviteCode(db);
+  } catch (err) {
+    log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
+    return;
+  }
+
+  let group;
+  try {
+    group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
+  } catch (err) {
+    log('error', 'Groups', `createGroup failed for ${chatId}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+    return;
+  }
+
+  log('info', 'Groups', `User ${chatId} created group ${group.id} (${trimmed})`);
+
+  const kb = new InlineKeyboard().text('📋 כרטיס הקבוצה', cb(`g:c:${group.id}`));
+  await ctx.reply(
+    `✅ <b>קבוצה נוצרה: ${escapeHtml(trimmed)}</b>\n\n` +
+      `קוד הזמנה: <code>${inviteCode}</code>\n\n` +
+      `שתפו את הקוד עם בני המשפחה / חברים — הם יוכלו להצטרף עם:\n` +
+      `<code>/group join ${inviteCode}</code>`,
+    { parse_mode: 'HTML', reply_markup: kb }
+  );
+}
+
+async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+
+  if (isJoinBlocked(chatId)) {
+    await ctx.reply('⏳ יותר מדי ניסיונות שגויים. נסה שוב בעוד דקה.');
+    return;
+  }
+  if (isJoinOnCooldown(chatId)) {
+    await ctx.reply('⏳ נסה שוב בעוד כמה שניות.');
+    return;
+  }
+  setJoinCooldown(chatId);
+
+  const code = codeArg.trim().toUpperCase();
+  if (code.length === 0) {
+    await ctx.reply(
+      '❌ חסר קוד הזמנה.\nשימוש: <code>/group join &lt;קוד&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  const db = getDb();
+  const group = findGroupByInviteCode(db, code);
+  if (!group) {
+    recordJoinFailure(chatId);
+    await ctx.reply('❌ קוד לא תקין. בדקו שהעתקתם נכון.');
+    return;
+  }
+
+  // Already a member?
+  const members = getMembersOfGroup(db, group.id);
+  if (members.some((m) => m.userId === chatId)) {
+    clearJoinFailures(chatId);
+    await ctx.reply(`ℹ️ אתה כבר חבר בקבוצה <b>${escapeHtml(group.name)}</b>.`, {
+      parse_mode: 'HTML',
+    });
+    return;
+  }
+
+  if (members.length >= MAX_MEMBERS_PER_GROUP_FALLBACK) {
+    await ctx.reply(
+      `❌ הקבוצה מלאה (מקסימום ${MAX_MEMBERS_PER_GROUP_FALLBACK} חברים).`
+    );
+    return;
+  }
+
+  try {
+    addMember(db, group.id, chatId);
+  } catch (err) {
+    log('error', 'Groups', `addMember failed for ${chatId} → ${group.id}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת בהצטרפות. נסה שוב.');
+    return;
+  }
+
+  clearJoinFailures(chatId);
+  log('info', 'Groups', `User ${chatId} joined group ${group.id} (${group.name})`);
+
+  await ctx.reply(`✅ הצטרפת לקבוצה <b>${escapeHtml(group.name)}</b>!`, {
+    parse_mode: 'HTML',
+  });
+}
+
+async function handleLeave(ctx: Context, groupIdArg: string | undefined): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+  const db = getDb();
+
+  if (!groupIdArg) {
+    // No id — show picker
+    const groups = getGroupsForUser(db, chatId);
+    if (groups.length === 0) {
+      await ctx.reply('אינך חבר באף קבוצה.');
+      return;
+    }
+    const kb = new InlineKeyboard();
+    for (const g of groups) kb.text(`❌ ${g.name}`, cb(`g:leaveY:${g.id}`)).row();
+    await ctx.reply('בחר קבוצה לעזיבה:', { reply_markup: kb });
+    return;
+  }
+
+  const groupId = Number(groupIdArg);
+  if (!Number.isInteger(groupId) || groupId <= 0) {
+    await ctx.reply('❌ מזהה קבוצה לא תקין.');
+    return;
+  }
+
+  const group = findGroupById(db, groupId);
+  if (!group) {
+    await ctx.reply('❌ הקבוצה לא נמצאה.');
+    return;
+  }
+  const members = getMembersOfGroup(db, groupId);
+  if (!members.some((m) => m.userId === chatId)) {
+    await ctx.reply('❌ אינך חבר בקבוצה זו.');
+    return;
+  }
+
+  await performLeave(ctx, groupId, chatId);
+}
+
+async function performLeave(
+  ctx: Context,
+  groupId: number,
+  chatId: number
+): Promise<void> {
+  const db = getDb();
+  const group = findGroupById(db, groupId);
+  if (!group) {
+    await ctx.reply('❌ הקבוצה לא נמצאה.');
+    return;
+  }
+
+  const isOwner = group.ownerId === chatId;
+  const memberCount = countMembersOfGroup(db, groupId);
+
+  if (isOwner && memberCount > 1) {
+    await ctx.reply(
+      '❌ אינך יכול לעזוב — אתה הבעלים. העבר בעלות או מחק את הקבוצה.\n' +
+        '<i>(מחיקת קבוצות תיתמך בגרסה הבאה)</i>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  if (isOwner && memberCount === 1) {
+    // Last member + owner: delete the whole group (CASCADE removes membership)
+    deleteGroup(db, groupId);
+    log('info', 'Groups', `Group ${groupId} (${group.name}) deleted by owner ${chatId} (last member)`);
+    await ctx.reply(`🗑 הקבוצה <b>${escapeHtml(group.name)}</b> נמחקה.`, {
+      parse_mode: 'HTML',
+    });
+    return;
+  }
+
+  // Regular member leaving
+  removeMember(db, groupId, chatId);
+  log('info', 'Groups', `User ${chatId} left group ${groupId} (${group.name})`);
+  await ctx.reply(`✅ עזבת את הקבוצה <b>${escapeHtml(group.name)}</b>.`, {
+    parse_mode: 'HTML',
+  });
+}
+
+// ─── Main dispatch ───────────────────────────────────────────────────────────
+
+async function handleGroupCommand(ctx: Context): Promise<void> {
+  if (ctx.chat?.type !== 'private') return;
+  const chatId = ctx.chat.id;
+
+  try {
+    upsertUser(chatId);
+  } catch (err) {
+    log('error', 'Groups', `Failed to upsert user ${chatId}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת — נסה שוב.');
+    return;
+  }
+
+  const args = (ctx.message?.text ?? '').split(/\s+/).slice(1);
+  const sub = args[0]?.toLowerCase();
+  const rest = args.slice(1).join(' ');
+
+  switch (sub) {
+    case undefined:
+    case 'list':
+      await handleList(ctx);
+      return;
+    case 'create':
+      await handleCreate(ctx, rest);
+      return;
+    case 'join':
+      await handleJoin(ctx, rest);
+      return;
+    case 'leave':
+      await handleLeave(ctx, args[1]);
+      return;
+    default:
+      await ctx.reply(
+        '❌ פקודה לא מוכרת.\n\n' +
+          'שימוש:\n' +
+          '<code>/group</code> — רשימת הקבוצות שלי\n' +
+          '<code>/group create &lt;שם&gt;</code> — יצירת קבוצה\n' +
+          '<code>/group join &lt;קוד&gt;</code> — הצטרפות עם קוד\n' +
+          '<code>/group leave [id]</code> — עזיבת קבוצה',
+        { parse_mode: 'HTML' }
+      );
+  }
+}
+
+// ─── Registration ────────────────────────────────────────────────────────────
+
+export function registerGroupHandler(bot: Bot): void {
+  bot.command('group', async (ctx) => {
+    try {
+      await handleGroupCommand(ctx);
+    } catch (err) {
+      log('error', 'Groups', `handler error: ${String(err)}`);
+      await ctx.reply('⚠️ שגיאה בטיפול בקבוצה').catch(() => undefined);
+    }
+  });
+
+  // g:c:<id> — show group card
+  bot.callbackQuery(/^g:c:(\d+)$/, async (ctx) => {
+    await ctx.answerCallbackQuery().catch(() => undefined);
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    const raw = ctx.match?.[1];
+    if (!raw) return;
+    const groupId = parseInt(raw, 10);
+    if (isNaN(groupId)) return;
+
+    const db = getDb();
+    const group = findGroupById(db, groupId);
+    if (!group) {
+      await ctx.editMessageText('❌ הקבוצה לא נמצאה.').catch(() => undefined);
+      return;
+    }
+    const members = getMembersOfGroup(db, groupId);
+    if (!members.some((m) => m.userId === chatId)) {
+      await ctx.editMessageText('❌ אינך חבר בקבוצה זו.').catch(() => undefined);
+      return;
+    }
+
+    const isOwner = group.ownerId === chatId;
+    const lines = [
+      `📋 <b>${escapeHtml(group.name)}</b>`,
+      '',
+      `חברים: ${members.length}`,
+      `נוצרה: ${group.createdAt.split(' ')[0] ?? group.createdAt}`,
+    ];
+    if (isOwner) {
+      lines.push('', `קוד הזמנה: <code>${group.inviteCode}</code>`);
+    }
+
+    const kb = new InlineKeyboard().text('🚪 עזיבה', cb(`g:leaveY:${groupId}`));
+    await ctx
+      .editMessageText(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb })
+      .catch((err) => {
+        log('warn', 'Groups', `editMessageText (g:c) failed: ${String(err)}`);
+      });
+  });
+
+  // g:leaveY:<id> — confirm leave
+  bot.callbackQuery(/^g:leaveY:(\d+)$/, async (ctx) => {
+    await ctx.answerCallbackQuery().catch(() => undefined);
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    const raw = ctx.match?.[1];
+    if (!raw) return;
+    const groupId = parseInt(raw, 10);
+    if (isNaN(groupId)) return;
+
+    const db = getDb();
+    const group = findGroupById(db, groupId);
+    if (!group) return;
+    const members = getMembersOfGroup(db, groupId);
+    if (!members.some((m) => m.userId === chatId)) return;
+
+    await performLeave(ctx, groupId, chatId);
+  });
+}

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -48,10 +48,23 @@ function decodeGroup(raw: RawGroup): Group {
 }
 
 function decodeMember(raw: RawMember): GroupMember {
+  // Hardened role decode — refuses to lie about an invalid union value.
+  // SQLite has a CHECK constraint, so 'owner'|'member' is the only legal
+  // value at write-time, but a corrupted/migrated DB row could still slip
+  // through. Default to 'member' (least-privileged) and log a warn rather
+  // than producing an unsafe `as` cast.
+  let role: 'owner' | 'member';
+  if (raw.role === 'owner' || raw.role === 'member') {
+    role = raw.role;
+  } else {
+    log('warn', 'GroupRepo', `unexpected role value for group_id=${raw.group_id} user_id=${raw.user_id}: ${JSON.stringify(raw.role)} — defaulting to 'member'`);
+    role = 'member';
+  }
+
   return {
     groupId: raw.group_id,
     userId: raw.user_id,
-    role: raw.role as 'owner' | 'member',
+    role,
     joinedAt: raw.joined_at,
     notifyGroup: raw.notify_group === 1, // strict INTEGER→boolean
   };
@@ -60,26 +73,57 @@ function decodeMember(raw: RawMember): GroupMember {
 // ─── Writes ──────────────────────────────────────────────────────────────────
 
 /**
+ * Sentinel error thrown when the invite_code UNIQUE constraint fires.
+ * Callers (groupHandler.handleCreate) catch this to retry with a fresh code.
+ *
+ * The pre-check in `generateInviteCode` is best-effort and is not safe under
+ * concurrent inserts — this sentinel makes the race recoverable.
+ */
+export class InviteCodeCollisionError extends Error {
+  constructor(code: string) {
+    super(`Invite code collision: ${code}`);
+    this.name = 'InviteCodeCollisionError';
+  }
+}
+
+/**
  * Creates a new group and inserts the owner as a member in a single transaction.
  * Rolls back atomically if either insert fails (e.g. invalid ownerId FK).
+ *
+ * Throws `InviteCodeCollisionError` if `invite_code` UNIQUE constraint fires
+ * (e.g. concurrent insert raced past the pre-check). Other errors propagate.
  */
 export function createGroup(
   db: Database.Database,
   input: { name: string; ownerId: number; inviteCode: string }
 ): Group {
-  return db.transaction(() => {
-    const raw = db
-      .prepare(
-        'INSERT INTO groups (name, invite_code, owner_id) VALUES (?, ?, ?) RETURNING *'
-      )
-      .get(input.name, input.inviteCode, input.ownerId) as RawGroup;
+  try {
+    return db.transaction(() => {
+      const raw = db
+        .prepare(
+          'INSERT INTO groups (name, invite_code, owner_id) VALUES (?, ?, ?) RETURNING *'
+        )
+        .get(input.name, input.inviteCode, input.ownerId) as RawGroup;
 
-    db.prepare(
-      "INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'owner')"
-    ).run(raw.id, input.ownerId);
+      db.prepare(
+        "INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'owner')"
+      ).run(raw.id, input.ownerId);
 
-    return decodeGroup(raw);
-  })();
+      return decodeGroup(raw);
+    })();
+  } catch (err: unknown) {
+    // better-sqlite3 throws SqliteError with `.code` property — narrow to the
+    // UNIQUE-constraint case so handlers can retry. Other errors propagate.
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      (err as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE' &&
+      err.message.includes('groups.invite_code')
+    ) {
+      throw new InviteCodeCollisionError(input.inviteCode);
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -1,0 +1,206 @@
+import type Database from 'better-sqlite3';
+import { log } from '../logger.js';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export interface Group {
+  id: number;
+  name: string;
+  inviteCode: string;
+  ownerId: number;
+  createdAt: string;
+}
+
+export interface GroupMember {
+  groupId: number;
+  userId: number;
+  role: 'owner' | 'member';
+  joinedAt: string;
+  notifyGroup: boolean;
+}
+
+// ─── Internal raw rows (match SQLite column names exactly) ───────────────────
+
+interface RawGroup {
+  id: number;
+  name: string;
+  invite_code: string;
+  owner_id: number;
+  created_at: string;
+}
+
+interface RawMember {
+  group_id: number;
+  user_id: number;
+  role: string;
+  joined_at: string;
+  notify_group: number; // SQLite INTEGER (0|1) — decoded to boolean at boundary
+}
+
+function decodeGroup(raw: RawGroup): Group {
+  return {
+    id: raw.id,
+    name: raw.name,
+    inviteCode: raw.invite_code,
+    ownerId: raw.owner_id,
+    createdAt: raw.created_at,
+  };
+}
+
+function decodeMember(raw: RawMember): GroupMember {
+  return {
+    groupId: raw.group_id,
+    userId: raw.user_id,
+    role: raw.role as 'owner' | 'member',
+    joinedAt: raw.joined_at,
+    notifyGroup: raw.notify_group === 1, // strict INTEGER→boolean
+  };
+}
+
+// ─── Writes ──────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a new group and inserts the owner as a member in a single transaction.
+ * Rolls back atomically if either insert fails (e.g. invalid ownerId FK).
+ */
+export function createGroup(
+  db: Database.Database,
+  input: { name: string; ownerId: number; inviteCode: string }
+): Group {
+  return db.transaction(() => {
+    const raw = db
+      .prepare(
+        'INSERT INTO groups (name, invite_code, owner_id) VALUES (?, ?, ?) RETURNING *'
+      )
+      .get(input.name, input.inviteCode, input.ownerId) as RawGroup;
+
+    db.prepare(
+      "INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'owner')"
+    ).run(raw.id, input.ownerId);
+
+    return decodeGroup(raw);
+  })();
+}
+
+/**
+ * Idempotent — uses INSERT OR IGNORE on the (group_id, user_id) composite PK.
+ * Logs a warn when the user was already a member, but does not throw.
+ */
+export function addMember(
+  db: Database.Database,
+  groupId: number,
+  userId: number
+): void {
+  const result = db
+    .prepare(
+      "INSERT OR IGNORE INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')"
+    )
+    .run(groupId, userId);
+  if (result.changes === 0) {
+    log('warn', 'GroupRepo', `addMember: user ${userId} already in group ${groupId}`);
+  }
+}
+
+export function removeMember(
+  db: Database.Database,
+  groupId: number,
+  userId: number
+): void {
+  db.prepare(
+    'DELETE FROM group_members WHERE group_id = ? AND user_id = ?'
+  ).run(groupId, userId);
+}
+
+/**
+ * Deletes the group row; `group_members` rows are removed by the CASCADE FK.
+ */
+export function deleteGroup(db: Database.Database, groupId: number): void {
+  db.prepare('DELETE FROM groups WHERE id = ?').run(groupId);
+}
+
+// ─── Reads ───────────────────────────────────────────────────────────────────
+
+export function findGroupByInviteCode(
+  db: Database.Database,
+  code: string
+): Group | undefined {
+  const raw = db
+    .prepare('SELECT * FROM groups WHERE invite_code = ?')
+    .get(code) as RawGroup | undefined;
+  return raw ? decodeGroup(raw) : undefined;
+}
+
+export function findGroupById(
+  db: Database.Database,
+  id: number
+): Group | undefined {
+  const raw = db.prepare('SELECT * FROM groups WHERE id = ?').get(id) as
+    | RawGroup
+    | undefined;
+  return raw ? decodeGroup(raw) : undefined;
+}
+
+export function getGroupsForUser(db: Database.Database, userId: number): Group[] {
+  const rows = db
+    .prepare(
+      `SELECT g.* FROM groups g
+       INNER JOIN group_members gm ON gm.group_id = g.id
+       WHERE gm.user_id = ?
+       ORDER BY g.created_at DESC`
+    )
+    .all(userId) as RawGroup[];
+  return rows.map(decodeGroup);
+}
+
+export function getMembersOfGroup(
+  db: Database.Database,
+  groupId: number
+): GroupMember[] {
+  const rows = db
+    .prepare(
+      'SELECT * FROM group_members WHERE group_id = ? ORDER BY joined_at ASC'
+    )
+    .all(groupId) as RawMember[];
+  return rows.map(decodeMember);
+}
+
+export function countGroupsOwnedBy(
+  db: Database.Database,
+  ownerId: number
+): number {
+  const row = db
+    .prepare('SELECT COUNT(*) as c FROM groups WHERE owner_id = ?')
+    .get(ownerId) as { c: number };
+  return row.c;
+}
+
+export function countMembersOfGroup(
+  db: Database.Database,
+  groupId: number
+): number {
+  const row = db
+    .prepare('SELECT COUNT(*) as c FROM group_members WHERE group_id = ?')
+    .get(groupId) as { c: number };
+  return row.c;
+}
+
+/**
+ * Dashboard listing helper — joins group with its member count in a single query.
+ * Used by `src/dashboard/routes/groups.ts` in Task 4.
+ */
+export function listAllGroupsWithStats(
+  db: Database.Database
+): Array<Group & { memberCount: number }> {
+  const rows = db
+    .prepare(
+      `SELECT g.*,
+              (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id) AS member_count
+       FROM groups g
+       ORDER BY g.created_at DESC`
+    )
+    .all() as Array<RawGroup & { member_count: number }>;
+  return rows.map((r) => ({ ...decodeGroup(r), memberCount: r.member_count }));
+}
+
+// NOTE: `getMemberStatusesForGroup` (joining members with safetyStatusRepository)
+// will be added in Task 2 (#212) to keep this PR tight around #211.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -184,6 +184,30 @@ export function initSchema(database: Database.Database): void {
       FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE CASCADE
     );
 
+    -- v0.5.1 — resilience groups (family/friends/work cells)
+    CREATE TABLE IF NOT EXISTS groups (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      name         TEXT NOT NULL,
+      invite_code  TEXT NOT NULL UNIQUE,
+      owner_id     INTEGER NOT NULL,
+      created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (owner_id) REFERENCES users(chat_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_groups_invite_code ON groups(invite_code);
+    CREATE INDEX IF NOT EXISTS idx_groups_owner ON groups(owner_id);
+
+    CREATE TABLE IF NOT EXISTS group_members (
+      group_id     INTEGER NOT NULL,
+      user_id      INTEGER NOT NULL,
+      role         TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('owner', 'member')),
+      joined_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      notify_group INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY (group_id, user_id),
+      FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id)  REFERENCES users(chat_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_group_members_user ON group_members(user_id);
+
     CREATE TABLE IF NOT EXISTS safety_status (
       chat_id     INTEGER PRIMARY KEY,
       status      TEXT CHECK (status IN ('ok', 'help', 'dismissed')) NOT NULL,


### PR DESCRIPTION
## Summary

First PR in the v0.5.1 stacked series. Adds the foundational tables, repository, and bot handler for resilience groups (family/friends/work cells).

**Stacked PR strategy** — this targets `v0.5.1-base` (not `main`). PRs #212 / #213 / #225 will stack on top of this branch.

### What changes
- **DB**: two new tables added to `initSchema()`:
  - `groups` (id, name, invite_code UNIQUE, owner_id FK→users CASCADE, created_at)
  - `group_members` (composite PK group_id+user_id, role 'owner'|'member', joined_at, **notify_group INTEGER default 1**)
  - 3 indexes: invite_code, owner_id, user_id
  - `notify_group` is added now (cheap) so Task 3 #213 doesn't need an `ALTER TABLE` later
- **Repository** (`src/db/groupRepository.ts`): mirrors `contactRepository.ts` structure exactly — Raw* internal types, `decodeRow`, `db.transaction()` for the multi-row create, `INSERT OR IGNORE` for idempotent `addMember`. 12 exported functions, 20 tests.
- **Handler** (`src/bot/groupHandler.ts`): mirrors `connectHandler.ts` — 5s join cooldown + 5-failure-60s block + 6-char unambiguous invite codes (no 0/O/I/1) with collision retry. Sub-commands: `create | join | leave | list`. 17 tests.
- **`cb()` runtime guard**: every inline-keyboard button wraps its callback_data in `cb()`, which throws if `Buffer.byteLength(data, 'utf8') > 64`. Prevents Telegram silent-drop on accidental Hebrew/long payloads. Dedicated test for the Hebrew overflow case (33 × 2 bytes = 66).
- **Registration**: `botSetup.ts` registers `registerGroupHandler` after `registerConnectHandler`, and adds `/group` to `setMyCommands`.

### Critical guardrail — `notify_group` boolean decoding
SQLite stores `INTEGER 0|1`. The `decodeMember` function uses `notify_group === 1` to produce a strict TS `boolean`. Without this, a stray raw `1` would pass loose equality but break `if (!m.notifyGroup)` in Task 3 #213 (group notification service). A dedicated test enforces:
\`\`\`typescript
assert.equal(typeof owner.notifyGroup, 'boolean');
assert.equal(owner.notifyGroup, false);  // when DB has 0
\`\`\`

### Out of scope (deferred to follow-up PRs)
- `/group status` — Task 2 #212
- Status-change propagation to other group members — Task 3 #213
- Dashboard CRUD page + hot-config caps — Task 4 #225
- Ownership transfer + group rename — v0.5.2

## Test plan
- [x] \`npx tsx --test src/__tests__/groupRepository.test.ts\` (20 tests)
- [x] \`npx tsx --test src/__tests__/groupHandler.test.ts\` (17 tests)
- [x] \`npx tsx --test src/__tests__/contactRepository.test.ts\` (regression — 30 tests, passes after schema edit, including \`migration preserves existing data (re-init idempotency)\`)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` (backend + dashboard-ui) clean
- [x] Schema introspection one-shot confirms both tables + 3 indexes exist after \`initSchema()\`
- [ ] Manual smoke test (after merge): \`/group create משפחה\` from Account A → invite code → \`/group join CODE\` from Account B → \`/group list\` shows both members

closes #211