### PR TITLE
feat(v0.5.1): #212 קבוצות — מסך סטטוס קבוצתי (/group status)

### DIFF
--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -892,6 +892,30 @@ describe('renderGroupStatus — content + aggregate count', () => {
     const text = (ctx as any)._replyCalls[0][0] as string;
     assert.match(text, /הקבוצה לא נמצאה/);
   });
+
+  // PR #232 review item M1 — empty-group edge case
+  it('renders clean empty state when group has 0 members (defensive — should not happen via UI)', async () => {
+    const db = getDb();
+    upsertUser(1001);
+    const g = createGroup(db, { name: 'will-be-emptied', ownerId: 1001, inviteCode: 'EMP001' });
+
+    // Simulate a corruption or migration glitch: manually wipe group_members
+    // without deleting the group itself. This bypasses the auto-delete in
+    // performLeave that would normally fire when the last member leaves.
+    db.prepare('DELETE FROM group_members WHERE group_id = ?').run(g.id);
+    assert.equal(countMembersOfGroup(db, g.id), 0);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, g.id, lookup);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /will-be-emptied/);
+    assert.match(text, /הקבוצה ריקה/);
+    // Must NOT contain the ugly "0/0 בסדר" summary line
+    assert.doesNotMatch(text, /0\/0 בסדר/);
+  });
 });
 
 describe('g:s and g:refresh callbacks', () => {

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -18,8 +18,10 @@ import {
   MAX_GROUPS_PER_USER_FALLBACK,
   MAX_MEMBERS_PER_GROUP_FALLBACK,
   createGroupWithCollisionRetry,
+  renderGroupStatus,
 } from '../bot/groupHandler.js';
-import { InviteCodeCollisionError } from '../db/groupRepository.js';
+import { InviteCodeCollisionError, findGroupById } from '../db/groupRepository.js';
+import { upsertSafetyStatus } from '../db/safetyStatusRepository.js';
 import type { Bot, Context } from 'grammy';
 
 before(() => {
@@ -706,5 +708,248 @@ describe('groupHandler — /group leave', () => {
 
     // Group is gone
     assert.equal(findGroupByInviteCode(db, 'LV0003'), undefined);
+  });
+});
+
+// ─── Task 2 (#212) — /group status command ──────────────────────────────────
+
+describe('groupHandler — /group status command dispatch', () => {
+  it('shows empty state for user with no groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const ctx = makeCtx({ message: { text: '/group status' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר באף קבוצה/);
+  });
+
+  it('auto-picks single group and renders status card', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'STA001' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group status' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /family/);
+    // Single member who hasn't reported → shows "0/1 בסדר" + "לא דיווח"
+    assert.match(text, /0\/1 בסדר/);
+    assert.match(text, /לא דיווח/);
+    // Hint to /status command (no safety:menu callback exists)
+    assert.match(text, /\/status/);
+
+    // Inline keyboard should have just the refresh button targeting g:refresh:<id>
+    const markup = JSON.stringify((ctx as any)._replyCalls[0][1]?.reply_markup ?? {});
+    assert.ok(markup.includes(`g:refresh:${g.id}`), 'should have refresh button');
+    assert.ok(!markup.includes('safety:menu'), 'must NOT reference non-existent safety:menu');
+  });
+
+  it('shows multi-group picker when user belongs to ≥2 groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'STA002' });
+    const g2 = createGroup(db, { name: 'work',   ownerId: 1001, inviteCode: 'STA003' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group status' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /בחר קבוצה/);
+    const markup = JSON.stringify((ctx as any)._replyCalls[0][1]?.reply_markup ?? {});
+    assert.ok(markup.includes(`g:s:${g1.id}`), 'picker should include g1');
+    assert.ok(markup.includes(`g:s:${g2.id}`), 'picker should include g2');
+  });
+
+  it('rejects non-member trying to view status by explicit groupId', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999);
+    const db = getDb();
+    const g = createGroup(db, { name: 'private', ownerId: 1001, inviteCode: 'STA004' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' }, message: { text: `/group status ${g.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר/);
+    // Group internals never leak
+    assert.doesNotMatch(text, /private/);
+  });
+
+  it('rejects NaN / negative groupId in /group status', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    for (const badId of ['abc', '-5', '0']) {
+      const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group status ${badId}` } });
+      await bot._fireCmd('group', ctx);
+
+      const text = (ctx as any)._replyCalls[0][0] as string;
+      assert.match(text, /מזהה קבוצה לא תקין/, `expected validation error for badId="${badId}", got: ${text}`);
+    }
+  });
+});
+
+describe('renderGroupStatus — content + aggregate count', () => {
+  it('aggregates ok/help/dismissed/none with correct emoji + count', async () => {
+    upsertUser(1001);
+    upsertUser(1002);
+    upsertUser(1003);
+    upsertUser(1004);
+    const db = getDb();
+    const g = createGroup(db, { name: 'cell', ownerId: 1001, inviteCode: 'AGG001' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(g.id, 1002);
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(g.id, 1003);
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(g.id, 1004);
+
+    // Seed statuses: owner=ok, 1002=help, 1003=dismissed, 1004=no status
+    upsertSafetyStatus(db, 1001, 'ok');
+    upsertSafetyStatus(db, 1002, 'help');
+    upsertSafetyStatus(db, 1003, 'dismissed');
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    // Inject lookupUser that reads from THIS db (not getDb() singleton).
+    // Without injection, getUser() reads from process.env DB_PATH, which is :memory:
+    // here so it would happen to work — but we test the seam explicitly.
+    const testLookup = (chatId: number) => {
+      const row = db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as
+        | { display_name: string | null; home_city: string | null }
+        | undefined;
+      return row;
+    };
+    await renderGroupStatus(ctx as any, db, g.id, testLookup);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+
+    assert.match(text, /cell/);
+    assert.match(text, /✅/);
+    assert.match(text, /⚠️/);
+    assert.match(text, /🔇/);
+    assert.match(text, /❓/);
+    assert.match(text, /1\/4 בסדר/, 'only owner reported ok → 1/4');
+    assert.match(text, /\/status/);
+  });
+
+  it('uses editMessageText when called from a callback context (refresh path)', async () => {
+    upsertUser(1001);
+    const db = getDb();
+    const g = createGroup(db, { name: 'rfr', ownerId: 1001, inviteCode: 'RFR001' });
+
+    const ctx = makeCtx({
+      chat: { id: 1001, type: 'private' },
+      callbackQuery: { id: 'fakeId', data: `g:refresh:${g.id}` },
+    });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, g.id, lookup);
+
+    // Should have called editMessageText, NOT reply
+    assert.equal((ctx as any)._editCalls.length, 1);
+    assert.equal((ctx as any)._replyCalls.length, 0);
+    const editText = (ctx as any)._editCalls[0][0] as string;
+    assert.match(editText, /rfr/);
+  });
+
+  it('handles missing display_name with fallback "משתמש #<id>"', async () => {
+    const db = getDb();
+    // Insert a user with NO display_name (simulating pre-onboarding state)
+    db.prepare("INSERT INTO users (chat_id, created_at) VALUES (?, datetime('now'))").run(7777);
+    const g = createGroup(db, { name: 'noname', ownerId: 7777, inviteCode: 'NON001' });
+
+    const ctx = makeCtx({ chat: { id: 7777, type: 'private' } });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, g.id, lookup);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /משתמש #7777/);
+  });
+
+  it('returns "הקבוצה לא נמצאה" when group does not exist', async () => {
+    const db = getDb();
+    upsertUser(1001);
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, 999999, lookup);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הקבוצה לא נמצאה/);
+  });
+});
+
+describe('g:s and g:refresh callbacks', () => {
+  it('g:s:<id> callback renders status via editMessageText', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g = createGroup(db, { name: 'cb-test', ownerId: 1001, inviteCode: 'CBS001' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    await bot._fireCb(`g:s:${g.id}`, ctx);
+
+    // Either edited or replied — the callback wraps editMessageText which the
+    // mock supports — but since renderGroupStatus checks ctx.callbackQuery
+    // truthiness, and the mock setter doesn't add it, expect a reply OR an edit.
+    // The picker→g:s flow uses editMessageText (the mock context will have
+    // callbackQuery via _fireCb path).
+    const totalCalls = (ctx as any)._editCalls.length + (ctx as any)._replyCalls.length;
+    assert.ok(totalCalls > 0, 'g:s should produce some output');
+    // Find the rendered text
+    const text = ((ctx as any)._editCalls[0]?.[0] ?? (ctx as any)._replyCalls[0]?.[0]) as string;
+    assert.match(text, /cb-test/);
+  });
+
+  it('g:s:<id> blocks non-members entirely', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999);
+    const db = getDb();
+    const g = createGroup(db, { name: 'secret', ownerId: 1001, inviteCode: 'CBS002' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' } });
+    await bot._fireCb(`g:s:${g.id}`, ctx);
+
+    const text = ((ctx as any)._editCalls[0]?.[0] ?? (ctx as any)._replyCalls[0]?.[0]) as string;
+    assert.match(text, /אינך חבר/);
+    // Group name never leaks to non-member
+    assert.doesNotMatch(text, /secret/);
+  });
+
+  it('g:refresh:<id> blocks non-members', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999);
+    const db = getDb();
+    const g = createGroup(db, { name: 'rfr-secret', ownerId: 1001, inviteCode: 'RFR002' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' } });
+    await bot._fireCb(`g:refresh:${g.id}`, ctx);
+
+    const text = ((ctx as any)._editCalls[0]?.[0] ?? (ctx as any)._replyCalls[0]?.[0]) as string;
+    assert.match(text, /אינך חבר/);
+    assert.doesNotMatch(text, /rfr-secret/);
   });
 });

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -2,13 +2,15 @@ import crypto from 'crypto';
 import type Database from 'better-sqlite3';
 import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
-import { upsertUser } from '../db/userRepository.js';
+import { upsertUser, getUser } from '../db/userRepository.js';
+import type { User } from '../db/userRepository.js';
 import {
   createGroup,
   findGroupByInviteCode,
   findGroupById,
   getGroupsForUser,
   getMembersOfGroup,
+  getMemberStatusesForGroup,
   addMember,
   removeMember,
   deleteGroup,
@@ -19,7 +21,7 @@ import {
 } from '../db/groupRepository.js';
 import { getDb } from '../db/schema.js';
 import { log } from '../logger.js';
-import { escapeHtml } from '../textUtils.js';
+import { escapeHtml, formatRelativeTime } from '../textUtils.js';
 
 // ─── Constants (fallbacks until Task 4 #225 wires configResolver) ────────────
 
@@ -385,6 +387,132 @@ async function handleLeave(ctx: Context, groupIdArg: string | undefined): Promis
   await performLeave(ctx, groupId, chatId);
 }
 
+// ─── /group status — group-wide safety status aggregation ───────────────────
+
+/**
+ * Subset of `User` fields needed by the group status renderer. Tests inject
+ * a stub function returning this shape so they can drive renderGroupStatus
+ * with a `:memory:` DB that the production `getUser()` (singleton-backed)
+ * cannot see. Pattern: `pattern_getuser_singleton_vs_di.md` in memory.
+ */
+type GroupStatusUserLookup = (chatId: number) => Pick<User, 'display_name' | 'home_city'> | undefined;
+
+async function handleStatus(ctx: Context, groupIdArg: string | undefined): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+  const db = getDb();
+
+  // Resolve target group: explicit id, single group auto-pick, or picker
+  let groupId: number;
+  if (groupIdArg) {
+    const parsed = Number(groupIdArg);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      await ctx.reply('❌ מזהה קבוצה לא תקין.');
+      return;
+    }
+    groupId = parsed;
+  } else {
+    const groups = getGroupsForUser(db, chatId);
+    if (groups.length === 0) {
+      await ctx.reply('אינך חבר באף קבוצה.');
+      return;
+    }
+    if (groups.length === 1) {
+      const onlyGroup = groups[0];
+      if (!onlyGroup) return;
+      groupId = onlyGroup.id;
+    } else {
+      // Multi-group picker — show inline keyboard with one button per group
+      const kb = new InlineKeyboard();
+      for (const g of groups) {
+        kb.text(`👥 ${g.name}`, cb(`g:s:${g.id}`)).row();
+      }
+      await ctx.reply('בחר קבוצה לצפייה בסטטוס:', { reply_markup: kb });
+      return;
+    }
+  }
+
+  // Membership check (auth invariant) — only members can view a group's status
+  const members = getMembersOfGroup(db, groupId);
+  if (!members.some((m) => m.userId === chatId)) {
+    await ctx.reply('❌ אינך חבר בקבוצה זו.');
+    return;
+  }
+
+  await renderGroupStatus(ctx, db, groupId);
+}
+
+/**
+ * Renders the group status card. Used by both `/group status` (initial reply)
+ * and the `g:s:<id>` / `g:refresh:<id>` callbacks (in-place edit).
+ *
+ * Exported so tests can drive it directly with an injected `lookupUser` that
+ * reads from the test's `:memory:` DB instead of the `getDb()` singleton that
+ * `getUser()` reads from internally.
+ */
+export async function renderGroupStatus(
+  ctx: Context,
+  db: Database.Database,
+  groupId: number,
+  lookupUser: GroupStatusUserLookup = getUser,
+): Promise<void> {
+  const group = findGroupById(db, groupId);
+  if (!group) {
+    const message = '❌ הקבוצה לא נמצאה.';
+    if (ctx.callbackQuery) {
+      await ctx
+        .editMessageText(message)
+        .catch((e) => log('warn', 'Groups', `editMessageText (status not-found) failed: ${formatError(e)}`));
+    } else {
+      await ctx.reply(message);
+    }
+    return;
+  }
+
+  const statuses = getMemberStatusesForGroup(db, groupId);
+
+  let okCount = 0;
+  const lines: string[] = [`👥 <b>${escapeHtml(group.name)}</b>`, ''];
+  for (const { userId, status } of statuses) {
+    const user = lookupUser(userId);
+    const displayName = escapeHtml(user?.display_name ?? `משתמש #${userId}`);
+    const homeCity = user?.home_city ? ` · ${escapeHtml(user.home_city)}` : '';
+
+    let emoji = '❓';
+    let label = 'לא דיווח';
+    if (status?.status === 'ok') {
+      emoji = '✅';
+      label = 'בסדר';
+      okCount++;
+    } else if (status?.status === 'help') {
+      emoji = '⚠️';
+      label = 'צריך עזרה';
+    } else if (status?.status === 'dismissed') {
+      emoji = '🔇';
+      label = 'התעלם';
+    }
+
+    const when = status ? ` · ${formatRelativeTime(status.updated_at)}` : '';
+    lines.push(`${emoji} <b>${displayName}</b> · ${label}${homeCity}${when}`);
+  }
+  lines.push('', `<b>${okCount}/${statuses.length} בסדר</b>`);
+  // Hint: there's no "safety:menu" callback — use the slash command instead.
+  // Verified during planning against safetyStatusHandler.ts (only safety:back,
+  // safety:contacts, safety:ok:N, safety:help:N, safety:dismiss:N exist).
+  lines.push('', '<i>לעדכון הסטטוס שלך: /status</i>');
+
+  const kb = new InlineKeyboard().text('🔄 רענן', cb(`g:refresh:${groupId}`));
+  const text = lines.join('\n');
+
+  if (ctx.callbackQuery) {
+    await ctx
+      .editMessageText(text, { parse_mode: 'HTML', reply_markup: kb })
+      .catch((e) => log('warn', 'Groups', `editMessageText (status render) failed: ${formatError(e)}`));
+  } else {
+    await ctx.reply(text, { parse_mode: 'HTML', reply_markup: kb });
+  }
+}
+
 async function performLeave(
   ctx: Context,
   groupId: number,
@@ -469,6 +597,9 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
     case 'leave':
       await handleLeave(ctx, args[1]);
       return;
+    case 'status':
+      await handleStatus(ctx, args[1]);
+      return;
     default:
       await ctx.reply(
         '❌ פקודה לא מוכרת.\n\n' +
@@ -476,7 +607,8 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
           '<code>/group</code> — רשימת הקבוצות שלי\n' +
           '<code>/group create &lt;שם&gt;</code> — יצירת קבוצה\n' +
           '<code>/group join &lt;קוד&gt;</code> — הצטרפות עם קוד\n' +
-          '<code>/group leave [id]</code> — עזיבת קבוצה',
+          '<code>/group leave [id]</code> — עזיבת קבוצה\n' +
+          '<code>/group status [id]</code> — סטטוס קבוצתי',
         { parse_mode: 'HTML' }
       );
   }
@@ -566,6 +698,59 @@ export function registerGroupHandler(bot: Bot): void {
         .catch((err) => {
           log('warn', 'Groups', `editMessageText (g:c) failed: ${formatError(err)}`);
         });
+    }),
+  );
+
+  // g:s:<id> — render group status (from multi-group picker)
+  bot.callbackQuery(
+    /^g:s:(\d+)$/,
+    wrapCallback('g:s', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:s) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
+
+      const db = getDb();
+      // Auth check before render — non-members must NOT see status (privacy invariant).
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) {
+        await ctx
+          .editMessageText('❌ אינך חבר בקבוצה זו.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:s non-member) failed: ${formatError(e)}`));
+        return;
+      }
+      await renderGroupStatus(ctx, db, groupId);
+    }),
+  );
+
+  // g:refresh:<id> — re-render in place (the 🔄 רענן button)
+  bot.callbackQuery(
+    /^g:refresh:(\d+)$/,
+    wrapCallback('g:refresh', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:refresh) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
+
+      const db = getDb();
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) {
+        await ctx
+          .editMessageText('❌ אינך חבר בקבוצה זו.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:refresh non-member) failed: ${formatError(e)}`));
+        return;
+      }
+      await renderGroupStatus(ctx, db, groupId);
     }),
   );
 

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -433,6 +433,14 @@ async function handleStatus(ctx: Context, groupIdArg: string | undefined): Promi
   }
 
   // Membership check (auth invariant) — only members can view a group's status
