### PR TITLE
feat(v0.5.1): #225 ניהול קבוצות בדשבורד + hot-config

### DIFF
--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -18,6 +18,7 @@ const WhatsApp         = lazy(() => import('./pages/WhatsApp').then(m => ({ defa
 const WhatsAppListeners  = lazy(() => import('./pages/WhatsAppListeners').then(m => ({ default: m.WhatsAppListeners })));
 const TelegramListeners  = lazy(() => import('./pages/TelegramListeners').then(m => ({ default: m.TelegramListeners })));
 const Configuration      = lazy(() => import('./pages/Configuration'));
+const Groups             = lazy(() => import('./pages/Groups'));
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 30_000 } } });
 
@@ -44,6 +45,7 @@ export function App() {
               <Route path="whatsapp-listeners" element={<WhatsAppListeners />} />
               <Route path="telegram-listeners" element={<TelegramListeners />} />
               <Route path="configuration" element={<Configuration />} />
+              <Route path="groups" element={<Groups />} />
             </Route>
           </Routes>
         </Suspense>

--- a/dashboard-ui/src/layout/Sidebar.tsx
+++ b/dashboard-ui/src/layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import {
-  Activity, Bell, Users, Radio, SlidersHorizontal,
+  Activity, Bell, Users, UsersRound, Radio, SlidersHorizontal,
   Globe, MessageSquare, Phone, Rss, MessageCircle,
   LayoutDashboard, Settings, ChevronLeft, ChevronDown, KeyRound,
 } from 'lucide-react';
@@ -31,6 +31,7 @@ const NAV: SidebarEntry[] = [
     },
   },
   { kind: 'item', item: { to: '/subscribers', icon: Users, label: 'מנויים' } },
