### PR TITLE
feat(v0.5.1): #213 קבוצות — התראות סטטוס אוטומטיות

### DIFF
--- a/src/__tests__/groupNotificationService.test.ts
+++ b/src/__tests__/groupNotificationService.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  createGroup,
+  addMember,
+} from '../db/groupRepository.js';
+import { notifyGroupMembersOfStatusChange } from '../services/groupNotificationService.js';
+import type { Bot } from 'grammy';
+
+// Standalone DB pattern (telegramListenerRepository style) — each test owns
+// the seeded users and groups. We use explicit `db` injection everywhere
+// because the production `getUser()` reads from the getDb() singleton, which
+// would silently miss this test's :memory: instance. Pattern documented in
+// memory: pattern_getuser_singleton_vs_di.md.
+
+let db: Database.Database;
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+});
+
+beforeEach(() => {
+  // Cascade wipes group_members + safety_status automatically
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+});
+
+function seedUser(chatId: number, displayName: string): void {
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(chatId, displayName);
+}
+
+function makeTestLookup() {
+  return (chatId: number) =>
+    db.prepare('SELECT display_name FROM users WHERE chat_id = ?').get(chatId) as
+      | { display_name: string | null }
+      | undefined;
+}
+
+const fakeBot = {} as unknown as Bot; // _bot param is unused — only present for API symmetry with safetyNotificationService
+
+describe('notifyGroupMembersOfStatusChange', () => {
+  it("notifies all group members except the sender (status='ok')", async () => {
+    seedUser(1001, 'אבא');
+    seedUser(1002, 'אמא');
+    seedUser(1003, 'ילד');
+    const group = createGroup(db, { name: 'בית', ownerId: 1001, inviteCode: 'NTF001' });
+    addMember(db, group.id, 1002);
+    addMember(db, group.id, 1003);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    // Sender excluded, both other members notified
+    assert.equal(enqueued.length, 2);
+    const chatIds = enqueued.map((t) => t.chatId).sort();
+    assert.deepEqual(chatIds, ['1002', '1003']);
+
+    // Each task carries the sender's display name + group name
+    for (const task of enqueued) {
+      assert.match(task.text, /אבא/);
+      assert.match(task.text, /בית/);
+      assert.match(task.text, /בסדר/);
+      assert.match(task.text, /✅/);
+    }
+  });
+
+  it("formats 'help' status with warning emoji and call-to-action", async () => {
+    seedUser(1001, 'דנה');
+    seedUser(1002, 'אורי');
+    const group = createGroup(db, { name: 'משפחה', ownerId: 1001, inviteCode: 'NTF002' });
+    addMember(db, group.id, 1002);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'help', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    const text = enqueued[0]?.text ?? '';
+    assert.match(text, /דנה/);
+    assert.match(text, /משפחה/);
+    assert.match(text, /⚠️/);
+    assert.match(text, /זקוק/);
+    // The "consider reaching out" call-to-action distinguishes 'help' from 'ok'
+    assert.match(text, /צור|ליצור|קשר/);
+  });
+
+  it("skips notification entirely when status='dismissed'", async () => {
+    seedUser(1001, 'a');
+    seedUser(1002, 'b');
+    const group = createGroup(db, { name: 'g', ownerId: 1001, inviteCode: 'NTF003' });
+    addMember(db, group.id, 1002);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'dismissed', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 0, 'dismissed should not produce any tasks');
+  });
+
+  it('respects notify_group=0 opt-out per member', async () => {
+    seedUser(1001, 'sender');
+    seedUser(1002, 'optedIn');
+    seedUser(1003, 'optedOut');
+    const group = createGroup(db, { name: 'g', ownerId: 1001, inviteCode: 'NTF004' });
+    addMember(db, group.id, 1002);
+    addMember(db, group.id, 1003);
+
+    // Flip notify_group to 0 for member 1003
+    db.prepare('UPDATE group_members SET notify_group = 0 WHERE user_id = ?').run(1003);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    assert.equal(enqueued[0]?.chatId, '1002', 'opted-out member must not receive a task');
+  });
+
+  it("dedupes recipients across overlapping groups", async () => {
+    seedUser(1001, 'sender');
+    seedUser(1002, 'overlapMember');
+    seedUser(1003, 'g1Only');
+    seedUser(1004, 'g2Only');
+    // Two groups, both owned by sender, both contain overlapMember
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'DUP001' });
+    addMember(db, g1.id, 1002);
+    addMember(db, g1.id, 1003);
+    const g2 = createGroup(db, { name: 'work', ownerId: 1001, inviteCode: 'DUP002' });
+    addMember(db, g2.id, 1002);
+    addMember(db, g2.id, 1004);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    // 3 distinct recipients: 1002 (in both groups, deduped), 1003, 1004
+    assert.equal(enqueued.length, 3, `expected 3 deduped recipients, got ${enqueued.length}`);
+    const chatIds = enqueued.map((t) => t.chatId).sort();
+    assert.deepEqual(chatIds, ['1002', '1003', '1004']);
+
+    // The deduped recipient gets the notification labeled with ONE of the
+    // groups (whichever was iterated first via getGroupsForUser ORDER BY
+    // created_at DESC). Just verify it has SOME group name.
+    const overlapTask = enqueued.find((t) => t.chatId === '1002');
+    assert.ok(overlapTask);
+    assert.ok(/family|work/.test(overlapTask.text), `overlap task text should mention a group: ${overlapTask.text}`);
+  });
+
+  it('returns silently when sender belongs to no groups', async () => {
+    seedUser(9999, 'lonely');
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 9999, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+    assert.equal(enqueued.length, 0);
+  });
+
+  it('returns silently when group has only the sender (no recipients)', async () => {
+    seedUser(1001, 'solo');
+    createGroup(db, { name: 'just-me', ownerId: 1001, inviteCode: 'SOLO01' });
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+    assert.equal(enqueued.length, 0);
+  });
+
+  it("uses fallback 'משתמש #<id>' when sender has no display_name", async () => {
+    // No display_name (pre-onboarding state)
+    db.prepare("INSERT INTO users (chat_id, created_at) VALUES (?, datetime('now'))").run(7777);
+    seedUser(8888, 'recipient');
+    const group = createGroup(db, { name: 'g', ownerId: 7777, inviteCode: 'NON001' });
+    addMember(db, group.id, 8888);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 7777, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    assert.match(enqueued[0]?.text ?? '', /משתמש #7777/);
+  });
+
+  it('escapes HTML in display_name and group name to prevent injection', async () => {
+    seedUser(1001, '<script>alert(1)</script>');
+    seedUser(1002, 'recipient');
+    const group = createGroup(db, { name: '<b>EvilGroup</b>', ownerId: 1001, inviteCode: 'XSS001' });
+    addMember(db, group.id, 1002);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    const text = enqueued[0]?.text ?? '';
+    // The literal raw HTML must NOT appear unescaped — must be entity-encoded
+    assert.doesNotMatch(text, /<script>/);
+    assert.doesNotMatch(text, /<b>EvilGroup<\/b>/);
+    assert.match(text, /&lt;script&gt;/);
+    assert.match(text, /&lt;b&gt;EvilGroup&lt;\/b&gt;/);
+  });
+});