+  // TODO(#213): consolidate this membership check pattern into a shared
+  // assertGroupMember(ctx, db, groupId, chatId) helper. The pattern is
+  // duplicated across 6 sites today (handleLeave, handleStatus, g:c, g:s,
+  // g:refresh, g:leaveY) and #213 will add a 7th. The helper should branch
+  // on ctx.callbackQuery for reply vs editMessageText. See PR #232 review
+  // item I1 for the proposed signature. Also kills the redundant
+  // getMembersOfGroup call (review I2): pass the resolved members list to
+  // getMemberStatusesForGroup so renderGroupStatus doesn't re-query.
   const members = getMembersOfGroup(db, groupId);
   if (!members.some((m) => m.userId === chatId)) {
     await ctx.reply('❌ אינך חבר בקבוצה זו.');
@@ -470,6 +478,23 @@ export async function renderGroupStatus(
   }
 
   const statuses = getMemberStatusesForGroup(db, groupId);
+
+  // Defensive — should not happen in practice because the last member
+  // leaving deletes the group via performLeave's auto-delete branch.
+  // But if it ever does, render a clean "empty" state instead of an
+  // ugly "0/0 בסדר" line.
+  if (statuses.length === 0) {
+    const emptyText =
+      `👥 <b>${escapeHtml(group.name)}</b>\n\n<i>הקבוצה ריקה.</i>`;
+    if (ctx.callbackQuery) {
+      await ctx
+        .editMessageText(emptyText, { parse_mode: 'HTML' })
+        .catch((e) => log('warn', 'Groups', `editMessageText (status empty) failed: ${formatError(e)}`));
+    } else {
+      await ctx.reply(emptyText, { parse_mode: 'HTML' });
+    }
+    return;
+  }
 
   let okCount = 0;
   const lines: string[] = [`👥 <b>${escapeHtml(group.name)}</b>`, ''];

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -1,5 +1,7 @@
 import type Database from 'better-sqlite3';
 import { log } from '../logger.js';
+import { getActiveStatusesForContacts } from './safetyStatusRepository.js';
+import type { SafetyStatusRow } from './safetyStatusRepository.js';
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -246,5 +248,36 @@ export function listAllGroupsWithStats(
   return rows.map((r) => ({ ...decodeGroup(r), memberCount: r.member_count }));
 }
 
-// NOTE: `getMemberStatusesForGroup` (joining members with safetyStatusRepository)
-// will be added in Task 2 (#212) to keep this PR tight around #211.
+/**
+ * Aggregates each group member's current active safety_status row, or `null`
+ * if the member has no active status (never reported, or status expired past
+ * the 24h TTL). Used by the `/group status` command and the `g:s:<id>` /
+ * `g:refresh:<id>` callbacks added in #212.
+ *
+ * IMPORTANT: `getActiveStatusesForContacts` returns `SafetyStatusRow[]` (a
+ * plain array, NOT a Map). Verified: safetyStatusRepository.ts:62. The
+ * lookup Map is built locally so each member lookup is O(1).
+ *
+ * Member iteration order matches `getMembersOfGroup` (joined_at ASC), which
+ * gives a stable display order — the rendered card doesn't shuffle on refresh.
+ */
+export function getMemberStatusesForGroup(
+  db: Database.Database,
+  groupId: number,
+): Array<{ userId: number; status: SafetyStatusRow | null }> {
+  const members = getMembersOfGroup(db, groupId);
+  if (members.length === 0) return [];
+
+  const memberIds = members.map((m) => m.userId);
+  const statusRows = getActiveStatusesForContacts(db, memberIds);
+
+  // Build O(1) lookup keyed on chat_id (snake_case at the boundary —
+  // see SafetyStatusRow definition in safetyStatusRepository.ts:3-8).
+  const statusMap = new Map<number, SafetyStatusRow>();
+  for (const row of statusRows) statusMap.set(row.chat_id, row);
+
+  return members.map((m) => ({
+    userId: m.userId,
+    status: statusMap.get(m.userId) ?? null,
+  }));
+}


### PR DESCRIPTION
## Summary

Second PR in the v0.5.1 stacked series. Adds the group-wide safety status aggregation card built on top of #211's foundation.

**Stacked PR strategy** — this targets \`feat/v0.5.1-groups-db\` (PR #230), NOT \`v0.5.1-base\`. Merge order: #230 → #232 (this) → #213 → #225.

### What changes
- **Repository**: new \`getMemberStatusesForGroup(db, groupId)\` helper. Builds a Map locally from the array returned by \`getActiveStatusesForContacts\` (verified: returns plain array, not Map). Member iteration order is stable (joined_at ASC) so cards don't shuffle on refresh.
- **Handler**: new \`/group status [id]\` sub-command + 2 callbacks (\`g:s:<id>\` for picker target, \`g:refresh:<id>\` for the refresh button). Aggregation card shows ✅/⚠️/🔇/❓ per member with display name, home city, relative time, plus a summary count \"X/Y בסדר\".
- **\`renderGroupStatus\` exported with DI**: takes an optional \`lookupUser\` parameter (defaults to real \`getUser\`). This is the seam called out in \`pattern_getuser_singleton_vs_di.md\` — production uses the singleton-backed \`getUser\`, tests inject a function reading from the test's own \`:memory:\` DB.

### Key design decisions
- **No \"safety:menu\" button** — verified during planning that no such callback exists in safetyStatusHandler.ts. Replaced with a text hint pointing to the \`/status\` slash command.
- **Auth invariant enforced everywhere**: command path, g:s callback, and g:refresh callback ALL check group membership before render. Non-members see \"אינך חבר בקבוצה זו\" without leaking the group name.
- **Single-group auto-pick** — if user is in exactly 1 group, \`/group status\` skips the picker and goes straight to render. Multi-group shows inline keyboard. Empty state for users in 0 groups.

### Memory pattern applied (from prior PR review)
- \`pattern_getuser_singleton_vs_di.md\` — \`getUser(chatId)\` reads from \`getDb()\` singleton. Without DI, tests using \`new Database(':memory:')\` would silently produce \"undefined\" display names. Solution: \`renderGroupStatus(ctx, db, groupId, lookupUser?)\` with the seam.

## Test plan
- [x] \`npx tsx --test src/__tests__/groupHandler.test.ts\` (46 tests, +12 new for #212)
- [x] \`npx tsx --test src/__tests__/groupRepository.test.ts\` (25 tests, no regression)
- [x] \`npx tsc --noEmit\` clean
- [x] Full \`npm test\`: 1267/1267 passing (was 1255/1255)
- [ ] Manual smoke (after stack merge): account A creates group, account B joins, both run \`/status ok\`, \`/group status\` shows \"2/2 בסדר\", refresh button updates in place

### Out of scope (deferred to follow-up PRs)
- Status-change auto-propagation to other group members — Task 3 #213
- Dashboard CRUD page + hot-config caps — Task 4 #225

closes #212