+  { kind: 'item', item: { to: '/groups',      icon: UsersRound, label: 'קבוצות חוסן' } },
   { kind: 'item', item: { to: '/operations',  icon: Radio, label: 'מרכז פיקוד' }, dividerAfter: true },
   {
     kind: 'group',

--- a/dashboard-ui/src/pages/Groups.tsx
+++ b/dashboard-ui/src/pages/Groups.tsx
@@ -1,0 +1,262 @@
+import React, { useState } from 'react';
+import { UsersRound, Trash2, X } from 'lucide-react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { motion, AnimatePresence } from 'framer-motion';
+import toast from 'react-hot-toast';
+import { api } from '../api/client';
+import { ConfirmModal } from '../components/ConfirmModal';
+import { EmptyState } from '../components/EmptyState';
+import { Skeleton } from '../components/Skeleton';
+import { GlassCard } from '../components/ui/GlassCard';
+import { PageTransition } from '../components/ui/PageTransition';
+
+// ─── API types — mirror src/dashboard/routes/groups.ts response shape ────────
+
+interface GroupRow {
+  id: number;
+  name: string;
+  inviteCode: string;
+  ownerId: number;
+  ownerDisplayName: string | null;
+  createdAt: string;
+  memberCount: number;
+}
+
+interface GroupsResponse {
+  ok: true;
+  groups: GroupRow[];
+}
+
+interface GroupStats {
+  ok: true;
+  total: number;
+  avgMembers: number;
+  top10: Array<{ id: number; name: string; memberCount: number }>;
+}
+
+interface GroupMemberDetail {
+  userId: number;
+  role: 'owner' | 'member';
+  joinedAt: string;
+  notifyGroup: boolean;
+  displayName: string | null;
+  homeCity: string | null;
+}
+
+interface GroupDetailResponse {
+  ok: true;
+  group: {
+    id: number;
+    name: string;
+    inviteCode: string;
+    ownerId: number;
+    createdAt: string;
+  };
+  members: GroupMemberDetail[];
+}
+
+function relDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('he-IL');
+}
+
+function Groups(): React.ReactElement {
+  const qc = useQueryClient();
+  const [drillId, setDrillId] = useState<number | null>(null);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+
+  const { data: list, isLoading } = useQuery<GroupsResponse>({
+    queryKey: ['dashboard-groups', 'list'],
+    queryFn: () => api.get<GroupsResponse>('/api/groups'),
+  });
+
+  const { data: stats } = useQuery<GroupStats>({
+    queryKey: ['dashboard-groups', 'stats'],
+    queryFn: () => api.get<GroupStats>('/api/groups/stats'),
+  });
+
+  const { data: detail } = useQuery<GroupDetailResponse>({
+    queryKey: ['dashboard-groups', 'detail', drillId],
+    queryFn: () => api.get<GroupDetailResponse>(`/api/groups/${drillId}`),
+    enabled: drillId !== null,
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: number) => api.delete(`/api/groups/${id}`),
+    onSuccess: () => {
+      toast.success('הקבוצה נמחקה');
+      qc.invalidateQueries({ queryKey: ['dashboard-groups'] });
+      setDeleteId(null);
+      setDrillId(null);
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : 'מחיקה נכשלה';
+      toast.error(msg);
+    },
+  });
+
+  return (
+    <PageTransition>
+      <div className="space-y-6 p-6">
+        <header className="flex items-center gap-3">
+          <UsersRound className="text-blue-400" size={28} />
+          <h1 className="text-2xl font-bold">קבוצות חוסן</h1>
+        </header>
+
+        {/* KPI cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <GlassCard className="p-4">
+            <div className="text-sm text-gray-400">סה״כ קבוצות</div>
+            <div className="text-3xl font-bold mt-1">{stats?.total ?? '—'}</div>
+          </GlassCard>
+          <GlassCard className="p-4">
+            <div className="text-sm text-gray-400">חברים בממוצע</div>
+            <div className="text-3xl font-bold mt-1">{stats?.avgMembers ?? '—'}</div>
+          </GlassCard>
+          <GlassCard className="p-4">
+            <div className="text-sm text-gray-400">קבוצה עם הכי הרבה חברים</div>
+            <div className="text-xl font-semibold mt-1 truncate">
+              {stats?.top10[0]?.name ?? '—'}
+              {stats?.top10[0] !== undefined && (
+                <span className="text-sm text-gray-400 mr-2">
+                  ({stats.top10[0].memberCount})
+                </span>
+              )}
+            </div>
+          </GlassCard>
+        </div>
+
+        {/* Groups table */}
+        <GlassCard className="p-4">
+          {isLoading ? (
+            <Skeleton className="h-64" />
+          ) : !list?.groups || list.groups.length === 0 ? (
+            <EmptyState
+              icon="👥"
+              message="אין קבוצות עדיין. קבוצות נוצרות מהבוט עם /group create."
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-white/10 text-sm text-gray-400">
+                    <th className="p-2 text-right">שם</th>
+                    <th className="p-2 text-right">בעלים</th>
+                    <th className="p-2 text-right">חברים</th>
+                    <th className="p-2 text-right">קוד הזמנה</th>
+                    <th className="p-2 text-right">נוצרה</th>
+                    <th className="p-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {list.groups.map((g) => (
+                    <tr
+                      key={g.id}
+                      className="border-b border-white/5 hover:bg-white/5 cursor-pointer"
+                      onClick={() => setDrillId(g.id)}
+                    >
+                      <td className="p-2 font-medium">{g.name}</td>
+                      <td className="p-2 text-sm">
+                        {g.ownerDisplayName ?? <span className="text-gray-500">—</span>}
+                      </td>
+                      <td className="p-2">{g.memberCount}</td>
+                      <td className="p-2 font-mono text-xs">{g.inviteCode}</td>
+                      <td className="p-2 text-sm text-gray-400">{relDate(g.createdAt)}</td>
+                      <td className="p-2 text-left">
+                        <button
+                          aria-label={`מחק קבוצה ${g.name}`}
+                          className="text-red-400 hover:text-red-300"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteId(g.id);
+                          }}
+                        >
+                          <Trash2 size={18} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </GlassCard>
+      </div>
+
+      {/* Detail drawer */}
+      <AnimatePresence>
+        {drillId !== null && detail !== undefined && (
+          <motion.div
+            className="fixed inset-y-0 left-0 w-full md:w-[480px] bg-zinc-900 border-l border-white/10 shadow-2xl z-40 overflow-y-auto"
+            initial={{ x: -480 }}
+            animate={{ x: 0 }}
+            exit={{ x: -480 }}
+            transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+          >
+            <div className="p-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xl font-bold">{detail.group.name}</h2>
+                <button
+                  aria-label="סגור"
+                  className="text-gray-400 hover:text-white"
+                  onClick={() => setDrillId(null)}
+                >
+                  <X size={20} />
+                </button>
+              </div>
+
+              <div className="text-sm text-gray-400 space-y-1">
+                <div>
+                  קוד הזמנה: <span className="font-mono text-white">{detail.group.inviteCode}</span>
+                </div>
+                <div>נוצרה: {relDate(detail.group.createdAt)}</div>
+                <div>חברים: {detail.members.length}</div>
+              </div>
+
+              <div className="border-t border-white/10 pt-4">
+                <h3 className="text-sm font-semibold mb-2 text-gray-300">חברים</h3>
+                <ul className="space-y-2">
+                  {detail.members.map((m) => (
+                    <li key={m.userId} className="flex items-center justify-between p-2 rounded bg-white/5">
+                      <div>
+                        <div className="font-medium">
+                          {m.displayName ?? `משתמש #${m.userId}`}
+                          {m.role === 'owner' && <span className="mr-2 text-xs text-blue-400">בעלים</span>}
+                        </div>
+                        {m.homeCity !== null && m.homeCity !== '' && (
+                          <div className="text-xs text-gray-400">{m.homeCity}</div>
+                        )}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {m.notifyGroup ? '🔔' : '🔕'}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <button
+                className="w-full py-2 bg-red-500/20 text-red-400 rounded hover:bg-red-500/30"
+                onClick={() => setDeleteId(detail.group.id)}
+              >
+                מחק קבוצה
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <ConfirmModal
+        open={deleteId !== null}
+        title="מחיקת קבוצה"
+        description="האם אתה בטוח שברצונך למחוק את הקבוצה? כל החברים יסולקו ולא ניתן לבטל פעולה זו."
+        danger
+        onConfirm={() => {
+          if (deleteId !== null) deleteMut.mutate(deleteId);
+        }}
+        onCancel={() => setDeleteId(null)}
+      />
+    </PageTransition>
+  );
+}
+
+export default Groups;

--- a/src/__tests__/dashboard/routes/groups.test.ts
+++ b/src/__tests__/dashboard/routes/groups.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import request from 'supertest';
+import { initDb, getDb, closeDb } from '../../../db/schema.js';
+import { createGroupsRouter, groupMutateLimiter } from '../../../dashboard/routes/groups.js';
+import {
+  createGroup,
+  addMember,
+  countMembersOfGroup,
+  findGroupById,
+} from '../../../db/groupRepository.js';
+
+// IMPORTANT: this test runs with DB_PATH=:memory: set on the command line.
+// We use initDb()+getDb() (not new Database(':memory:')) so the singleton
+// is the SAME instance the route's getUser() calls read from. Without this,
+// owner display names would be silently null even though we seeded them
+// (pattern_getuser_singleton_vs_di.md).
+
+let app: express.Express;
+
+before(() => {
+  initDb();
+  app = express();
+  app.use(express.json());
+  app.use('/api/groups', createGroupsRouter(getDb()));
+});
+
+after(() => closeDb());
+
+beforeEach(() => {
+  const db = getDb();
+  // Cascade order: groups → group_members (via FK CASCADE)
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(1001, 'אבא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(1002, 'אמא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(1003, 'ילד');
+  // Reset DELETE rate limit state between tests so multiple tests can hit DELETE.
+  // Pattern: pattern_rate_limiter_test_isolation.md.
+  groupMutateLimiter.clearStore();
+});
+
+describe('GET /api/groups', () => {
+  it('returns empty list when no groups exist', async () => {
+    const res = await request(app).get('/api/groups');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.deepEqual(res.body.groups, []);
+  });
+
+  it('returns groups with member count and owner display name', async () => {
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'API001' });
+    const g2 = createGroup(db, { name: 'work',   ownerId: 1002, inviteCode: 'API002' });
+    addMember(db, g2.id, 1003);
+
+    const res = await request(app).get('/api/groups');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.groups.length, 2);
+
+    const byId = new Map(res.body.groups.map((g: any) => [g.id, g]));
+    const familyGroup = byId.get(g1.id) as any;
+    assert.equal(familyGroup.name, 'family');
+    assert.equal(familyGroup.ownerId, 1001);
+    assert.equal(familyGroup.ownerDisplayName, 'אבא', 'getUser() must resolve via singleton — pattern_getuser_singleton_vs_di');
+    assert.equal(familyGroup.memberCount, 1);
+    assert.equal(familyGroup.inviteCode, 'API001');
+
+    const workGroup = byId.get(g2.id) as any;
+    assert.equal(workGroup.memberCount, 2);
+    assert.equal(workGroup.ownerDisplayName, 'אמא');
+  });
+});
+
+describe('GET /api/groups/stats', () => {
+  it('returns zero stats when no groups exist', async () => {
+    const res = await request(app).get('/api/groups/stats');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(res.body.total, 0);
+    assert.equal(res.body.avgMembers, 0);
+    assert.deepEqual(res.body.top10, []);
+  });
+
+  it('computes total + avgMembers + top10 correctly', async () => {
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'tiny', ownerId: 1001, inviteCode: 'STAT01' });
+    const g2 = createGroup(db, { name: 'big',  ownerId: 1002, inviteCode: 'STAT02' });
+    addMember(db, g2.id, 1003);
+
+    const res = await request(app).get('/api/groups/stats');
+    assert.equal(res.body.total, 2);
+    // (1 + 2) / 2 = 1.5
+    assert.equal(res.body.avgMembers, 1.5);
+    assert.equal(res.body.top10.length, 2);
+    // Sorted desc by memberCount → 'big' first
+    assert.equal(res.body.top10[0].id, g2.id);
+    assert.equal(res.body.top10[0].name, 'big');
+    assert.equal(res.body.top10[0].memberCount, 2);
+  });
+
+  // Make sure /stats doesn't get matched as /:id
+  it('static /stats route takes precedence over /:id', async () => {
+    const res = await request(app).get('/api/groups/stats');
+    assert.equal(res.status, 200);
+    assert.equal(typeof res.body.total, 'number', 'should return stats shape, not group-not-found');
+  });
+});
+
+describe('GET /api/groups/:id', () => {
+  it('returns 400 for invalid id (NaN / negative / zero)', async () => {
+    for (const badId of ['abc', '-5', '0']) {
+      const res = await request(app).get(`/api/groups/${badId}`);
+      assert.equal(res.status, 400, `expected 400 for badId="${badId}"`);
+      assert.equal(res.body.ok, false);
+    }
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app).get('/api/groups/999999');
+    assert.equal(res.status, 404);
+    assert.equal(res.body.ok, false);
+  });
+
+  it('returns full group + member list for known id', async () => {
+    const db = getDb();
+    const group = createGroup(db, { name: 'detail', ownerId: 1001, inviteCode: 'DTL001' });
+    addMember(db, group.id, 1002);
+
+    const res = await request(app).get(`/api/groups/${group.id}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.group.id, group.id);
+    assert.equal(res.body.group.name, 'detail');
+    assert.equal(res.body.members.length, 2);
+
+    // Member entries enriched with display name + role + notify_group
+    const owner = res.body.members.find((m: any) => m.userId === 1001);
+    assert.ok(owner);
+    assert.equal(owner.displayName, 'אבא');
+    assert.equal(owner.role, 'owner');
+    assert.equal(owner.notifyGroup, true);
+
+    const member = res.body.members.find((m: any) => m.userId === 1002);
+    assert.equal(member.role, 'member');
+    assert.equal(member.displayName, 'אמא');
+  });
+});
+
+describe('DELETE /api/groups/:id', () => {
+  it('returns 400 for invalid id', async () => {
+    const res = await request(app).delete('/api/groups/abc');
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app).delete('/api/groups/999999');
+    assert.equal(res.status, 404);
+  });
+
+  it('deletes group and CASCADEs to remove member rows', async () => {
+    const db = getDb();
+    const group = createGroup(db, { name: 'doomed', ownerId: 1001, inviteCode: 'DEL001' });
+    addMember(db, group.id, 1002);
+    addMember(db, group.id, 1003);
+    assert.equal(countMembersOfGroup(db, group.id), 3);
+
+    const res = await request(app).delete(`/api/groups/${group.id}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+
+    // Group is gone
+    assert.equal(findGroupById(db, group.id), undefined);
+    // CASCADE removed all 3 member rows
+    const remainingMembers = db
+      .prepare('SELECT * FROM group_members WHERE group_id = ?')
+      .all(group.id);
+    assert.equal(remainingMembers.length, 0);
+  });
+
+  it('rate limits after 5 requests in a minute', async () => {
+    const db = getDb();
+    // Create 6 groups so we can try 6 deletes
+    for (let i = 0; i < 6; i++) {
+      createGroup(db, { name: `g${i}`, ownerId: 1001, inviteCode: `RL${i.toString().padStart(4, '0')}` });
+    }
+    const groupIds = db.prepare('SELECT id FROM groups ORDER BY id ASC').all() as Array<{ id: number }>;
+
+    // First 5 deletes succeed
+    for (let i = 0; i < 5; i++) {
+      const id = groupIds[i]?.id;
+      const res = await request(app).delete(`/api/groups/${id}`);
+      assert.equal(res.status, 200, `delete ${i + 1} should succeed`);
+    }
+
+    // 6th delete is rate-limited
+    const lastId = groupIds[5]?.id;
+    const res = await request(app).delete(`/api/groups/${lastId}`);
+    assert.equal(res.status, 429, '6th delete in window should be rate-limited');
+  });
+});