--- a/src/bot/safetyStatusHandler.ts
+++ b/src/bot/safetyStatusHandler.ts
@@ -9,6 +9,7 @@ import { createUserCooldown } from './userCooldown.js';
 import { formatRelativeTime, formatTimeUntil, escapeHtml } from '../textUtils.js';
 import { log } from '../logger.js';
 import { notifyContactsOfStatusChange } from '../services/safetyNotificationService.js';
+import { notifyGroupMembersOfStatusChange } from '../services/groupNotificationService.js';
 
 // Set before registering (called from index.ts after initDb).
 let _db: Database.Database | null = null;
@@ -194,6 +195,13 @@ export function registerSafetyStatusHandler(bot: Bot): void {
 
       await ctx.editMessageText(CONFIRMATION[status], { parse_mode: 'HTML' });
       await notifyContactsOfStatusChange(_db, bot, chatId, status);
+      // Fire-and-forget — group propagation must not block the user's UX or
+      // the contact-notification path. Errors are logged via the project
+      // logger; the shared dmQueue handles 429 retries internally. Mirrors
+      // the dispatchSafetyPrompts pattern in alertHandler.ts.
+      notifyGroupMembersOfStatusChange(_db, bot, chatId, status).catch((err) =>
+        log('error', 'GroupNotify', `propagate failed for ${chatId}: ${String(err)}`),
+      );
     } catch (err) {
       log('error', 'SafetyStatus', `כישלון בטיפול בסטטוס בטיחות: ${err}`);
     } finally {

--- a/src/services/groupNotificationService.ts
+++ b/src/services/groupNotificationService.ts
@@ -1,0 +1,101 @@
+import type { Bot } from 'grammy';
+import type Database from 'better-sqlite3';
+import { getGroupsForUser, getMembersOfGroup } from '../db/groupRepository.js';
+import { getUser } from '../db/userRepository.js';
+import type { User } from '../db/userRepository.js';
+import { dmQueue } from './dmQueue.js';
+import { escapeHtml } from '../textUtils.js';
+import { log } from '../logger.js';
+
+/**
+ * Dependencies for `notifyGroupMembersOfStatusChange`. The `getUser` seam is
+ * MANDATORY for tests using `:memory:` databases — the production `getUser()`
+ * reads from the `getDb()` singleton, which is a different instance from a
+ * test-owned `new Database(':memory:')`. Without injection, tests would
+ * silently get `undefined` display names. Pattern documented in memory:
+ * `pattern_getuser_singleton_vs_di.md`.
+ */
+export interface GroupNotificationDeps {
+  enqueueAll?: (tasks: Array<{ chatId: string; text: string }>) => void;
+  getUser?: (chatId: number) => Pick<User, 'display_name'> | undefined;
+}
+
+/**
+ * Notify all members of every group the sender belongs to — except the sender
+ * themselves — that their safety status just changed. Mirrors
+ * `safetyNotificationService.notifyContactsOfStatusChange` in shape and
+ * intent, but operates over groups instead of contacts.
+ *
+ * Behaviour:
+ * - Skips entirely when `status === 'dismissed'` (the user explicitly chose
+ *   not to broadcast)
+ * - Skips when sender belongs to no groups
+ * - Iterates every group the sender is a member of (via `getGroupsForUser`)
+ *   and collects every other member who has not opted out via
+ *   `notify_group = 0`
+ * - **Dedupes** recipients across overlapping groups — a user who shares
+ *   two groups with the sender gets one DM, not two
+ * - Each task carries the group name where the recipient first appeared
+ *   (iteration order is `getGroupsForUser` ORDER BY created_at DESC)
+ * - HTML-escapes both display name and group name to prevent injection
+ *   when tasks reach Telegram's HTML parse mode
+ *
+ * Reuses the **bot-wide** `dmQueue` singleton — never instantiate a second
+ * queue. The queue handles 429 backoff bot-globally and creating a parallel
+ * queue would break that pause semantics.
+ *
+ * `_bot` is accepted for API symmetry with `notifyContactsOfStatusChange`
+ * — `dmQueue` already holds a reference to the bot internally.
+ *
+ * Hooked into `safetyStatusHandler.ts` immediately after the existing
+ * `notifyContactsOfStatusChange` call (~line 197). Fire-and-forget pattern
+ * mirrors `dispatchSafetyPrompts` in `alertHandler.ts`.
+ */
+export async function notifyGroupMembersOfStatusChange(
+  db: Database.Database,
+  _bot: Bot,
+  fromChatId: number,
+  status: 'ok' | 'help' | 'dismissed',
+  deps: GroupNotificationDeps = {},
+): Promise<void> {
+  if (status === 'dismissed') return;
+
+  const groups = getGroupsForUser(db, fromChatId);
+  if (groups.length === 0) return;
+
+  const lookupUser = deps.getUser ?? getUser;
+  const sender = lookupUser(fromChatId);
+  const displayName = escapeHtml(sender?.display_name ?? `משתמש #${fromChatId}`);
+
+  // Dedupe recipients across overlapping groups. Map key is recipient chatId,
+  // value is the group name where they were first seen — that's what gets
+  // shown in the DM ("👥 [groupName] ..."). The first-seen iteration order
+  // matches `getGroupsForUser` (ORDER BY created_at DESC), giving newest
+  // groups priority.
+  const recipients = new Map<number, string>();
+  for (const group of groups) {
+    const members = getMembersOfGroup(db, group.id);
+    for (const m of members) {
+      if (m.userId === fromChatId) continue;
+      if (!m.notifyGroup) continue;
+      if (!recipients.has(m.userId)) {
+        recipients.set(m.userId, group.name);
+      }
+    }
+  }
+  if (recipients.size === 0) return;
+
+  const tasks: Array<{ chatId: string; text: string }> = [];
+  for (const [userId, groupName] of recipients) {
+    const escapedGroup = escapeHtml(groupName);
+    const text =
+      status === 'ok'
+        ? `👥 <b>[${escapedGroup}]</b> ${displayName} דיווח/ה: ✅ בסדר`
+        : `👥 <b>[${escapedGroup}]</b> ⚠️ ${displayName} מדווח/ת: זקוק/ה לעזרה\n\nשקול/י ליצור קשר ישירות.`;
+    tasks.push({ chatId: String(userId), text });
+  }
+
+  log('info', 'GroupNotify', `${fromChatId} → ${tasks.length} recipients (${status})`);
+  const enqueueAll = deps.enqueueAll ?? ((t) => dmQueue.enqueueAll(t));
+  enqueueAll(tasks);
+}


### PR DESCRIPTION
## Summary

Third PR in the v0.5.1 stacked series. When a group member updates their safety status, every other member in their groups gets a DM in real time.

**Stacked PR strategy** — this targets \`feat/v0.5.1-group-status\` (PR #232), which targets \`feat/v0.5.1-groups-db\` (PR #230). Merge order: #230 → #232 → #233 (this) → #225.

## Critical architectural note

The Issue title (\"התראות קבוצתיות אוטומטיות\") could mislead readers into thinking this is an alert-handler hook. **It is not.** This propagation fires when a group member updates **their own safety status**, not when a Pikud HaOref alert is broadcast. \`alertHandler.ts\` is **unchanged** by this PR.

The hook is a single line added to \`safetyStatusHandler.ts\` immediately after the existing \`notifyContactsOfStatusChange\` call. This is the same surface the contacts notification uses — groups simply piggyback on the same trigger point.

## What changes

### New service: \`src/services/groupNotificationService.ts\`
Mirrors \`safetyNotificationService.notifyContactsOfStatusChange\` exactly:
- Iterates every group the sender belongs to via \`getGroupsForUser\`
- Collects every other member who has not opted out via \`notify_group=0\`
- **Dedupes** recipients across overlapping groups (a user sharing two groups with the sender gets ONE DM, not two)
- Reuses the **bot-wide** \`dmQueue\` singleton — never instantiates a second queue
- HTML-escapes display name and group name to prevent injection (XSS test included)
- Skips entirely on \`status='dismissed'\`

### Hook in \`src/bot/safetyStatusHandler.ts\` (~line 197)
One-line addition right after \`await notifyContactsOfStatusChange(...)\`:
\`\`\`typescript
notifyGroupMembersOfStatusChange(_db, bot, chatId, status).catch((err) =>
  log('error', 'GroupNotify', \`propagate failed for \${chatId}: \${String(err)}\`),
);
\`\`\`
**Fire-and-forget** intentionally — group propagation must NOT block:
1. The user's UX (\`editMessageText\` confirmation must arrive immediately)
2. The contacts notification path that runs first

Mirrors the \`dispatchSafetyPrompts\` pattern in \`alertHandler.ts:188\`.

## Memory pattern applied

\`pattern_getuser_singleton_vs_di.md\` — \`getUser(chatId)\` reads from the \`getDb()\` singleton. \`GroupNotificationDeps\` has a **mandatory** \`getUser\` injection seam for \`:memory:\` tests. Without injection, tests would silently get \`undefined\` display names and produce hollow assertions.

## Test plan

- [x] \`npx tsx --test src/__tests__/groupNotificationService.test.ts\` (9 tests, all passing)
- [x] \`npx tsx --test src/__tests__/safetyStatusHandler.test.ts\` (14 tests, **no regression** — existing tests use single-user setup so \`getGroupsForUser\` returns \`[]\` and the new hook returns immediately)
- [x] \`npx tsc --noEmit\` clean
- [x] Full \`npm test\`: 1277/1277 (was 1268/1268 before #213)

### Test coverage breakdown (9 tests)
1. Notifies all group members except sender (status='ok')
2. Formats 'help' status with warning emoji + call-to-action
3. Skips entirely when status='dismissed'
4. Respects \`notify_group=0\` opt-out per member
5. **Dedupes** recipients across overlapping groups
6. Returns silently when sender has no groups
7. Returns silently when group has only the sender (no recipients)
8. Falls back to \"משתמש #<id>\" when display_name is null
9. **HTML-escapes** display name and group name (XSS prevention)

## Out of scope (deferred to follow-up PRs)

- Dashboard CRUD page + hot-config caps — Task 4 #225
- I1+I2 from PR #232 review (\`assertGroupMember\` helper consolidation) — will be done as a polish commit on top of this PR or in a follow-up cleanup PR after the stack merges

closes #213