--- a/src/__tests__/dashboard/routes/settings.test.ts
+++ b/src/__tests__/dashboard/routes/settings.test.ts
@@ -148,6 +148,49 @@ describe('PATCH /api/settings — value validation', () => {
     assert.equal(res.status, 400);
   });
 
+  // PR #234 review #1 — caps must be ≥1 (validatePositiveInt rejects 0).
+  // Three reviewer agents converged on this: groups_max_per_user=0 would
+  // make countGroupsOwnedBy(...) >= 0 always true → every create rejected.
+  it('rejects groups_max_per_user=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('groups_max_per_user'));
+    assert.ok(res.body.error.includes('חיובי') || res.body.error.includes('≥1'));
+    // No partial write
+    const row = db.prepare("SELECT value FROM settings WHERE key = 'groups_max_per_user'").get();
+    assert.equal(row, undefined);
+  });
+
+  it('rejects groups_max_members=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_members: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('groups_max_members'));
+    assert.ok(res.body.error.includes('חיובי') || res.body.error.includes('≥1'));
+  });
+
+  it('accepts groups_max_per_user=1 (boundary)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '1' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+  });
+
+  it('accepts groups_max_per_user=100 (typical hot-config value)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '100' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects groups_max_per_user=-5 (also negative)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '-5' });
+    assert.equal(res.status, 400);
+  });
+
+  it('accepts groups_invite_code_ttl_hours=0 (means "never expire" in v0.5.2 semantics)', async () => {
+    // Unlike the cap keys, the TTL key uses validateNonNegativeInt because
+    // 0 plausibly encodes "no expiry". This is documented in settings.ts.
+    const res = await request(app).patch('/api/settings').send({ groups_invite_code_ttl_hours: '0' });
+    assert.equal(res.status, 200);
+  });
+
   it('does NOT partially apply when one key in a multi-key PATCH is invalid', async () => {
     // Both keys are allowed, but the second one fails validation. The first
     // key must NOT be persisted (validation runs as a separate pass before

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -207,6 +207,65 @@ describe('groupHandler — /group create', () => {
     assert.match(text, /הגעת לגבול|מקסימום|מוגבל/);
     assert.equal(countGroupsOwnedBy(db, 1001), MAX_GROUPS_PER_USER_FALLBACK);
   });
+
+  // PR #225 — hot-config override for groups_max_per_user
+  it('reads groups_max_per_user from settings table at runtime (hot-config)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    // Override the cap via the settings table — simulates a dashboard PATCH.
+    // Without the configResolver wiring, this would be ignored and the cap
+    // would still be MAX_GROUPS_PER_USER_FALLBACK (5). With the wiring, the
+    // handler reads `groups_max_per_user = 2` and rejects on the 3rd create.
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)").run('groups_max_per_user', '2');
+
+    // Pre-create 2 groups (at the new cap)
+    createGroup(db, { name: 'g1', ownerId: 1001, inviteCode: 'HC0001' });
+    createGroup(db, { name: 'g2', ownerId: 1001, inviteCode: 'HC0002' });
+
+    // 3rd create should be rejected
+    const ctx = makeCtx({ message: { text: '/group create third' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הגעת לגבול/);
+    // Error message should reference the OVERRIDE value, not the fallback
+    assert.match(text, /\b2 קבוצות/, 'cap message should show the dashboard-overridden value (2)');
+    assert.equal(countGroupsOwnedBy(db, 1001), 2);
+
+    // Cleanup — restore default for subsequent tests
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+
+  it('reads groups_max_members from settings table at runtime (hot-config)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+
+    // Cap members at 2 via dashboard override
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)").run('groups_max_members', '2');
+
+    const group = createGroup(db, { name: 'tiny', ownerId: 1001, inviteCode: 'HCM001' });
+    upsertUser(1002);
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    // 3rd member tries to join via /group join — should be rejected
+    upsertUser(1003);
+    const ctx = makeCtx({ chat: { id: 1003, type: 'private' }, message: { text: '/group join HCM001' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הקבוצה מלאה/);
+    assert.match(text, /\b2 חברים/);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_members'").run();
+  });
 });
 
 describe('groupHandler — /group join', () => {

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -1036,3 +1036,115 @@ describe('g:s and g:refresh callbacks', () => {
     assert.doesNotMatch(text, /rfr-secret/);
   });
 });
+
+// PR #234 review #1 + #3 — defense in depth for hot-config caps.
+// Three reviewer agents independently flagged that cap=0 silently bricks the
+// feature. The fix has two layers:
+//   1. Dashboard validator (validatePositiveInt) rejects 0 at the PATCH
+//      boundary — covered by settings.test.ts.
+//   2. Runtime resolveIntConfig has a `minimum` parameter that clamps to
+//      fallback if the DB/env value is below the floor — covered HERE.
+//      This catches env-var bypass + direct-SQL writes + corrupt rows.
+describe('PR #234 review — hot-config defense in depth', () => {
+  it('cap=0 in DB falls back to MAX_GROUPS_PER_USER_FALLBACK (not 0)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    // Bypass the dashboard validator by writing directly to settings —
+    // simulates an env var override, a corrupt row, or pre-validator data.
+    // The runtime should NOT use 0; resolveIntConfig clamps to fallback.
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_per_user', '0');
+
+    // Pre-create exactly MAX_GROUPS_PER_USER_FALLBACK groups so the
+    // fallback's cap is hit on the next create
+    for (let i = 0; i < MAX_GROUPS_PER_USER_FALLBACK; i++) {
+      createGroup(db, { name: `g${i}`, ownerId: 1001, inviteCode: `D0D${i}AB` });
+    }
+
+    const ctx = makeCtx({ message: { text: '/group create blocked-by-fallback' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    // The error message must reference the FALLBACK value (5), NOT 0.
+    // If the bug were unfixed, the message would say "ניתן ליצור עד 0 קבוצות".
+    assert.match(text, new RegExp(`ניתן ליצור עד ${MAX_GROUPS_PER_USER_FALLBACK}`));
+    assert.doesNotMatch(text, /ניתן ליצור עד 0/);
+    assert.equal(countGroupsOwnedBy(db, 1001), MAX_GROUPS_PER_USER_FALLBACK);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+
+  it('cap=0 still allows group creation when under fallback cap', async () => {
+    // The CRITICAL property: cap=0 must NOT block creation when the user
+    // has < fallback groups. This is the actual symptom of the bug —
+    // a fresh user with 0 groups gets ❌ "ניתן ליצור עד 0 קבוצות" on
+    // their first create.
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_per_user', '0');
+
+    const ctx = makeCtx({ message: { text: '/group create works-despite-zero' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    // Success path: group is created using the fallback cap of 5
+    assert.match(text, /קבוצה נוצרה/);
+    assert.equal(countGroupsOwnedBy(db, 1001), 1);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+
+  it('groups_max_members=0 falls back to MAX_MEMBERS_PER_GROUP_FALLBACK', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    upsertUser(1002);
+    const db = getDb();
+
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_members', '0');
+
+    const group = createGroup(db, { name: 'doomed', ownerId: 1001, inviteCode: 'MEMBR1' });
+    // Without defense in depth, this join would be rejected with
+    // "❌ הקבוצה מלאה (מקסימום 0 חברים)" — instead it should succeed
+    // because the fallback (20) kicks in.
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join MEMBR1' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הצטרפת לקבוצה/);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_members'").run();
+  });
+
+  it('unparseable cap value (PR #234 review #3) falls back without crashing', async () => {
+    // An admin typo'd "five" into the dashboard (bypass via env var or
+    // corrupt row). resolveIntConfig should warn-log AND fall back —
+    // group creation should proceed normally with the fallback cap.
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_per_user', 'five');
+
+    const ctx = makeCtx({ message: { text: '/group create works-anyway' } });
+    await bot._fireCmd('group', ctx);
+
+    // Success path proves the early-return-on-NaN was taken (fallback used)
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /קבוצה נוצרה/);
+    assert.equal(countGroupsOwnedBy(db, 1001), 1);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+});

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -22,13 +22,45 @@ import {
 import { getDb } from '../db/schema.js';
 import { log } from '../logger.js';
 import { escapeHtml, formatRelativeTime } from '../textUtils.js';
+import { resolveConfig } from '../config/configResolver.js';
 
-// ─── Constants (fallbacks until Task 4 #225 wires configResolver) ────────────
+// ─── Hot-config caps (resolved per call via configResolver) ──────────────────
 
-/** Max groups a single user may own. Task 4 will replace with hot-config. */
+/**
+ * Default max groups a single user may own. Overridable via the dashboard
+ * Settings page (writes to the `groups_max_per_user` key in the `settings`
+ * table). Read on every /group create call so dashboard changes take effect
+ * immediately without restart.
+ */
 export const MAX_GROUPS_PER_USER_FALLBACK = 5;
-/** Max members per group, including owner. Task 4 will replace with hot-config. */
+/**
+ * Default max members per group, including owner. Overridable via the
+ * dashboard Settings page (`groups_max_members`). Read on every /group join.
+ */
 export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
+
+/**
+ * Resolves a hot-config integer cap with fallback. Wraps `resolveConfig`
+ * with parsing + fallback so the call sites stay clean. Reads on every
+ * call — appropriate for low-frequency user-triggered paths (/group create
+ * and /group join). For per-alert hot paths, prefer cached patterns.
+ */
+function resolveIntConfig(key: string, fallback: number): number {
+  const raw = resolveConfig(getDb(), key);
+  if (raw === null || raw === undefined) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && Number.isInteger(n) && n >= 0 ? n : fallback;
+}
+
+/** Hot-configurable — reads `groups_max_per_user` from DB→env→fallback. */
+function getMaxGroupsPerUser(): number {
+  return resolveIntConfig('groups_max_per_user', MAX_GROUPS_PER_USER_FALLBACK);
+}
+
+/** Hot-configurable — reads `groups_max_members` from DB→env→fallback. */
+function getMaxMembersPerGroup(): number {
+  return resolveIntConfig('groups_max_members', MAX_MEMBERS_PER_GROUP_FALLBACK);
+}
 
 const JOIN_COOLDOWN_MS = 5_000;
 const MAX_JOIN_FAILURES = 5;
@@ -247,9 +279,10 @@ async function handleCreate(ctx: Context, name: string): Promise<void> {
   }
 
   const db = getDb();
-  if (countGroupsOwnedBy(db, chatId) >= MAX_GROUPS_PER_USER_FALLBACK) {
+  const maxGroups = getMaxGroupsPerUser();
+  if (countGroupsOwnedBy(db, chatId) >= maxGroups) {
     await ctx.reply(
-      `❌ הגעת לגבול: ניתן ליצור עד ${MAX_GROUPS_PER_USER_FALLBACK} קבוצות.\nמחק קבוצה קיימת לפני יצירת חדשה.`
+      `❌ הגעת לגבול: ניתן ליצור עד ${maxGroups} קבוצות.\nמחק קבוצה קיימת לפני יצירת חדשה.`
     );
     return;
   }
@@ -326,9 +359,10 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
     return;
   }
 
-  if (members.length >= MAX_MEMBERS_PER_GROUP_FALLBACK) {
+  const maxMembers = getMaxMembersPerGroup();
+  if (members.length >= maxMembers) {
     await ctx.reply(
-      `❌ הקבוצה מלאה (מקסימום ${MAX_MEMBERS_PER_GROUP_FALLBACK} חברים).`
+      `❌ הקבוצה מלאה (מקסימום ${maxMembers} חברים).`
     );
     return;
   }

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -44,22 +44,49 @@ export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
  * with parsing + fallback so the call sites stay clean. Reads on every
  * call — appropriate for low-frequency user-triggered paths (/group create
  * and /group join). For per-alert hot paths, prefer cached patterns.
+ *
+ * PR #234 review #1 (3 reviewers converged): the dashboard validator
+ * `validatePositiveInt` rejects 0 at the PATCH boundary, but env vars
+ * and direct SQL writes bypass it. The `minimum` parameter enforces the
+ * floor at the runtime layer too — defense in depth. For cap keys, pass
+ * `minimum: 1` so a stray 0 falls back to the safe default instead of
+ * silently bricking the feature.
+ *
+ * PR #234 review #3: when raw is set but unparseable (e.g. an admin typo'd
+ * "five" into the dashboard, bypassing the validator via direct env var,
+ * or the row got corrupted), log a warn so the issue is visible. Without
+ * this, the bot would silently keep using the fallback forever with no
+ * trace in the logs that the override is being ignored.
  */
-function resolveIntConfig(key: string, fallback: number): number {
+function resolveIntConfig(key: string, fallback: number, minimum: number = 0): number {
   const raw = resolveConfig(getDb(), key);
   if (raw === null || raw === undefined) return fallback;
   const n = Number(raw);
-  return Number.isFinite(n) && Number.isInteger(n) && n >= 0 ? n : fallback;
+  if (Number.isFinite(n) && Number.isInteger(n) && n >= minimum) return n;
+  log(
+    'warn',
+    'Groups',
+    `invalid config value for "${key}": ${JSON.stringify(raw)} (minimum=${minimum}) — falling back to ${fallback}`,
+  );
+  return fallback;
 }
 
-/** Hot-configurable — reads `groups_max_per_user` from DB→env→fallback. */
+/**
+ * Hot-configurable — reads `groups_max_per_user` from DB→env→fallback.
+ * Minimum 1 enforced at the runtime layer (defense in depth — see
+ * resolveIntConfig docstring).
+ */
 function getMaxGroupsPerUser(): number {
-  return resolveIntConfig('groups_max_per_user', MAX_GROUPS_PER_USER_FALLBACK);
+  return resolveIntConfig('groups_max_per_user', MAX_GROUPS_PER_USER_FALLBACK, 1);
 }
 
-/** Hot-configurable — reads `groups_max_members` from DB→env→fallback. */
+/**
+ * Hot-configurable — reads `groups_max_members` from DB→env→fallback.
+ * Minimum 1 enforced at the runtime layer (defense in depth — see
+ * resolveIntConfig docstring).
+ */
 function getMaxMembersPerGroup(): number {
-  return resolveIntConfig('groups_max_members', MAX_MEMBERS_PER_GROUP_FALLBACK);
+  return resolveIntConfig('groups_max_members', MAX_MEMBERS_PER_GROUP_FALLBACK, 1);
 }
 
 const JOIN_COOLDOWN_MS = 5_000;

--- a/src/config/configResolver.ts
+++ b/src/config/configResolver.ts
@@ -47,6 +47,10 @@ export const CONFIG_KEYS: ReadonlySet<string> = new Set([
   'all_clear_topic_id',
   'landing_url',
   'privacy_defaults',
+  // v0.5.1 — group feature hot-config (refs #225)
+  'groups_max_per_user',
+  'groups_max_members',
+  'groups_invite_code_ttl_hours',
 ]);
 
 /** Keys whose change requires a process restart to take effect. */

--- a/src/dashboard/router.ts
+++ b/src/dashboard/router.ts
@@ -11,6 +11,7 @@ import { createWhatsAppRouter } from './routes/whatsapp.js';
 import { createListenersRouter } from './routes/whatsappListeners.js';
 import { createTelegramListenerRouter } from './routes/telegramListeners.js';
 import { createSecretsRouter } from './routes/secrets.js';
+import { createGroupsRouter } from './routes/groups.js';
 import * as whatsappService from '../whatsapp/whatsappService.js';
 import { getEnabledGroupsForAlertType } from '../db/whatsappGroupRepository.js';
 
@@ -30,5 +31,6 @@ export function createApiRouter(db: Database.Database, bot: Bot): Router {
   router.use('/whatsapp', createWhatsAppRouter(db, whatsappService));
   router.use('/telegram', createTelegramListenerRouter(db, bot));
   router.use('/secrets', createSecretsRouter(db));
+  router.use('/groups', createGroupsRouter(db));
   return router;
 }

--- a/src/dashboard/routes/groups.ts
+++ b/src/dashboard/routes/groups.ts
@@ -1,0 +1,177 @@
+import { Router } from 'express';
+import type Database from 'better-sqlite3';
+import { log } from '../../logger.js';
+import {
+  listAllGroupsWithStats,
+  findGroupById,
+  getMembersOfGroup,
+  deleteGroup,
+} from '../../db/groupRepository.js';
+import { getUser } from '../../db/userRepository.js';
+import { createRateLimitMiddleware } from '../rateLimiter.js';
+
+/**
+ * Mutation endpoints (DELETE) are rate-limited per IP — admin moderation
+ * actions should be deliberate. 5 deletes per minute is generous for normal
+ * use and tight enough to prevent runaway scripts.
+ *
+ * Exported so tests can call `.clearStore()` between cases — same pattern
+ * as the other dashboard route limiters. Per memory:
+ * pattern_rate_limiter_test_isolation.md.
+ */
+export const groupMutateLimiter = createRateLimitMiddleware({
+  maxRequests: 5,
+  windowMs: 60_000,
+  message: 'יותר מדי פעולות מחיקה — נסה שוב בעוד דקה',
+});
+
+export function createGroupsRouter(db: Database.Database): Router {
+  const router = Router();
+
+  /**
+   * GET /api/groups
+   * Lists every group in the system with member count, owner display name,
+   * and creation timestamp. Used by the dashboard Groups page table.
+   */
+  router.get('/', (_req, res) => {
+    try {
+      const rows = listAllGroupsWithStats(db);
+      // Enrich each row with the owner's display name (single getUser call
+      // per group — bounded by the total number of groups in the system,
+      // which is small for the foreseeable future).
+      const groups = rows.map((g) => {
+        const owner = getUser(g.ownerId);
+        return {
+          id: g.id,
+          name: g.name,
+          inviteCode: g.inviteCode,
+          ownerId: g.ownerId,
+          ownerDisplayName: owner?.display_name ?? null,
+          createdAt: g.createdAt,
+          memberCount: g.memberCount,
+        };
+      });
+      res.json({ ok: true, groups });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `list failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to list groups' });
+    }
+  });
+
+  /**
+   * GET /api/groups/stats
+   * Aggregate statistics for the dashboard KPI cards: total groups, average
+   * members per group, and the top-10 most-populated groups.
+   *
+   * Must come BEFORE /:id so the static segment doesn't get matched as an id.
+   */
+  router.get('/stats', (_req, res) => {
+    try {
+      const rows = listAllGroupsWithStats(db);
+      const total = rows.length;
+      const avgMembers =
+        total === 0 ? 0 : rows.reduce((s, g) => s + g.memberCount, 0) / total;
+      const top10 = [...rows]
+        .sort((a, b) => b.memberCount - a.memberCount)
+        .slice(0, 10)
+        .map((g) => ({ id: g.id, name: g.name, memberCount: g.memberCount }));
+
+      res.json({
+        ok: true,
+        total,
+        avgMembers: Number(avgMembers.toFixed(2)),
+        top10,
+      });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `stats failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to compute stats' });
+    }
+  });
+
+  /**
+   * GET /api/groups/:id
+   * Drill-down detail for a single group: full member list with display
+   * names + roles + joined_at + notify_group flag. Used by the dashboard
+   * Groups drawer when clicking a row.
+   */
+  router.get('/:id', (req, res) => {
+    try {
+      const idParam = req.params['id'];
+      const id = Number(idParam);
+      if (!Number.isInteger(id) || id <= 0) {
+        res.status(400).json({ ok: false, error: 'Invalid group id' });
+        return;
+      }
+
+      const group = findGroupById(db, id);
+      if (!group) {
+        res.status(404).json({ ok: false, error: 'Group not found' });
+        return;
+      }
+
+      const members = getMembersOfGroup(db, id).map((m) => {
+        const user = getUser(m.userId);
+        return {
+          userId: m.userId,
+          role: m.role,
+          joinedAt: m.joinedAt,
+          notifyGroup: m.notifyGroup,
+          displayName: user?.display_name ?? null,
+          homeCity: user?.home_city ?? null,
+        };
+      });
+
+      res.json({
+        ok: true,
+        group: {
+          id: group.id,
+          name: group.name,
+          inviteCode: group.inviteCode,
+          ownerId: group.ownerId,
+          createdAt: group.createdAt,
+        },
+        members,
+      });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `get failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to fetch group' });
+    }
+  });
+
+  /**
+   * DELETE /api/groups/:id
+   * Admin moderation — deletes a group and CASCADE removes all member rows.
+   * Rate-limited via groupMutateLimiter (5 per minute per IP).
+   * Logs at WARN level to make moderation actions visible in the operations
+   * log.
+   */
+  router.delete('/:id', groupMutateLimiter, (req, res) => {
+    try {
+      const idParam = req.params['id'];
+      const id = Number(idParam);
+      if (!Number.isInteger(id) || id <= 0) {
+        res.status(400).json({ ok: false, error: 'Invalid group id' });
+        return;
+      }
+
+      const group = findGroupById(db, id);
+      if (!group) {
+        res.status(404).json({ ok: false, error: 'Group not found' });
+        return;
+      }
+
+      deleteGroup(db, id);
+      log(
+        'warn',
+        'Dashboard/Groups',
+        `admin deleted group ${id} (${group.name}, owner=${group.ownerId})`,
+      );
+      res.json({ ok: true });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `delete failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to delete group' });
+    }
+  });
+
+  return router;
+}

--- a/src/dashboard/routes/groups.ts
+++ b/src/dashboard/routes/groups.ts
@@ -32,25 +32,23 @@ export function createGroupsRouter(db: Database.Database): Router {
    * GET /api/groups
    * Lists every group in the system with member count, owner display name,
    * and creation timestamp. Used by the dashboard Groups page table.
+   *
+   * PR #234 review #2: previously this called `getUser(g.ownerId)` per row
+   * (N+1). The owner display name now comes from the LEFT JOIN inside
+   * `listAllGroupsWithStats` itself — single SQL query regardless of row count.
    */
   router.get('/', (_req, res) => {
     try {
       const rows = listAllGroupsWithStats(db);
-      // Enrich each row with the owner's display name (single getUser call
-      // per group — bounded by the total number of groups in the system,
-      // which is small for the foreseeable future).
-      const groups = rows.map((g) => {
-        const owner = getUser(g.ownerId);
-        return {
-          id: g.id,
-          name: g.name,
-          inviteCode: g.inviteCode,
-          ownerId: g.ownerId,
-          ownerDisplayName: owner?.display_name ?? null,
-          createdAt: g.createdAt,
-          memberCount: g.memberCount,
-        };
-      });
+      const groups = rows.map((g) => ({
+        id: g.id,
+        name: g.name,
+        inviteCode: g.inviteCode,
+        ownerId: g.ownerId,
+        ownerDisplayName: g.ownerDisplayName,
+        createdAt: g.createdAt,
+        memberCount: g.memberCount,
+      }));
       res.json({ ok: true, groups });
     } catch (err) {
       log('error', 'Dashboard/Groups', `list failed: ${String(err)}`);

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -60,6 +60,22 @@ function validateNonNegativeInt(value: string): string | null {
   return null;
 }
 
+/**
+ * Strict positive integer validator (n ≥ 1). Use for caps where 0 would
+ * silently disable the feature instead of expressing "no limit". For example:
+ * `groups_max_per_user = 0` would make `countGroupsOwnedBy(...) >= 0` always
+ * true, blocking every group creation with no error visible to the admin
+ * who set the value via the dashboard. Three reviewer agents independently
+ * flagged this on PR #234.
+ */
+function validatePositiveInt(value: string): string | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    return `הערך חייב להיות מספר שלם חיובי (≥1), התקבל: ${value}`;
+  }
+  return null;
+}
+
 function validateBoolish(value: string): string | null {
   return value === 'true' || value === 'false'
     ? null
@@ -88,8 +104,12 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   whatsapp_enabled:              validateBoolish,
   privacy_defaults:              validateJson,
   // v0.5.1 — group feature hot-config (refs #225)
-  groups_max_per_user:           validateNonNegativeInt,
-  groups_max_members:            validateNonNegativeInt,
+  // PR #234 review: caps must be ≥1 because 0 would brick the feature
+  // (countGroupsOwnedBy(...) >= 0 is always true → every create rejected).
+  // groups_invite_code_ttl_hours stays non-negative because 0 plausibly
+  // means "never expire" (semantics to be defined when v0.5.2 enforces TTL).
+  groups_max_per_user:           validatePositiveInt,
+  groups_max_members:            validatePositiveInt,
   groups_invite_code_ttl_hours:  validateNonNegativeInt,
 };
 

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -35,6 +35,10 @@ const ALLOWED_KEYS = new Set([
   'dm_relevance_in_area',
   'dm_relevance_nearby',
   'dm_relevance_not_area',
+  // v0.5.1 — group feature hot-config (refs #225)
+  'groups_max_per_user',
+  'groups_max_members',
+  'groups_invite_code_ttl_hours',
 ]);
 
 // ─── Per-key value validators ─────────────────────────────────────────────
@@ -83,6 +87,10 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   quiet_hours_global:            validateBoolish,
   whatsapp_enabled:              validateBoolish,
   privacy_defaults:              validateJson,
+  // v0.5.1 — group feature hot-config (refs #225)
+  groups_max_per_user:           validateNonNegativeInt,
+  groups_max_members:            validateNonNegativeInt,
+  groups_invite_code_ttl_hours:  validateNonNegativeInt,
 };
 
 export function createSettingsRouter(db: Database.Database): Router {

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -231,21 +231,37 @@ export function countMembersOfGroup(
 }
 
 /**
- * Dashboard listing helper — joins group with its member count in a single query.
- * Used by `src/dashboard/routes/groups.ts` in Task 4.
+ * Dashboard listing helper — joins group with its member count AND owner's
+ * display_name in a single query. Used by `src/dashboard/routes/groups.ts`.
+ *
+ * PR #234 review #2: previously this returned only the group + memberCount
+ * and the route called `getUser(g.ownerId)` once per row to enrich the owner
+ * display name — a classic N+1. At thousands of groups the dashboard would
+ * stall. The LEFT JOIN to `users` makes the entire enrichment a single query.
+ *
+ * LEFT JOIN (not INNER JOIN) defends against soft-corruption: if a group's
+ * owner row was deleted without CASCADE (shouldn't happen — FK enforces it,
+ * but defense in depth), we still return the group with `ownerDisplayName: null`
+ * instead of dropping the row from the result.
  */
 export function listAllGroupsWithStats(
   db: Database.Database
-): Array<Group & { memberCount: number }> {
+): Array<Group & { memberCount: number; ownerDisplayName: string | null }> {
   const rows = db
     .prepare(
       `SELECT g.*,
-              (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id) AS member_count
+              (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id) AS member_count,
+              u.display_name AS owner_display_name
        FROM groups g
+       LEFT JOIN users u ON u.chat_id = g.owner_id
        ORDER BY g.created_at DESC`
     )
-    .all() as Array<RawGroup & { member_count: number }>;
-  return rows.map((r) => ({ ...decodeGroup(r), memberCount: r.member_count }));
+    .all() as Array<RawGroup & { member_count: number; owner_display_name: string | null }>;
+  return rows.map((r) => ({
+    ...decodeGroup(r),
+    memberCount: r.member_count,
+    ownerDisplayName: r.owner_display_name,
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary

Final PR in the v0.5.1 stacked series. Adds the dashboard Groups page for admin moderation, plus 3 hot-configurable caps that the bot reads on every relevant call.

**Stacked PR strategy** — this targets \`feat/v0.5.1-group-propagate\` (PR #233), which targets \`feat/v0.5.1-group-status\` (PR #232), which targets \`feat/v0.5.1-groups-db\` (PR #230). Linear merge order: #230 → #232 → #233 → #234 (this).

## What changes

### 1. Hot-config wiring (\`src/config/configResolver.ts\`, \`src/dashboard/routes/settings.ts\`, \`src/bot/groupHandler.ts\`)
- 3 new keys registered in \`CONFIG_KEYS\` + \`ALLOWED_KEYS\` + \`VALIDATORS\`:
  - \`groups_max_per_user\` (default 5, validateNonNegativeInt)
  - \`groups_max_members\` (default 20, validateNonNegativeInt)
  - \`groups_invite_code_ttl_hours\` (default 24, **NOT enforced** in v0.5.1 — pre-registered for v0.5.2 invite-code TTL)
- New \`resolveIntConfig(key, fallback)\` helper in groupHandler wraps \`resolveConfig\` with parsing + validation
- \`handleCreate\` and \`handleJoin\` now read caps via \`getMaxGroupsPerUser()\` / \`getMaxMembersPerGroup()\` — dashboard PATCH takes effect immediately, no restart needed
- Error messages reference the **resolved** value, not the fallback constant

### 2. Dashboard route (\`src/dashboard/routes/groups.ts\` mounted at \`/api/groups\`)
- \`GET /api/groups\` — list with member count + owner display name
- \`GET /api/groups/stats\` — total + avgMembers + top10 (registered BEFORE \`/:id\` so the static segment wins)
- \`GET /api/groups/:id\` — full group + member list with displayName/role/joinedAt/notifyGroup
- \`DELETE /api/groups/:id\` — admin moderation (logs at WARN level), CASCADE removes member rows
- All endpoints validate the id is a positive integer (400 for invalid, 404 for unknown)
- DELETE rate-limited via \`groupMutateLimiter\` (5/minute/IP), exported for test isolation

### 3. React UI page (\`dashboard-ui/src/pages/Groups.tsx\` + Sidebar entry + lazy route)
- 3 KPI cards at top: total groups, average members, top group
- Sortable table with name/owner/memberCount/inviteCode/createdAt + delete button per row
- Click row → slide-in drawer (left edge, RTL-correct) with full member list
- Delete gated by \`ConfirmModal\` with \`danger\` variant
- React Query for caching: list / stats / detail with separate keys
- Sidebar entry "קבוצות חוסן" with \`UsersRound\` icon, placed between \`/subscribers\` and \`/operations\`

## Memory patterns applied
- \`pattern_getuser_singleton_vs_di.md\` — dashboard route uses \`getUser()\` directly, which is safe because the dashboard server uses the same singleton DB. Tests use \`initDb()+getDb()\` (not \`new Database\`) so the route's \`getUser()\` calls resolve to the same DB the test seeds.
- \`pattern_rate_limiter_test_isolation.md\` — \`groupMutateLimiter\` is exported so tests can call \`.clearStore()\` between cases.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] Backend tests: 1279/1279 (was 1277 before #225, +2 hot-config tests)
- [x] Dashboard tests: 326/326 (was 314 before #225, +12 dashboard groups route tests)
- [x] \`npm run build\` clean (backend + dashboard-ui — Groups bundle = 6.21 kB / 2.14 kB gzipped)
- [ ] Manual smoke (after stack merge): create groups via bot, verify they appear in dashboard /groups page, drill down to see members, delete via UI, override \`groups_max_per_user\` via Settings page → verify bot enforces new cap on next \`/group create\` without restart

## Out of scope (deferred)
- I1+I2 from PR #232 review (\`assertGroupMember\` helper consolidation across 7 sites) — TODO breadcrumb already in place at \`groupHandler.ts:436\`. This is a polish refactor that can land as a follow-up cleanup PR after the v0.5.1 stack merges.
- Invite code TTL enforcement (\`groups_invite_code_ttl_hours\` is registered but unused in v0.5.1) — deferred to v0.5.2.
- Issue #231 — orphan group escape hatch (transfer/delete/force-delete) — tracked separately for v0.5.2.

closes #225