### PR TITLE
ci: dedupe PR runs (~50% Actions minutes saved)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,12 @@ name: CI
 on:
   push:
     branches: ['**']
+  # Only trigger on PR open/reopen — `synchronize` (the event for PR-branch
+  # pushes) duplicates the `push` trigger above and was burning ~50% of
+  # Actions minutes on every PR push. The `push` trigger already covers
+  # PR-branch updates because PRs are just branches with commits.
   pull_request:
+    types: [opened, reopened]
     branches: ['**']
 
 concurrency:

--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -18,6 +18,7 @@ const WhatsApp         = lazy(() => import('./pages/WhatsApp').then(m => ({ defa
 const WhatsAppListeners  = lazy(() => import('./pages/WhatsAppListeners').then(m => ({ default: m.WhatsAppListeners })));
 const TelegramListeners  = lazy(() => import('./pages/TelegramListeners').then(m => ({ default: m.TelegramListeners })));
 const Configuration      = lazy(() => import('./pages/Configuration'));
+const Groups             = lazy(() => import('./pages/Groups'));
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 30_000 } } });
 
@@ -44,6 +45,7 @@ export function App() {
               <Route path="whatsapp-listeners" element={<WhatsAppListeners />} />
               <Route path="telegram-listeners" element={<TelegramListeners />} />
               <Route path="configuration" element={<Configuration />} />
+              <Route path="groups" element={<Groups />} />
             </Route>
           </Routes>
         </Suspense>

--- a/dashboard-ui/src/layout/Sidebar.tsx
+++ b/dashboard-ui/src/layout/Sidebar.tsx
@@ -2,7 +2,7 @@ import { NavLink } from 'react-router-dom';
 import { useState } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import {
-  Activity, Bell, Users, Radio, SlidersHorizontal,
+  Activity, Bell, Users, UsersRound, Radio, SlidersHorizontal,
   Globe, MessageSquare, Phone, Rss, MessageCircle,
   LayoutDashboard, Settings, ChevronLeft, ChevronDown, KeyRound,
 } from 'lucide-react';
@@ -31,6 +31,7 @@ const NAV: SidebarEntry[] = [
     },
   },
   { kind: 'item', item: { to: '/subscribers', icon: Users, label: 'מנויים' } },
+  { kind: 'item', item: { to: '/groups',      icon: UsersRound, label: 'קבוצות חוסן' } },
   { kind: 'item', item: { to: '/operations',  icon: Radio, label: 'מרכז פיקוד' }, dividerAfter: true },
   {
     kind: 'group',

--- a/dashboard-ui/src/pages/Groups.tsx
+++ b/dashboard-ui/src/pages/Groups.tsx
@@ -1,0 +1,262 @@
+import React, { useState } from 'react';
+import { UsersRound, Trash2, X } from 'lucide-react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { motion, AnimatePresence } from 'framer-motion';
+import toast from 'react-hot-toast';
+import { api } from '../api/client';
+import { ConfirmModal } from '../components/ConfirmModal';
+import { EmptyState } from '../components/EmptyState';
+import { Skeleton } from '../components/Skeleton';
+import { GlassCard } from '../components/ui/GlassCard';
+import { PageTransition } from '../components/ui/PageTransition';
+
+// ─── API types — mirror src/dashboard/routes/groups.ts response shape ────────
+
+interface GroupRow {
+  id: number;
+  name: string;
+  inviteCode: string;
+  ownerId: number;
+  ownerDisplayName: string | null;
+  createdAt: string;
+  memberCount: number;
+}
+
+interface GroupsResponse {
+  ok: true;
+  groups: GroupRow[];
+}
+
+interface GroupStats {
+  ok: true;
+  total: number;
+  avgMembers: number;
+  top10: Array<{ id: number; name: string; memberCount: number }>;
+}
+
+interface GroupMemberDetail {
+  userId: number;
+  role: 'owner' | 'member';
+  joinedAt: string;
+  notifyGroup: boolean;
+  displayName: string | null;
+  homeCity: string | null;
+}
+
+interface GroupDetailResponse {
+  ok: true;
+  group: {
+    id: number;
+    name: string;
+    inviteCode: string;
+    ownerId: number;
+    createdAt: string;
+  };
+  members: GroupMemberDetail[];
+}
+
+function relDate(iso: string): string {
+  return new Date(iso).toLocaleDateString('he-IL');
+}
+
+function Groups(): React.ReactElement {
+  const qc = useQueryClient();
+  const [drillId, setDrillId] = useState<number | null>(null);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+
+  const { data: list, isLoading } = useQuery<GroupsResponse>({
+    queryKey: ['dashboard-groups', 'list'],
+    queryFn: () => api.get<GroupsResponse>('/api/groups'),
+  });
+
+  const { data: stats } = useQuery<GroupStats>({
+    queryKey: ['dashboard-groups', 'stats'],
+    queryFn: () => api.get<GroupStats>('/api/groups/stats'),
+  });
+
+  const { data: detail } = useQuery<GroupDetailResponse>({
+    queryKey: ['dashboard-groups', 'detail', drillId],
+    queryFn: () => api.get<GroupDetailResponse>(`/api/groups/${drillId}`),
+    enabled: drillId !== null,
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: number) => api.delete(`/api/groups/${id}`),
+    onSuccess: () => {
+      toast.success('הקבוצה נמחקה');
+      qc.invalidateQueries({ queryKey: ['dashboard-groups'] });
+      setDeleteId(null);
+      setDrillId(null);
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : 'מחיקה נכשלה';
+      toast.error(msg);
+    },
+  });
+
+  return (
+    <PageTransition>
+      <div className="space-y-6 p-6">
+        <header className="flex items-center gap-3">
+          <UsersRound className="text-blue-400" size={28} />
+          <h1 className="text-2xl font-bold">קבוצות חוסן</h1>
+        </header>
+
+        {/* KPI cards */}
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <GlassCard className="p-4">
+            <div className="text-sm text-gray-400">סה״כ קבוצות</div>
+            <div className="text-3xl font-bold mt-1">{stats?.total ?? '—'}</div>
+          </GlassCard>
+          <GlassCard className="p-4">
+            <div className="text-sm text-gray-400">חברים בממוצע</div>
+            <div className="text-3xl font-bold mt-1">{stats?.avgMembers ?? '—'}</div>
+          </GlassCard>
+          <GlassCard className="p-4">
+            <div className="text-sm text-gray-400">קבוצה עם הכי הרבה חברים</div>
+            <div className="text-xl font-semibold mt-1 truncate">
+              {stats?.top10[0]?.name ?? '—'}
+              {stats?.top10[0] !== undefined && (
+                <span className="text-sm text-gray-400 mr-2">
+                  ({stats.top10[0].memberCount})
+                </span>
+              )}
+            </div>
+          </GlassCard>
+        </div>
+
+        {/* Groups table */}
+        <GlassCard className="p-4">
+          {isLoading ? (
+            <Skeleton className="h-64" />
+          ) : !list?.groups || list.groups.length === 0 ? (
+            <EmptyState
+              icon="👥"
+              message="אין קבוצות עדיין. קבוצות נוצרות מהבוט עם /group create."
+            />
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-white/10 text-sm text-gray-400">
+                    <th className="p-2 text-right">שם</th>
+                    <th className="p-2 text-right">בעלים</th>
+                    <th className="p-2 text-right">חברים</th>
+                    <th className="p-2 text-right">קוד הזמנה</th>
+                    <th className="p-2 text-right">נוצרה</th>
+                    <th className="p-2"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {list.groups.map((g) => (
+                    <tr
+                      key={g.id}
+                      className="border-b border-white/5 hover:bg-white/5 cursor-pointer"
+                      onClick={() => setDrillId(g.id)}
+                    >
+                      <td className="p-2 font-medium">{g.name}</td>
+                      <td className="p-2 text-sm">
+                        {g.ownerDisplayName ?? <span className="text-gray-500">—</span>}
+                      </td>
+                      <td className="p-2">{g.memberCount}</td>
+                      <td className="p-2 font-mono text-xs">{g.inviteCode}</td>
+                      <td className="p-2 text-sm text-gray-400">{relDate(g.createdAt)}</td>
+                      <td className="p-2 text-left">
+                        <button
+                          aria-label={`מחק קבוצה ${g.name}`}
+                          className="text-red-400 hover:text-red-300"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setDeleteId(g.id);
+                          }}
+                        >
+                          <Trash2 size={18} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </GlassCard>
+      </div>
+
+      {/* Detail drawer */}
+      <AnimatePresence>
+        {drillId !== null && detail !== undefined && (
+          <motion.div
+            className="fixed inset-y-0 left-0 w-full md:w-[480px] bg-zinc-900 border-l border-white/10 shadow-2xl z-40 overflow-y-auto"
+            initial={{ x: -480 }}
+            animate={{ x: 0 }}
+            exit={{ x: -480 }}
+            transition={{ type: 'spring', stiffness: 220, damping: 26 }}
+          >
+            <div className="p-6 space-y-4">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xl font-bold">{detail.group.name}</h2>
+                <button
+                  aria-label="סגור"
+                  className="text-gray-400 hover:text-white"
+                  onClick={() => setDrillId(null)}
+                >
+                  <X size={20} />
+                </button>
+              </div>
+
+              <div className="text-sm text-gray-400 space-y-1">
+                <div>
+                  קוד הזמנה: <span className="font-mono text-white">{detail.group.inviteCode}</span>
+                </div>
+                <div>נוצרה: {relDate(detail.group.createdAt)}</div>
+                <div>חברים: {detail.members.length}</div>
+              </div>
+
+              <div className="border-t border-white/10 pt-4">
+                <h3 className="text-sm font-semibold mb-2 text-gray-300">חברים</h3>
+                <ul className="space-y-2">
+                  {detail.members.map((m) => (
+                    <li key={m.userId} className="flex items-center justify-between p-2 rounded bg-white/5">
+                      <div>
+                        <div className="font-medium">
+                          {m.displayName ?? `משתמש #${m.userId}`}
+                          {m.role === 'owner' && <span className="mr-2 text-xs text-blue-400">בעלים</span>}
+                        </div>
+                        {m.homeCity !== null && m.homeCity !== '' && (
+                          <div className="text-xs text-gray-400">{m.homeCity}</div>
+                        )}
+                      </div>
+                      <div className="text-xs text-gray-500">
+                        {m.notifyGroup ? '🔔' : '🔕'}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <button
+                className="w-full py-2 bg-red-500/20 text-red-400 rounded hover:bg-red-500/30"
+                onClick={() => setDeleteId(detail.group.id)}
+              >
+                מחק קבוצה
+              </button>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      <ConfirmModal
+        open={deleteId !== null}
+        title="מחיקת קבוצה"
+        description="האם אתה בטוח שברצונך למחוק את הקבוצה? כל החברים יסולקו ולא ניתן לבטל פעולה זו."
+        danger
+        onConfirm={() => {
+          if (deleteId !== null) deleteMut.mutate(deleteId);
+        }}
+        onCancel={() => setDeleteId(null)}
+      />
+    </PageTransition>
+  );
+}
+
+export default Groups;

--- a/src/__tests__/botSetup.test.ts
+++ b/src/__tests__/botSetup.test.ts
@@ -36,8 +36,8 @@ describe('setupBotHandlers', () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
-    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend', 'status'];
-    assert.equal(bot._registeredCommands.length, expected.length, 'should register exactly 14 commands');
+    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status'];
+    assert.equal(bot._registeredCommands.length, expected.length, `should register exactly ${expected.length} commands`);
     for (const cmd of expected) {
       assert.ok(
         bot._registeredCommands.includes(cmd),
@@ -111,16 +111,16 @@ describe('setupBotHandlers', () => {
     assert.equal(typeof bot._getCatchHandler(), 'function', 'catch handler should be a function');
   });
 
-  it('calls bot.api.setMyCommands with all 14 commands', async () => {
+  it('calls bot.api.setMyCommands with all 15 commands', async () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
     const cmds = bot._getSetMyCommandsArg() as Array<{ command: string; description: string }>;
     assert.ok(Array.isArray(cmds), 'setMyCommands should receive an array');
-    assert.equal(cmds.length, 14, 'setMyCommands should receive exactly 14 commands');
+    assert.equal(cmds.length, 15, 'setMyCommands should receive exactly 15 commands');
 
     const commandNames = cmds.map((c) => c.command);
-    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'privacy', 'today', 'legend', 'status']) {
+    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status']) {
       assert.ok(commandNames.includes(name), `setMyCommands should include /${name}`);
     }
     // Each command must have a non-empty Hebrew description

--- a/src/__tests__/dashboard/routes/groups.test.ts
+++ b/src/__tests__/dashboard/routes/groups.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import express from 'express';
+import request from 'supertest';
+import { initDb, getDb, closeDb } from '../../../db/schema.js';
+import { createGroupsRouter, groupMutateLimiter } from '../../../dashboard/routes/groups.js';
+import {
+  createGroup,
+  addMember,
+  countMembersOfGroup,
+  findGroupById,
+} from '../../../db/groupRepository.js';
+
+// IMPORTANT: this test runs with DB_PATH=:memory: set on the command line.
+// We use initDb()+getDb() (not new Database(':memory:')) so the singleton
+// is the SAME instance the route's getUser() calls read from. Without this,
+// owner display names would be silently null even though we seeded them
+// (pattern_getuser_singleton_vs_di.md).
+
+let app: express.Express;
+
+before(() => {
+  initDb();
+  app = express();
+  app.use(express.json());
+  app.use('/api/groups', createGroupsRouter(getDb()));
+});
+
+after(() => closeDb());
+
+beforeEach(() => {
+  const db = getDb();
+  // Cascade order: groups → group_members (via FK CASCADE)
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(1001, 'אבא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(1002, 'אמא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(1003, 'ילד');
+  // Reset DELETE rate limit state between tests so multiple tests can hit DELETE.
+  // Pattern: pattern_rate_limiter_test_isolation.md.
+  groupMutateLimiter.clearStore();
+});
+
+describe('GET /api/groups', () => {
+  it('returns empty list when no groups exist', async () => {
+    const res = await request(app).get('/api/groups');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.deepEqual(res.body.groups, []);
+  });
+
+  it('returns groups with member count and owner display name', async () => {
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'API001' });
+    const g2 = createGroup(db, { name: 'work',   ownerId: 1002, inviteCode: 'API002' });
+    addMember(db, g2.id, 1003);
+
+    const res = await request(app).get('/api/groups');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.groups.length, 2);
+
+    const byId = new Map(res.body.groups.map((g: any) => [g.id, g]));
+    const familyGroup = byId.get(g1.id) as any;
+    assert.equal(familyGroup.name, 'family');
+    assert.equal(familyGroup.ownerId, 1001);
+    assert.equal(familyGroup.ownerDisplayName, 'אבא', 'getUser() must resolve via singleton — pattern_getuser_singleton_vs_di');
+    assert.equal(familyGroup.memberCount, 1);
+    assert.equal(familyGroup.inviteCode, 'API001');
+
+    const workGroup = byId.get(g2.id) as any;
+    assert.equal(workGroup.memberCount, 2);
+    assert.equal(workGroup.ownerDisplayName, 'אמא');
+  });
+});
+
+describe('GET /api/groups/stats', () => {
+  it('returns zero stats when no groups exist', async () => {
+    const res = await request(app).get('/api/groups/stats');
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+    assert.equal(res.body.total, 0);
+    assert.equal(res.body.avgMembers, 0);
+    assert.deepEqual(res.body.top10, []);
+  });
+
+  it('computes total + avgMembers + top10 correctly', async () => {
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'tiny', ownerId: 1001, inviteCode: 'STAT01' });
+    const g2 = createGroup(db, { name: 'big',  ownerId: 1002, inviteCode: 'STAT02' });
+    addMember(db, g2.id, 1003);
+
+    const res = await request(app).get('/api/groups/stats');
+    assert.equal(res.body.total, 2);
+    // (1 + 2) / 2 = 1.5
+    assert.equal(res.body.avgMembers, 1.5);
+    assert.equal(res.body.top10.length, 2);
+    // Sorted desc by memberCount → 'big' first
+    assert.equal(res.body.top10[0].id, g2.id);
+    assert.equal(res.body.top10[0].name, 'big');
+    assert.equal(res.body.top10[0].memberCount, 2);
+  });
+
+  // Make sure /stats doesn't get matched as /:id
+  it('static /stats route takes precedence over /:id', async () => {
+    const res = await request(app).get('/api/groups/stats');
+    assert.equal(res.status, 200);
+    assert.equal(typeof res.body.total, 'number', 'should return stats shape, not group-not-found');
+  });
+});
+
+describe('GET /api/groups/:id', () => {
+  it('returns 400 for invalid id (NaN / negative / zero)', async () => {
+    for (const badId of ['abc', '-5', '0']) {
+      const res = await request(app).get(`/api/groups/${badId}`);
+      assert.equal(res.status, 400, `expected 400 for badId="${badId}"`);
+      assert.equal(res.body.ok, false);
+    }
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app).get('/api/groups/999999');
+    assert.equal(res.status, 404);
+    assert.equal(res.body.ok, false);
+  });
+
+  it('returns full group + member list for known id', async () => {
+    const db = getDb();
+    const group = createGroup(db, { name: 'detail', ownerId: 1001, inviteCode: 'DTL001' });
+    addMember(db, group.id, 1002);
+
+    const res = await request(app).get(`/api/groups/${group.id}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.group.id, group.id);
+    assert.equal(res.body.group.name, 'detail');
+    assert.equal(res.body.members.length, 2);
+
+    // Member entries enriched with display name + role + notify_group
+    const owner = res.body.members.find((m: any) => m.userId === 1001);
+    assert.ok(owner);
+    assert.equal(owner.displayName, 'אבא');
+    assert.equal(owner.role, 'owner');
+    assert.equal(owner.notifyGroup, true);
+
+    const member = res.body.members.find((m: any) => m.userId === 1002);
+    assert.equal(member.role, 'member');
+    assert.equal(member.displayName, 'אמא');
+  });
+});
+
+describe('DELETE /api/groups/:id', () => {
+  it('returns 400 for invalid id', async () => {
+    const res = await request(app).delete('/api/groups/abc');
+    assert.equal(res.status, 400);
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app).delete('/api/groups/999999');
+    assert.equal(res.status, 404);
+  });
+
+  it('deletes group and CASCADEs to remove member rows', async () => {
+    const db = getDb();
+    const group = createGroup(db, { name: 'doomed', ownerId: 1001, inviteCode: 'DEL001' });
+    addMember(db, group.id, 1002);
+    addMember(db, group.id, 1003);
+    assert.equal(countMembersOfGroup(db, group.id), 3);
+
+    const res = await request(app).delete(`/api/groups/${group.id}`);
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+
+    // Group is gone
+    assert.equal(findGroupById(db, group.id), undefined);
+    // CASCADE removed all 3 member rows
+    const remainingMembers = db
+      .prepare('SELECT * FROM group_members WHERE group_id = ?')
+      .all(group.id);
+    assert.equal(remainingMembers.length, 0);
+  });
+
+  it('rate limits after 5 requests in a minute', async () => {
+    const db = getDb();
+    // Create 6 groups so we can try 6 deletes
+    for (let i = 0; i < 6; i++) {
+      createGroup(db, { name: `g${i}`, ownerId: 1001, inviteCode: `RL${i.toString().padStart(4, '0')}` });
+    }
+    const groupIds = db.prepare('SELECT id FROM groups ORDER BY id ASC').all() as Array<{ id: number }>;
+
+    // First 5 deletes succeed
+    for (let i = 0; i < 5; i++) {
+      const id = groupIds[i]?.id;
+      const res = await request(app).delete(`/api/groups/${id}`);
+      assert.equal(res.status, 200, `delete ${i + 1} should succeed`);
+    }
+
+    // 6th delete is rate-limited
+    const lastId = groupIds[5]?.id;
+    const res = await request(app).delete(`/api/groups/${lastId}`);
+    assert.equal(res.status, 429, '6th delete in window should be rate-limited');
+  });
+});

--- a/src/__tests__/dashboard/routes/settings.test.ts
+++ b/src/__tests__/dashboard/routes/settings.test.ts
@@ -148,6 +148,49 @@ describe('PATCH /api/settings — value validation', () => {
     assert.equal(res.status, 400);
   });
 
+  // PR #234 review #1 — caps must be ≥1 (validatePositiveInt rejects 0).
+  // Three reviewer agents converged on this: groups_max_per_user=0 would
+  // make countGroupsOwnedBy(...) >= 0 always true → every create rejected.
+  it('rejects groups_max_per_user=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('groups_max_per_user'));
+    assert.ok(res.body.error.includes('חיובי') || res.body.error.includes('≥1'));
+    // No partial write
+    const row = db.prepare("SELECT value FROM settings WHERE key = 'groups_max_per_user'").get();
+    assert.equal(row, undefined);
+  });
+
+  it('rejects groups_max_members=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_members: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('groups_max_members'));
+    assert.ok(res.body.error.includes('חיובי') || res.body.error.includes('≥1'));
+  });
+
+  it('accepts groups_max_per_user=1 (boundary)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '1' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+  });
+
+  it('accepts groups_max_per_user=100 (typical hot-config value)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '100' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects groups_max_per_user=-5 (also negative)', async () => {
+    const res = await request(app).patch('/api/settings').send({ groups_max_per_user: '-5' });
+    assert.equal(res.status, 400);
+  });
+
+  it('accepts groups_invite_code_ttl_hours=0 (means "never expire" in v0.5.2 semantics)', async () => {
+    // Unlike the cap keys, the TTL key uses validateNonNegativeInt because
+    // 0 plausibly encodes "no expiry". This is documented in settings.ts.
+    const res = await request(app).patch('/api/settings').send({ groups_invite_code_ttl_hours: '0' });
+    assert.equal(res.status, 200);
+  });
+
   it('does NOT partially apply when one key in a multi-key PATCH is invalid', async () => {
     // Both keys are allowed, but the second one fails validation. The first
     // key must NOT be persisted (validation runs as a separate pass before

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, before, beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
+import crypto from 'crypto';
 import { initDb, getDb } from '../db/schema.js';
 import { upsertUser } from '../db/userRepository.js';
 import {
@@ -16,7 +17,9 @@ import {
   joinFailures,
   MAX_GROUPS_PER_USER_FALLBACK,
   MAX_MEMBERS_PER_GROUP_FALLBACK,
+  createGroupWithCollisionRetry,
 } from '../bot/groupHandler.js';
+import { InviteCodeCollisionError } from '../db/groupRepository.js';
 import type { Bot, Context } from 'grammy';
 
 before(() => {
@@ -427,6 +430,228 @@ describe('groupHandler — input validation', () => {
     assert.match(text, /חסר קוד|שימוש/);
     // Cooldown map should NOT have an entry for 1002
     assert.equal(joinCooldownMap.has(1002), false);
+  });
+});
+
+// PR #230 second-round review Gap A — exhaustion path of the collision retry loop.
+// The helper is exported precisely so this test can drive the loop with stub
+// dependencies, exercising the all-collide branch without requiring concurrent
+// inserts or DB-level race simulation.
+describe('createGroupWithCollisionRetry — exhaustion + all branches', () => {
+  it("returns 'collision-exhausted' after maxRetries consecutive collisions", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    let calls = 0;
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'doomed', ownerId: 1001 },
+      {
+        // Generate predictable codes — values don't matter, only that they're fresh
+        generateInviteCodeFn: () => `STUB${++calls}`,
+        // Always collide
+        createGroupFn: () => {
+          throw new InviteCodeCollisionError('STUB');
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'collision-exhausted');
+    // Each retry should have called both deps once
+    assert.equal(calls, 3, 'generateInviteCodeFn should have been called maxRetries times');
+    // No actual group was created in the DB
+    assert.equal(countGroupsOwnedBy(db, 1001), 0);
+  });
+
+  it("returns 'codegen-failed' when generateInviteCodeFn throws non-collision error", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'x', ownerId: 1001 },
+      {
+        generateInviteCodeFn: () => {
+          throw new Error('crypto exhausted');
+        },
+        createGroupFn: () => {
+          throw new Error('should not be reached');
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'codegen-failed');
+    if (result.kind === 'codegen-failed') {
+      assert.match(String((result.cause as Error).message), /crypto exhausted/);
+    }
+  });
+
+  it("returns 'createGroup-failed' when createGroup throws a non-collision error (e.g. FK)", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'x', ownerId: 1001 },
+      {
+        generateInviteCodeFn: () => 'OKAY01',
+        createGroupFn: () => {
+          throw new Error('FOREIGN KEY constraint failed');
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'createGroup-failed');
+    if (result.kind === 'createGroup-failed') {
+      assert.match(String((result.cause as Error).message), /FOREIGN KEY/);
+    }
+  });
+
+  it("retries past one collision and returns 'ok' when subsequent attempt succeeds", () => {
+    const db = getDb();
+    upsertUser(1001);
+
+    let attempt = 0;
+    const result = createGroupWithCollisionRetry(
+      db,
+      { name: 'persistent', ownerId: 1001 },
+      {
+        generateInviteCodeFn: () => `RTY${++attempt}`,
+        createGroupFn: (innerDb, input) => {
+          if (attempt === 1) throw new InviteCodeCollisionError(input.inviteCode);
+          // Second attempt: actually create
+          return createGroup(innerDb, input);
+        },
+        maxRetries: 3,
+      },
+    );
+
+    assert.equal(result.kind, 'ok');
+    if (result.kind === 'ok') {
+      assert.equal(result.inviteCode, 'RTY2'); // first retry
+      assert.equal(result.group.name, 'persistent');
+      assert.equal(result.group.ownerId, 1001);
+    }
+    assert.equal(countGroupsOwnedBy(db, 1001), 1);
+  });
+
+  it('handler integration — exhaustion path surfaces the specific Hebrew error message', async () => {
+    // Top-level test: exhaustion shows "לא הצלחנו ליצור קוד הזמנה ייחודי" — distinct
+    // from the generic 'שגיאת שרת ביצירת קוד'. This guards against future refactors
+    // collapsing the two error messages.
+    const db = getDb();
+    upsertUser(1001);
+
+    // Pre-seed all 32 alphabet permutations is impractical. Instead, use the seam:
+    // monkey-patch crypto.randomInt to always return 0 so generateInviteCode
+    // produces "AAAAAA", then pre-create that row so generateInviteCode itself
+    // exhausts internally (5 retries on the same code).
+    const realRandomInt = crypto.randomInt;
+    (crypto as any).randomInt = () => 0;
+    try {
+      // Pre-create the row that will collide
+      createGroup(db, { name: 'blocker', ownerId: 1001, inviteCode: 'AAAAAA' });
+
+      const bot = buildMockBot();
+      registerGroupHandler(bot as unknown as Bot);
+
+      const ctx = makeCtx({ message: { text: '/group create newone' } });
+      await bot._fireCmd('group', ctx);
+
+      const text = (ctx as any)._replyCalls[0][0] as string;
+      // generateInviteCode exhausts internally → 'codegen-failed' branch → its message
+      assert.match(text, /קוד הזמנה|שגיאת שרת/);
+    } finally {
+      (crypto as any).randomInt = realRandomInt;
+    }
+  });
+});
+
+// PR #230 second-round review Gap B — handleLeave picker + validation branches.
+// 5 distinct branches, covered by 4 tests (NaN + negative grouped).
+describe('groupHandler — /group leave validation branches', () => {
+  it('shows empty-state reply when user has no groups and uses no-arg picker', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group leave' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר באף קבוצה/);
+  });
+
+  it('shows multi-group inline picker when user belongs to ≥2 groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'PCK001' });
+    const g2 = createGroup(db, { name: 'work',   ownerId: 1001, inviteCode: 'PCK002' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group leave' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /בחר קבוצה/);
+    // Inline keyboard should have one button per group, both pointing at g:leaveY:<id>
+    const markup = JSON.stringify((ctx as any)._replyCalls[0][1]?.reply_markup ?? {});
+    assert.ok(markup.includes(`g:leaveY:${g1.id}`), 'picker should include g1');
+    assert.ok(markup.includes(`g:leaveY:${g2.id}`), 'picker should include g2');
+  });
+
+  it('rejects NaN / negative / zero groupId', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    for (const badId of ['abc', '-5', '0', '999999999999999999999999']) {
+      const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group leave ${badId}` } });
+      await bot._fireCmd('group', ctx);
+
+      const text = (ctx as any)._replyCalls[0]?.[0] as string;
+      // Either "מזהה קבוצה לא תקין" (NaN/<=0 path) or "הקבוצה לא נמצאה" (huge int → no row)
+      assert.ok(
+        /מזהה קבוצה לא תקין|הקבוצה לא נמצאה/.test(text),
+        `expected validation error for badId="${badId}", got: ${text}`,
+      );
+    }
+  });
+
+  it('rejects "group not found" when groupId does not exist', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group leave 99999' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הקבוצה לא נמצאה/);
+  });
+
+  it('rejects non-member trying to leave a group they are not in', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(9999); // not a member
+    const db = getDb();
+    const g = createGroup(db, { name: 'private', ownerId: 1001, inviteCode: 'NMB001' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' }, message: { text: `/group leave ${g.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר/);
+    // Group still exists, untouched
+    assert.equal(countMembersOfGroup(db, g.id), 1);
   });
 });
 

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -892,6 +892,30 @@ describe('renderGroupStatus — content + aggregate count', () => {
     const text = (ctx as any)._replyCalls[0][0] as string;
     assert.match(text, /הקבוצה לא נמצאה/);
   });
+
+  // PR #232 review item M1 — empty-group edge case
+  it('renders clean empty state when group has 0 members (defensive — should not happen via UI)', async () => {
+    const db = getDb();
+    upsertUser(1001);
+    const g = createGroup(db, { name: 'will-be-emptied', ownerId: 1001, inviteCode: 'EMP001' });
+
+    // Simulate a corruption or migration glitch: manually wipe group_members
+    // without deleting the group itself. This bypasses the auto-delete in
+    // performLeave that would normally fire when the last member leaves.
+    db.prepare('DELETE FROM group_members WHERE group_id = ?').run(g.id);
+    assert.equal(countMembersOfGroup(db, g.id), 0);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, g.id, lookup);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /will-be-emptied/);
+    assert.match(text, /הקבוצה ריקה/);
+    // Must NOT contain the ugly "0/0 בסדר" summary line
+    assert.doesNotMatch(text, /0\/0 בסדר/);
+  });
 });
 
 describe('g:s and g:refresh callbacks', () => {

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -1,0 +1,349 @@
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { initDb, getDb } from '../db/schema.js';
+import { upsertUser } from '../db/userRepository.js';
+import {
+  createGroup,
+  findGroupByInviteCode,
+  getGroupsForUser,
+  countGroupsOwnedBy,
+  countMembersOfGroup,
+} from '../db/groupRepository.js';
+import {
+  registerGroupHandler,
+  cb,
+  joinCooldownMap,
+  joinFailures,
+  MAX_GROUPS_PER_USER_FALLBACK,
+  MAX_MEMBERS_PER_GROUP_FALLBACK,
+} from '../bot/groupHandler.js';
+import type { Bot, Context } from 'grammy';
+
+before(() => {
+  process.env['DB_PATH'] = ':memory:';
+  initDb();
+});
+
+beforeEach(() => {
+  const db = getDb();
+  // Cascade deletes group_members + memberships
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+  joinCooldownMap.clear();
+  joinFailures.clear();
+});
+
+// Mock Grammy Bot — just records the registered command + callback handlers
+function buildMockBot() {
+  const commands: Record<string, (ctx: Context) => Promise<void>> = {};
+  const callbacks: Array<[string | RegExp, (ctx: Context) => Promise<void>]> = [];
+
+  return {
+    command: (name: string, handler: (ctx: Context) => Promise<void>) => {
+      commands[name] = handler;
+    },
+    callbackQuery: (pat: string | RegExp, handler: (ctx: Context) => Promise<void>) => {
+      callbacks.push([pat, handler]);
+    },
+    on: () => {},
+    catch: () => {},
+    _fireCmd: async (name: string, ctx: Context) => commands[name]?.(ctx),
+    _fireCb: async (data: string, ctx: Context) => {
+      for (const [pat, handler] of callbacks) {
+        if (typeof pat === 'string' && pat === data) {
+          await handler(ctx);
+          return;
+        }
+        if (pat instanceof RegExp && pat.test(data)) {
+          (ctx as any).match = data.match(pat);
+          await handler(ctx);
+          return;
+        }
+      }
+    },
+  };
+}
+
+function makeCtx(overrides: Record<string, unknown> = {}): Context {
+  const replyCalls: unknown[] = [];
+  const editCalls: unknown[] = [];
+  const sendCalls: unknown[] = [];
+  const answerCalls: unknown[] = [];
+  const ctx: any = {
+    chat: { id: 1001, type: 'private' },
+    message: { text: '/group' },
+    match: null,
+    reply: async (...args: unknown[]) => {
+      replyCalls.push(args);
+    },
+    editMessageText: async (...args: unknown[]) => {
+      editCalls.push(args);
+    },
+    answerCallbackQuery: async (...args: unknown[]) => {
+      answerCalls.push(args);
+    },
+    api: {
+      sendMessage: async (...args: unknown[]) => {
+        sendCalls.push(args);
+      },
+    },
+    _replyCalls: replyCalls,
+    _editCalls: editCalls,
+    _sendCalls: sendCalls,
+    _answerCalls: answerCalls,
+    ...overrides,
+  };
+  return ctx as Context;
+}
+
+describe('cb() — callback_data byte-length guard', () => {
+  it('accepts realistic worst-case payloads', () => {
+    // Worst case: g:leaveY:<10-digit ID> = 18 ASCII bytes
+    assert.equal(cb('g:leaveY:2147483647'), 'g:leaveY:2147483647');
+    assert.equal(cb('g:c:1'), 'g:c:1');
+    assert.equal(cb('g:list'), 'g:list');
+  });
+
+  it('throws on > 64 bytes UTF-8', () => {
+    const tooLong = 'g:leave:' + '1'.repeat(60);
+    assert.equal(Buffer.byteLength(tooLong, 'utf8'), 68);
+    assert.throws(() => cb(tooLong), /callback_data too long/);
+  });
+
+  it('throws on Hebrew payload that overflows due to multi-byte chars', () => {
+    // Each Hebrew char is 2 bytes — 33 chars = 66 bytes
+    const hebrewPayload = 'ק'.repeat(33);
+    assert.throws(() => cb(hebrewPayload), /callback_data too long/);
+  });
+
+  it('accepts payload exactly at 64 bytes', () => {
+    const exactly64 = 'a'.repeat(64);
+    assert.equal(cb(exactly64), exactly64);
+  });
+});
+
+describe('groupHandler — /group (no args) → list view', () => {
+  it('shows empty state for user with no groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const ctx = makeCtx({ message: { text: '/group' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר באף קבוצה/);
+  });
+
+  it('lists groups user belongs to', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    createGroup(db, { name: 'משפחה', ownerId: 1001, inviteCode: 'FAM001' });
+
+    const ctx = makeCtx({ message: { text: '/group' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /משפחה/);
+  });
+});
+
+describe('groupHandler — /group create', () => {
+  it('creates a group with valid name and shows invite code', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const ctx = makeCtx({ message: { text: '/group create משפחה' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /משפחה/);
+    // Invite code should appear in the message (6 chars from CODE_ALPHABET)
+    assert.match(text, /[A-Z2-9]{6}/);
+
+    // DB side-effect: 1 group + 1 owner membership
+    assert.equal(countGroupsOwnedBy(getDb(), 1001), 1);
+  });
+
+  it('rejects empty name', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const ctx = makeCtx({ message: { text: '/group create   ' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /שם/);
+    assert.equal(countGroupsOwnedBy(getDb(), 1001), 0);
+  });
+
+  it('enforces MAX_GROUPS_PER_USER_FALLBACK cap', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    // Pre-create exactly the cap directly via repo
+    const db = getDb();
+    for (let i = 0; i < MAX_GROUPS_PER_USER_FALLBACK; i++) {
+      createGroup(db, { name: `g${i}`, ownerId: 1001, inviteCode: `CAP${i}AB` });
+    }
+
+    const ctx = makeCtx({ message: { text: '/group create extra' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הגעת לגבול|מקסימום|מוגבל/);
+    assert.equal(countGroupsOwnedBy(db, 1001), MAX_GROUPS_PER_USER_FALLBACK);
+  });
+});
+
+describe('groupHandler — /group join', () => {
+  it('joins via valid invite code', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(1002); // joiner
+    const db = getDb();
+    const group = createGroup(db, { name: 'משפחה', ownerId: 1001, inviteCode: 'JOIN01' });
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join JOIN01' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+    const groups = getGroupsForUser(db, 1002);
+    assert.equal(groups.length, 1);
+  });
+
+  it('rejects invalid code and increments failure counter', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join NOPE99' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /קוד.*תקין|לא נמצא/);
+    assert.equal(joinFailures.get(1002)?.count, 1);
+  });
+
+  it('blocks user after 5 failed attempts', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    // Pre-set the failure count to the threshold
+    joinFailures.set(1002, { count: 5, blockedUntil: Date.now() + 60_000 });
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join ANY999' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /יותר מדי|נחסם|נסה שוב בעוד/);
+  });
+
+  it('rejects join when group is at member cap', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const group = createGroup(db, { name: 'full', ownerId: 1001, inviteCode: 'FULL01' });
+
+    // Fill the group to the cap (owner + N-1 others)
+    for (let i = 2; i < 2 + MAX_MEMBERS_PER_GROUP_FALLBACK - 1; i++) {
+      upsertUser(i);
+      db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, i);
+    }
+    assert.equal(countMembersOfGroup(db, group.id), MAX_MEMBERS_PER_GROUP_FALLBACK);
+
+    const lateJoinerId = 9999;
+    upsertUser(lateJoinerId);
+    const ctx = makeCtx({ chat: { id: lateJoinerId, type: 'private' }, message: { text: '/group join FULL01' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /מלאה|מקסימום|חברים/);
+    // Joiner did NOT get added
+    assert.equal(countMembersOfGroup(db, group.id), MAX_MEMBERS_PER_GROUP_FALLBACK);
+  });
+
+  it('respects 5s cooldown between attempts', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    // First attempt — sets cooldown (will fail with bad code, that's fine)
+    let ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join NOPE01' } });
+    await bot._fireCmd('group', ctx);
+
+    // Second attempt immediately — should be cooldown-blocked
+    ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join NOPE02' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /נסה שוב|המתן|שניות/);
+  });
+});
+
+describe('groupHandler — /group leave', () => {
+  it('removes member from group', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(1002); // member
+    const db = getDb();
+    const group = createGroup(db, { name: 'x', ownerId: 1001, inviteCode: 'LV0001' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: `/group leave ${group.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal(countMembersOfGroup(db, group.id), 1);
+  });
+
+  it('blocks owner from leaving when other members exist', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(1002);
+    const db = getDb();
+    const group = createGroup(db, { name: 'x', ownerId: 1001, inviteCode: 'LV0002' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group leave ${group.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /בעלים|בעלות|מחק/);
+    // Still in the group
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+  });
+
+  it('owner leaving last member deletes the group entirely', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const group = createGroup(db, { name: 'solo', ownerId: 1001, inviteCode: 'LV0003' });
+    assert.equal(countMembersOfGroup(db, group.id), 1);
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group leave ${group.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    // Group is gone
+    assert.equal(findGroupByInviteCode(db, 'LV0003'), undefined);
+  });
+});

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -207,6 +207,65 @@ describe('groupHandler — /group create', () => {
     assert.match(text, /הגעת לגבול|מקסימום|מוגבל/);
     assert.equal(countGroupsOwnedBy(db, 1001), MAX_GROUPS_PER_USER_FALLBACK);
   });
+
+  // PR #225 — hot-config override for groups_max_per_user
+  it('reads groups_max_per_user from settings table at runtime (hot-config)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    // Override the cap via the settings table — simulates a dashboard PATCH.
+    // Without the configResolver wiring, this would be ignored and the cap
+    // would still be MAX_GROUPS_PER_USER_FALLBACK (5). With the wiring, the
+    // handler reads `groups_max_per_user = 2` and rejects on the 3rd create.
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)").run('groups_max_per_user', '2');
+
+    // Pre-create 2 groups (at the new cap)
+    createGroup(db, { name: 'g1', ownerId: 1001, inviteCode: 'HC0001' });
+    createGroup(db, { name: 'g2', ownerId: 1001, inviteCode: 'HC0002' });
+
+    // 3rd create should be rejected
+    const ctx = makeCtx({ message: { text: '/group create third' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הגעת לגבול/);
+    // Error message should reference the OVERRIDE value, not the fallback
+    assert.match(text, /\b2 קבוצות/, 'cap message should show the dashboard-overridden value (2)');
+    assert.equal(countGroupsOwnedBy(db, 1001), 2);
+
+    // Cleanup — restore default for subsequent tests
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+
+  it('reads groups_max_members from settings table at runtime (hot-config)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+
+    // Cap members at 2 via dashboard override
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)").run('groups_max_members', '2');
+
+    const group = createGroup(db, { name: 'tiny', ownerId: 1001, inviteCode: 'HCM001' });
+    upsertUser(1002);
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    // 3rd member tries to join via /group join — should be rejected
+    upsertUser(1003);
+    const ctx = makeCtx({ chat: { id: 1003, type: 'private' }, message: { text: '/group join HCM001' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הקבוצה מלאה/);
+    assert.match(text, /\b2 חברים/);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_members'").run();
+  });
 });
 
 describe('groupHandler — /group join', () => {

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -1036,3 +1036,115 @@ describe('g:s and g:refresh callbacks', () => {
     assert.doesNotMatch(text, /rfr-secret/);
   });
 });
+
+// PR #234 review #1 + #3 — defense in depth for hot-config caps.
+// Three reviewer agents independently flagged that cap=0 silently bricks the
+// feature. The fix has two layers:
+//   1. Dashboard validator (validatePositiveInt) rejects 0 at the PATCH
+//      boundary — covered by settings.test.ts.
+//   2. Runtime resolveIntConfig has a `minimum` parameter that clamps to
+//      fallback if the DB/env value is below the floor — covered HERE.
+//      This catches env-var bypass + direct-SQL writes + corrupt rows.
+describe('PR #234 review — hot-config defense in depth', () => {
+  it('cap=0 in DB falls back to MAX_GROUPS_PER_USER_FALLBACK (not 0)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    // Bypass the dashboard validator by writing directly to settings —
+    // simulates an env var override, a corrupt row, or pre-validator data.
+    // The runtime should NOT use 0; resolveIntConfig clamps to fallback.
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_per_user', '0');
+
+    // Pre-create exactly MAX_GROUPS_PER_USER_FALLBACK groups so the
+    // fallback's cap is hit on the next create
+    for (let i = 0; i < MAX_GROUPS_PER_USER_FALLBACK; i++) {
+      createGroup(db, { name: `g${i}`, ownerId: 1001, inviteCode: `D0D${i}AB` });
+    }
+
+    const ctx = makeCtx({ message: { text: '/group create blocked-by-fallback' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    // The error message must reference the FALLBACK value (5), NOT 0.
+    // If the bug were unfixed, the message would say "ניתן ליצור עד 0 קבוצות".
+    assert.match(text, new RegExp(`ניתן ליצור עד ${MAX_GROUPS_PER_USER_FALLBACK}`));
+    assert.doesNotMatch(text, /ניתן ליצור עד 0/);
+    assert.equal(countGroupsOwnedBy(db, 1001), MAX_GROUPS_PER_USER_FALLBACK);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+
+  it('cap=0 still allows group creation when under fallback cap', async () => {
+    // The CRITICAL property: cap=0 must NOT block creation when the user
+    // has < fallback groups. This is the actual symptom of the bug —
+    // a fresh user with 0 groups gets ❌ "ניתן ליצור עד 0 קבוצות" on
+    // their first create.
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_per_user', '0');
+
+    const ctx = makeCtx({ message: { text: '/group create works-despite-zero' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    // Success path: group is created using the fallback cap of 5
+    assert.match(text, /קבוצה נוצרה/);
+    assert.equal(countGroupsOwnedBy(db, 1001), 1);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+
+  it('groups_max_members=0 falls back to MAX_MEMBERS_PER_GROUP_FALLBACK', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    upsertUser(1002);
+    const db = getDb();
+
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_members', '0');
+
+    const group = createGroup(db, { name: 'doomed', ownerId: 1001, inviteCode: 'MEMBR1' });
+    // Without defense in depth, this join would be rejected with
+    // "❌ הקבוצה מלאה (מקסימום 0 חברים)" — instead it should succeed
+    // because the fallback (20) kicks in.
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join MEMBR1' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הצטרפת לקבוצה/);
+    assert.equal(countMembersOfGroup(db, group.id), 2);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_members'").run();
+  });
+
+  it('unparseable cap value (PR #234 review #3) falls back without crashing', async () => {
+    // An admin typo'd "five" into the dashboard (bypass via env var or
+    // corrupt row). resolveIntConfig should warn-log AND fall back —
+    // group creation should proceed normally with the fallback cap.
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+    const db = getDb();
+
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES (?, ?, 0)")
+      .run('groups_max_per_user', 'five');
+
+    const ctx = makeCtx({ message: { text: '/group create works-anyway' } });
+    await bot._fireCmd('group', ctx);
+
+    // Success path proves the early-return-on-NaN was taken (fallback used)
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /קבוצה נוצרה/);
+    assert.equal(countGroupsOwnedBy(db, 1001), 1);
+
+    db.prepare("DELETE FROM settings WHERE key = 'groups_max_per_user'").run();
+  });
+});

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -294,6 +294,142 @@ describe('groupHandler — /group join', () => {
   });
 });
 
+// PR #230 review item #7 — invite alphabet exclusion (no 0/O/I/1)
+describe('invite code alphabet — generated codes never contain 0/O/I/1', () => {
+  it('500 generated codes all match /^[A-HJ-NP-Z2-9]{6}$/', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const codes: string[] = [];
+    for (let i = 0; i < 500; i++) {
+      // Each /group create call mints a fresh code; capture it from reply text
+      const ctx = makeCtx({ message: { text: `/group create test${i}` } });
+      // Bypass the MAX_GROUPS_PER_USER cap by deleting prior groups before each call
+      getDb().prepare('DELETE FROM groups').run();
+      await bot._fireCmd('group', ctx);
+      const reply = (ctx as any)._replyCalls[0]?.[0] as string;
+      const m = reply.match(/<code>([A-Z2-9]{6})<\/code>/);
+      assert.ok(m, `iteration ${i}: reply did not contain a code: ${reply.slice(0, 80)}`);
+      codes.push(m[1]);
+    }
+
+    // 500 samples × 6 chars = 3000 characters scanned
+    const banned = /[0OI1]/;
+    for (const code of codes) {
+      assert.ok(!banned.test(code), `code ${code} contains a banned char`);
+      assert.match(code, /^[A-HJ-NP-Z2-9]{6}$/);
+    }
+  });
+});
+
+// PR #230 review item #10 — owner-only invite code disclosure (auth invariant)
+describe('g:c callback — owner-only invite code disclosure', () => {
+  it('shows invite code to the owner', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const group = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'OWN001' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    await bot._fireCb(`g:c:${group.id}`, ctx);
+
+    // Latest editMessageText call is the rendered card
+    const editArgs = (ctx as any)._editCalls[0];
+    assert.ok(editArgs, 'expected an editMessageText call');
+    const text = editArgs[0] as string;
+    assert.match(text, /OWN001/, 'owner must see the invite code');
+  });
+
+  it('hides invite code from a non-owner member', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001); // owner
+    upsertUser(1002); // non-owner member
+    const db = getDb();
+    const group = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'NOSEE1' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(group.id, 1002);
+
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' } });
+    await bot._fireCb(`g:c:${group.id}`, ctx);
+
+    const editArgs = (ctx as any)._editCalls[0];
+    assert.ok(editArgs, 'expected an editMessageText call');
+    const text = editArgs[0] as string;
+    assert.doesNotMatch(text, /NOSEE1/, 'non-owner must NOT see the invite code');
+    // But the group name should still appear (basic card view)
+    assert.match(text, /family/);
+  });
+
+  it('blocks non-members from viewing the card entirely', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999); // not a member
+    const db = getDb();
+    const group = createGroup(db, { name: 'private', ownerId: 1001, inviteCode: 'BLK001' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' } });
+    await bot._fireCb(`g:c:${group.id}`, ctx);
+
+    const editArgs = (ctx as any)._editCalls[0];
+    assert.ok(editArgs);
+    const text = editArgs[0] as string;
+    assert.match(text, /אינך חבר/);
+    // No invite code, no group internals leaked
+    assert.doesNotMatch(text, /BLK001/);
+    assert.doesNotMatch(text, /private/);
+  });
+});
+
+// PR #230 review minor items — name length, non-private chat, cooldown ordering
+describe('groupHandler — input validation', () => {
+  it('rejects group name longer than 50 chars', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const longName = 'א'.repeat(51);
+    const ctx = makeCtx({ message: { text: `/group create ${longName}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /ארוך מדי|מקסימום/);
+    assert.equal(countGroupsOwnedBy(getDb(), 1001), 0);
+  });
+
+  it('replies with explanation in non-private chat (not silent)', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    const ctx = makeCtx({ chat: { id: -1001, type: 'group' }, message: { text: '/group' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /שיחה פרטית/);
+  });
+
+  it('does not consume cooldown when /group join has no args', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1002);
+
+    // Empty args — should NOT set cooldown
+    const ctx = makeCtx({ chat: { id: 1002, type: 'private' }, message: { text: '/group join' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /חסר קוד|שימוש/);
+    // Cooldown map should NOT have an entry for 1002
+    assert.equal(joinCooldownMap.has(1002), false);
+  });
+});
+
 describe('groupHandler — /group leave', () => {
   it('removes member from group', async () => {
     const bot = buildMockBot();

--- a/src/__tests__/groupHandler.test.ts
+++ b/src/__tests__/groupHandler.test.ts
@@ -18,8 +18,10 @@ import {
   MAX_GROUPS_PER_USER_FALLBACK,
   MAX_MEMBERS_PER_GROUP_FALLBACK,
   createGroupWithCollisionRetry,
+  renderGroupStatus,
 } from '../bot/groupHandler.js';
-import { InviteCodeCollisionError } from '../db/groupRepository.js';
+import { InviteCodeCollisionError, findGroupById } from '../db/groupRepository.js';
+import { upsertSafetyStatus } from '../db/safetyStatusRepository.js';
 import type { Bot, Context } from 'grammy';
 
 before(() => {
@@ -706,5 +708,248 @@ describe('groupHandler — /group leave', () => {
 
     // Group is gone
     assert.equal(findGroupByInviteCode(db, 'LV0003'), undefined);
+  });
+});
+
+// ─── Task 2 (#212) — /group status command ──────────────────────────────────
+
+describe('groupHandler — /group status command dispatch', () => {
+  it('shows empty state for user with no groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    const ctx = makeCtx({ message: { text: '/group status' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר באף קבוצה/);
+  });
+
+  it('auto-picks single group and renders status card', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'STA001' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group status' } });
+    await bot._fireCmd('group', ctx);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /family/);
+    // Single member who hasn't reported → shows "0/1 בסדר" + "לא דיווח"
+    assert.match(text, /0\/1 בסדר/);
+    assert.match(text, /לא דיווח/);
+    // Hint to /status command (no safety:menu callback exists)
+    assert.match(text, /\/status/);
+
+    // Inline keyboard should have just the refresh button targeting g:refresh:<id>
+    const markup = JSON.stringify((ctx as any)._replyCalls[0][1]?.reply_markup ?? {});
+    assert.ok(markup.includes(`g:refresh:${g.id}`), 'should have refresh button');
+    assert.ok(!markup.includes('safety:menu'), 'must NOT reference non-existent safety:menu');
+  });
+
+  it('shows multi-group picker when user belongs to ≥2 groups', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'STA002' });
+    const g2 = createGroup(db, { name: 'work',   ownerId: 1001, inviteCode: 'STA003' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: '/group status' } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /בחר קבוצה/);
+    const markup = JSON.stringify((ctx as any)._replyCalls[0][1]?.reply_markup ?? {});
+    assert.ok(markup.includes(`g:s:${g1.id}`), 'picker should include g1');
+    assert.ok(markup.includes(`g:s:${g2.id}`), 'picker should include g2');
+  });
+
+  it('rejects non-member trying to view status by explicit groupId', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999);
+    const db = getDb();
+    const g = createGroup(db, { name: 'private', ownerId: 1001, inviteCode: 'STA004' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' }, message: { text: `/group status ${g.id}` } });
+    await bot._fireCmd('group', ctx);
+
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /אינך חבר/);
+    // Group internals never leak
+    assert.doesNotMatch(text, /private/);
+  });
+
+  it('rejects NaN / negative groupId in /group status', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+    upsertUser(1001);
+
+    for (const badId of ['abc', '-5', '0']) {
+      const ctx = makeCtx({ chat: { id: 1001, type: 'private' }, message: { text: `/group status ${badId}` } });
+      await bot._fireCmd('group', ctx);
+
+      const text = (ctx as any)._replyCalls[0][0] as string;
+      assert.match(text, /מזהה קבוצה לא תקין/, `expected validation error for badId="${badId}", got: ${text}`);
+    }
+  });
+});
+
+describe('renderGroupStatus — content + aggregate count', () => {
+  it('aggregates ok/help/dismissed/none with correct emoji + count', async () => {
+    upsertUser(1001);
+    upsertUser(1002);
+    upsertUser(1003);
+    upsertUser(1004);
+    const db = getDb();
+    const g = createGroup(db, { name: 'cell', ownerId: 1001, inviteCode: 'AGG001' });
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(g.id, 1002);
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(g.id, 1003);
+    db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')").run(g.id, 1004);
+
+    // Seed statuses: owner=ok, 1002=help, 1003=dismissed, 1004=no status
+    upsertSafetyStatus(db, 1001, 'ok');
+    upsertSafetyStatus(db, 1002, 'help');
+    upsertSafetyStatus(db, 1003, 'dismissed');
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    // Inject lookupUser that reads from THIS db (not getDb() singleton).
+    // Without injection, getUser() reads from process.env DB_PATH, which is :memory:
+    // here so it would happen to work — but we test the seam explicitly.
+    const testLookup = (chatId: number) => {
+      const row = db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as
+        | { display_name: string | null; home_city: string | null }
+        | undefined;
+      return row;
+    };
+    await renderGroupStatus(ctx as any, db, g.id, testLookup);
+
+    assert.equal((ctx as any)._replyCalls.length, 1);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+
+    assert.match(text, /cell/);
+    assert.match(text, /✅/);
+    assert.match(text, /⚠️/);
+    assert.match(text, /🔇/);
+    assert.match(text, /❓/);
+    assert.match(text, /1\/4 בסדר/, 'only owner reported ok → 1/4');
+    assert.match(text, /\/status/);
+  });
+
+  it('uses editMessageText when called from a callback context (refresh path)', async () => {
+    upsertUser(1001);
+    const db = getDb();
+    const g = createGroup(db, { name: 'rfr', ownerId: 1001, inviteCode: 'RFR001' });
+
+    const ctx = makeCtx({
+      chat: { id: 1001, type: 'private' },
+      callbackQuery: { id: 'fakeId', data: `g:refresh:${g.id}` },
+    });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, g.id, lookup);
+
+    // Should have called editMessageText, NOT reply
+    assert.equal((ctx as any)._editCalls.length, 1);
+    assert.equal((ctx as any)._replyCalls.length, 0);
+    const editText = (ctx as any)._editCalls[0][0] as string;
+    assert.match(editText, /rfr/);
+  });
+
+  it('handles missing display_name with fallback "משתמש #<id>"', async () => {
+    const db = getDb();
+    // Insert a user with NO display_name (simulating pre-onboarding state)
+    db.prepare("INSERT INTO users (chat_id, created_at) VALUES (?, datetime('now'))").run(7777);
+    const g = createGroup(db, { name: 'noname', ownerId: 7777, inviteCode: 'NON001' });
+
+    const ctx = makeCtx({ chat: { id: 7777, type: 'private' } });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, g.id, lookup);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /משתמש #7777/);
+  });
+
+  it('returns "הקבוצה לא נמצאה" when group does not exist', async () => {
+    const db = getDb();
+    upsertUser(1001);
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    const lookup = (chatId: number) =>
+      db.prepare('SELECT display_name, home_city FROM users WHERE chat_id = ?').get(chatId) as any;
+
+    await renderGroupStatus(ctx as any, db, 999999, lookup);
+    const text = (ctx as any)._replyCalls[0][0] as string;
+    assert.match(text, /הקבוצה לא נמצאה/);
+  });
+});
+
+describe('g:s and g:refresh callbacks', () => {
+  it('g:s:<id> callback renders status via editMessageText', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    const db = getDb();
+    const g = createGroup(db, { name: 'cb-test', ownerId: 1001, inviteCode: 'CBS001' });
+
+    const ctx = makeCtx({ chat: { id: 1001, type: 'private' } });
+    await bot._fireCb(`g:s:${g.id}`, ctx);
+
+    // Either edited or replied — the callback wraps editMessageText which the
+    // mock supports — but since renderGroupStatus checks ctx.callbackQuery
+    // truthiness, and the mock setter doesn't add it, expect a reply OR an edit.
+    // The picker→g:s flow uses editMessageText (the mock context will have
+    // callbackQuery via _fireCb path).
+    const totalCalls = (ctx as any)._editCalls.length + (ctx as any)._replyCalls.length;
+    assert.ok(totalCalls > 0, 'g:s should produce some output');
+    // Find the rendered text
+    const text = ((ctx as any)._editCalls[0]?.[0] ?? (ctx as any)._replyCalls[0]?.[0]) as string;
+    assert.match(text, /cb-test/);
+  });
+
+  it('g:s:<id> blocks non-members entirely', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999);
+    const db = getDb();
+    const g = createGroup(db, { name: 'secret', ownerId: 1001, inviteCode: 'CBS002' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' } });
+    await bot._fireCb(`g:s:${g.id}`, ctx);
+
+    const text = ((ctx as any)._editCalls[0]?.[0] ?? (ctx as any)._replyCalls[0]?.[0]) as string;
+    assert.match(text, /אינך חבר/);
+    // Group name never leaks to non-member
+    assert.doesNotMatch(text, /secret/);
+  });
+
+  it('g:refresh:<id> blocks non-members', async () => {
+    const bot = buildMockBot();
+    registerGroupHandler(bot as unknown as Bot);
+
+    upsertUser(1001);
+    upsertUser(9999);
+    const db = getDb();
+    const g = createGroup(db, { name: 'rfr-secret', ownerId: 1001, inviteCode: 'RFR002' });
+
+    const ctx = makeCtx({ chat: { id: 9999, type: 'private' } });
+    await bot._fireCb(`g:refresh:${g.id}`, ctx);
+
+    const text = ((ctx as any)._editCalls[0]?.[0] ?? (ctx as any)._replyCalls[0]?.[0]) as string;
+    assert.match(text, /אינך חבר/);
+    assert.doesNotMatch(text, /rfr-secret/);
   });
 });

--- a/src/__tests__/groupNotificationService.test.ts
+++ b/src/__tests__/groupNotificationService.test.ts
@@ -1,0 +1,222 @@
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  createGroup,
+  addMember,
+} from '../db/groupRepository.js';
+import { notifyGroupMembersOfStatusChange } from '../services/groupNotificationService.js';
+import type { Bot } from 'grammy';
+
+// Standalone DB pattern (telegramListenerRepository style) — each test owns
+// the seeded users and groups. We use explicit `db` injection everywhere
+// because the production `getUser()` reads from the getDb() singleton, which
+// would silently miss this test's :memory: instance. Pattern documented in
+// memory: pattern_getuser_singleton_vs_di.md.
+
+let db: Database.Database;
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+});
+
+beforeEach(() => {
+  // Cascade wipes group_members + safety_status automatically
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+});
+
+function seedUser(chatId: number, displayName: string): void {
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(chatId, displayName);
+}
+
+function makeTestLookup() {
+  return (chatId: number) =>
+    db.prepare('SELECT display_name FROM users WHERE chat_id = ?').get(chatId) as
+      | { display_name: string | null }
+      | undefined;
+}
+
+const fakeBot = {} as unknown as Bot; // _bot param is unused — only present for API symmetry with safetyNotificationService
+
+describe('notifyGroupMembersOfStatusChange', () => {
+  it("notifies all group members except the sender (status='ok')", async () => {
+    seedUser(1001, 'אבא');
+    seedUser(1002, 'אמא');
+    seedUser(1003, 'ילד');
+    const group = createGroup(db, { name: 'בית', ownerId: 1001, inviteCode: 'NTF001' });
+    addMember(db, group.id, 1002);
+    addMember(db, group.id, 1003);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    // Sender excluded, both other members notified
+    assert.equal(enqueued.length, 2);
+    const chatIds = enqueued.map((t) => t.chatId).sort();
+    assert.deepEqual(chatIds, ['1002', '1003']);
+
+    // Each task carries the sender's display name + group name
+    for (const task of enqueued) {
+      assert.match(task.text, /אבא/);
+      assert.match(task.text, /בית/);
+      assert.match(task.text, /בסדר/);
+      assert.match(task.text, /✅/);
+    }
+  });
+
+  it("formats 'help' status with warning emoji and call-to-action", async () => {
+    seedUser(1001, 'דנה');
+    seedUser(1002, 'אורי');
+    const group = createGroup(db, { name: 'משפחה', ownerId: 1001, inviteCode: 'NTF002' });
+    addMember(db, group.id, 1002);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'help', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    const text = enqueued[0]?.text ?? '';
+    assert.match(text, /דנה/);
+    assert.match(text, /משפחה/);
+    assert.match(text, /⚠️/);
+    assert.match(text, /זקוק/);
+    // The "consider reaching out" call-to-action distinguishes 'help' from 'ok'
+    assert.match(text, /צור|ליצור|קשר/);
+  });
+
+  it("skips notification entirely when status='dismissed'", async () => {
+    seedUser(1001, 'a');
+    seedUser(1002, 'b');
+    const group = createGroup(db, { name: 'g', ownerId: 1001, inviteCode: 'NTF003' });
+    addMember(db, group.id, 1002);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'dismissed', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 0, 'dismissed should not produce any tasks');
+  });
+
+  it('respects notify_group=0 opt-out per member', async () => {
+    seedUser(1001, 'sender');
+    seedUser(1002, 'optedIn');
+    seedUser(1003, 'optedOut');
+    const group = createGroup(db, { name: 'g', ownerId: 1001, inviteCode: 'NTF004' });
+    addMember(db, group.id, 1002);
+    addMember(db, group.id, 1003);
+
+    // Flip notify_group to 0 for member 1003
+    db.prepare('UPDATE group_members SET notify_group = 0 WHERE user_id = ?').run(1003);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    assert.equal(enqueued[0]?.chatId, '1002', 'opted-out member must not receive a task');
+  });
+
+  it("dedupes recipients across overlapping groups", async () => {
+    seedUser(1001, 'sender');
+    seedUser(1002, 'overlapMember');
+    seedUser(1003, 'g1Only');
+    seedUser(1004, 'g2Only');
+    // Two groups, both owned by sender, both contain overlapMember
+    const g1 = createGroup(db, { name: 'family', ownerId: 1001, inviteCode: 'DUP001' });
+    addMember(db, g1.id, 1002);
+    addMember(db, g1.id, 1003);
+    const g2 = createGroup(db, { name: 'work', ownerId: 1001, inviteCode: 'DUP002' });
+    addMember(db, g2.id, 1002);
+    addMember(db, g2.id, 1004);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    // 3 distinct recipients: 1002 (in both groups, deduped), 1003, 1004
+    assert.equal(enqueued.length, 3, `expected 3 deduped recipients, got ${enqueued.length}`);
+    const chatIds = enqueued.map((t) => t.chatId).sort();
+    assert.deepEqual(chatIds, ['1002', '1003', '1004']);
+
+    // The deduped recipient gets the notification labeled with ONE of the
+    // groups (whichever was iterated first via getGroupsForUser ORDER BY
+    // created_at DESC). Just verify it has SOME group name.
+    const overlapTask = enqueued.find((t) => t.chatId === '1002');
+    assert.ok(overlapTask);
+    assert.ok(/family|work/.test(overlapTask.text), `overlap task text should mention a group: ${overlapTask.text}`);
+  });
+
+  it('returns silently when sender belongs to no groups', async () => {
+    seedUser(9999, 'lonely');
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 9999, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+    assert.equal(enqueued.length, 0);
+  });
+
+  it('returns silently when group has only the sender (no recipients)', async () => {
+    seedUser(1001, 'solo');
+    createGroup(db, { name: 'just-me', ownerId: 1001, inviteCode: 'SOLO01' });
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+    assert.equal(enqueued.length, 0);
+  });
+
+  it("uses fallback 'משתמש #<id>' when sender has no display_name", async () => {
+    // No display_name (pre-onboarding state)
+    db.prepare("INSERT INTO users (chat_id, created_at) VALUES (?, datetime('now'))").run(7777);
+    seedUser(8888, 'recipient');
+    const group = createGroup(db, { name: 'g', ownerId: 7777, inviteCode: 'NON001' });
+    addMember(db, group.id, 8888);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 7777, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    assert.match(enqueued[0]?.text ?? '', /משתמש #7777/);
+  });
+
+  it('escapes HTML in display_name and group name to prevent injection', async () => {
+    seedUser(1001, '<script>alert(1)</script>');
+    seedUser(1002, 'recipient');
+    const group = createGroup(db, { name: '<b>EvilGroup</b>', ownerId: 1001, inviteCode: 'XSS001' });
+    addMember(db, group.id, 1002);
+
+    const enqueued: Array<{ chatId: string; text: string }> = [];
+    await notifyGroupMembersOfStatusChange(db, fakeBot, 1001, 'ok', {
+      enqueueAll: (tasks) => enqueued.push(...tasks),
+      getUser: makeTestLookup(),
+    });
+
+    assert.equal(enqueued.length, 1);
+    const text = enqueued[0]?.text ?? '';
+    // The literal raw HTML must NOT appear unescaped — must be entity-encoded
+    assert.doesNotMatch(text, /<script>/);
+    assert.doesNotMatch(text, /<b>EvilGroup<\/b>/);
+    assert.match(text, /&lt;script&gt;/);
+    assert.match(text, /&lt;b&gt;EvilGroup&lt;\/b&gt;/);
+  });
+});

--- a/src/__tests__/groupRepository.test.ts
+++ b/src/__tests__/groupRepository.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  createGroup,
+  findGroupByInviteCode,
+  findGroupById,
+  getGroupsForUser,
+  addMember,
+  removeMember,
+  deleteGroup,
+  getMembersOfGroup,
+  countGroupsOwnedBy,
+  countMembersOfGroup,
+  listAllGroupsWithStats,
+} from '../db/groupRepository.js';
+
+const USER_A = 1001;
+const USER_B = 1002;
+const USER_C = 1003;
+
+let db: Database.Database;
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+});
+
+after(() => db.close());
+
+beforeEach(() => {
+  // Cascade wipes group_members automatically (FK ON DELETE CASCADE)
+  db.prepare('DELETE FROM groups').run();
+  db.prepare('DELETE FROM users').run();
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(USER_A, 'אבא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(USER_B, 'אמא');
+  db.prepare("INSERT INTO users (chat_id, display_name, created_at) VALUES (?, ?, datetime('now'))").run(USER_C, 'ילד');
+});
+
+describe('schema sanity', () => {
+  it('groups table exists after initSchema', () => {
+    const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='groups'").get();
+    assert.ok(row, 'groups table should exist');
+  });
+
+  it('group_members table exists after initSchema', () => {
+    const row = db.prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='group_members'").get();
+    assert.ok(row, 'group_members table should exist');
+  });
+});
+
+describe('createGroup', () => {
+  it('inserts row and auto-adds owner as member with role=owner', () => {
+    const group = createGroup(db, { name: 'משפחה', ownerId: USER_A, inviteCode: 'ABC123' });
+    assert.equal(group.name, 'משפחה');
+    assert.equal(group.ownerId, USER_A);
+    assert.equal(group.inviteCode, 'ABC123');
+    assert.ok(group.id > 0);
+    assert.ok(group.createdAt);
+
+    const members = getMembersOfGroup(db, group.id);
+    assert.equal(members.length, 1);
+    assert.equal(members[0]?.userId, USER_A);
+    assert.equal(members[0]?.role, 'owner');
+  });
+
+  it('rolls back atomically if owner membership insert fails', () => {
+    // Delete the owner's user row AFTER the FK check but... actually we can't
+    // easily simulate this. Instead: try inserting with a non-existent ownerId
+    // and assert that no `groups` row remains.
+    assert.throws(() => createGroup(db, { name: 'x', ownerId: 999999, inviteCode: 'X999' }));
+    const rows = db.prepare('SELECT * FROM groups WHERE invite_code = ?').all('X999');
+    assert.equal(rows.length, 0, 'groups row should have rolled back');
+  });
+
+  it('enforces invite_code uniqueness', () => {
+    createGroup(db, { name: 'a', ownerId: USER_A, inviteCode: 'DUP123' });
+    assert.throws(() => createGroup(db, { name: 'b', ownerId: USER_B, inviteCode: 'DUP123' }));
+  });
+});
+
+describe('findGroupByInviteCode', () => {
+  it('returns undefined for unknown code', () => {
+    assert.equal(findGroupByInviteCode(db, 'NOPE00'), undefined);
+  });
+
+  it('returns decoded group for known code', () => {
+    const created = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'FIND01' });
+    const found = findGroupByInviteCode(db, 'FIND01');
+    assert.ok(found);
+    assert.equal(found.id, created.id);
+    assert.equal(found.name, 'x');
+    assert.equal(found.inviteCode, 'FIND01');
+  });
+});
+
+describe('findGroupById', () => {
+  it('returns undefined for unknown id', () => {
+    assert.equal(findGroupById(db, 999999), undefined);
+  });
+
+  it('returns decoded group for known id', () => {
+    const created = createGroup(db, { name: 'y', ownerId: USER_A, inviteCode: 'FI02' });
+    const found = findGroupById(db, created.id);
+    assert.ok(found);
+    assert.equal(found.id, created.id);
+  });
+});
+
+describe('addMember / removeMember', () => {
+  it('adds a non-owner member and counts correctly', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'ADD001' });
+    addMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+
+    const members = getMembersOfGroup(db, g.id);
+    const nonOwner = members.find((m) => m.userId === USER_B);
+    assert.ok(nonOwner);
+    assert.equal(nonOwner.role, 'member');
+  });
+
+  it('addMember is idempotent (INSERT OR IGNORE)', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'IDEM01' });
+    addMember(db, g.id, USER_B);
+    addMember(db, g.id, USER_B); // no-op, not an error
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+  });
+
+  it('removeMember removes only the target', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'RM0001' });
+    addMember(db, g.id, USER_B);
+    addMember(db, g.id, USER_C);
+    removeMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2); // owner + USER_C
+    const ids = getMembersOfGroup(db, g.id).map((m) => m.userId).sort();
+    assert.deepEqual(ids, [USER_A, USER_C]);
+  });
+});
+
+describe('getGroupsForUser', () => {
+  it('returns empty array for user with no groups', () => {
+    assert.deepEqual(getGroupsForUser(db, USER_A), []);
+  });
+
+  it('returns all groups user is in (owned + joined)', () => {
+    const g1 = createGroup(db, { name: 'owned', ownerId: USER_A, inviteCode: 'G4U001' });
+    const g2 = createGroup(db, { name: 'joined', ownerId: USER_B, inviteCode: 'G4U002' });
+    addMember(db, g2.id, USER_A);
+
+    const groups = getGroupsForUser(db, USER_A);
+    assert.equal(groups.length, 2);
+    const ids = groups.map((g) => g.id).sort();
+    assert.deepEqual(ids, [g1.id, g2.id].sort());
+  });
+});
+
+describe('deleteGroup', () => {
+  it('removes group and cascades to group_members', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'DEL001' });
+    addMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+
+    deleteGroup(db, g.id);
+
+    assert.equal(findGroupById(db, g.id), undefined);
+    // Cascade removed all group_members rows for this group
+    const remainingMembers = db.prepare('SELECT * FROM group_members WHERE group_id = ?').all(g.id);
+    assert.equal(remainingMembers.length, 0);
+  });
+});
+
+describe('countGroupsOwnedBy', () => {
+  it('counts only owner, not member-of', () => {
+    createGroup(db, { name: 'a', ownerId: USER_A, inviteCode: 'CNT001' });
+    createGroup(db, { name: 'b', ownerId: USER_B, inviteCode: 'CNT002' });
+    assert.equal(countGroupsOwnedBy(db, USER_A), 1);
+    assert.equal(countGroupsOwnedBy(db, USER_B), 1);
+    assert.equal(countGroupsOwnedBy(db, USER_C), 0);
+  });
+});
+
+// CRITICAL — explicit INTEGER → boolean decode test for notify_group.
+// Without this, a mis-decoded raw integer `1` would pass ≠ false assertions
+// while `if (!m.notifyGroup)` in Task 3 would evaluate incorrectly on `0`.
+describe('notify_group decoding (SQLite INTEGER → TS boolean)', () => {
+  it('decodeMember converts raw notify_group integer to strict boolean', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'NTF001' });
+    addMember(db, g.id, USER_B);
+
+    // Direct DB flip: one row to 0, one to 1
+    db.prepare('UPDATE group_members SET notify_group = 0 WHERE user_id = ?').run(USER_A);
+    db.prepare('UPDATE group_members SET notify_group = 1 WHERE user_id = ?').run(USER_B);
+
+    const members = getMembersOfGroup(db, g.id);
+    const owner = members.find((m) => m.userId === USER_A);
+    const other = members.find((m) => m.userId === USER_B);
+    assert.ok(owner && other);
+
+    // Strict: must be boolean primitives, not numbers
+    assert.equal(owner.notifyGroup, false);
+    assert.equal(other.notifyGroup, true);
+    assert.equal(typeof owner.notifyGroup, 'boolean');
+    assert.equal(typeof other.notifyGroup, 'boolean');
+
+    // And the truthiness flip that Task 3 will rely on works correctly
+    assert.equal(!owner.notifyGroup, true);
+    assert.equal(!other.notifyGroup, false);
+  });
+
+  it('default notify_group is true for newly added members', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'NTF002' });
+    addMember(db, g.id, USER_B);
+    const members = getMembersOfGroup(db, g.id);
+    for (const m of members) {
+      assert.equal(m.notifyGroup, true);
+    }
+  });
+});
+
+describe('listAllGroupsWithStats', () => {
+  it('returns empty list when no groups', () => {
+    assert.deepEqual(listAllGroupsWithStats(db), []);
+  });
+
+  it('returns each group with its member count', () => {
+    const g1 = createGroup(db, { name: 'solo', ownerId: USER_A, inviteCode: 'LST001' });
+    const g2 = createGroup(db, { name: 'duo',  ownerId: USER_B, inviteCode: 'LST002' });
+    addMember(db, g2.id, USER_C);
+
+    const stats = listAllGroupsWithStats(db);
+    assert.equal(stats.length, 2);
+    const byId = new Map(stats.map((s) => [s.id, s.memberCount]));
+    assert.equal(byId.get(g1.id), 1); // just owner
+    assert.equal(byId.get(g2.id), 2); // owner + USER_C
+  });
+});

--- a/src/__tests__/groupRepository.test.ts
+++ b/src/__tests__/groupRepository.test.ts
@@ -235,3 +235,86 @@ describe('listAllGroupsWithStats', () => {
     assert.equal(byId.get(g2.id), 2); // owner + USER_C
   });
 });
+
+// CRITICAL — UNIQUE constraint race recovery
+// PR #230 review item #6: invite code collision must be recoverable via the
+// InviteCodeCollisionError sentinel so handleCreate can retry generation.
+describe('createGroup — invite code UNIQUE collision', () => {
+  it('throws InviteCodeCollisionError when invite_code is already taken', async () => {
+    // Import lazily so the import doesn't fail before the file is regenerated
+    const { InviteCodeCollisionError } = await import('../db/groupRepository.js');
+    createGroup(db, { name: 'first',  ownerId: USER_A, inviteCode: 'COLL01' });
+
+    try {
+      createGroup(db, { name: 'second', ownerId: USER_B, inviteCode: 'COLL01' });
+      assert.fail('expected InviteCodeCollisionError');
+    } catch (err) {
+      assert.ok(err instanceof InviteCodeCollisionError, `expected InviteCodeCollisionError, got ${err instanceof Error ? err.constructor.name : typeof err}`);
+      assert.match((err as Error).message, /COLL01/);
+    }
+  });
+
+  it('does not wrap other errors as InviteCodeCollisionError', async () => {
+    const { InviteCodeCollisionError } = await import('../db/groupRepository.js');
+    // Non-existent owner FK throws SQLITE_CONSTRAINT_FOREIGNKEY, NOT UNIQUE.
+    // The wrapper must let it propagate as-is.
+    try {
+      createGroup(db, { name: 'x', ownerId: 999999, inviteCode: 'OK0001' });
+      assert.fail('expected throw');
+    } catch (err) {
+      assert.ok(!(err instanceof InviteCodeCollisionError), 'FK error must not be wrapped as collision');
+    }
+  });
+});
+
+// CRITICAL — role decode hardening (PR #230 review item #3)
+describe('decodeMember role hardening', () => {
+  it('downgrades unexpected role values to "member" without throwing', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'ROL001' });
+
+    // Bypass CHECK constraint via PRAGMA — supported by SQLite for exactly
+    // this kind of corrupted-state simulation. Restored in finally{}.
+    db.pragma('ignore_check_constraints = ON');
+    try {
+      db.prepare("INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'admin')").run(g.id, USER_B);
+    } finally {
+      db.pragma('ignore_check_constraints = OFF');
+    }
+
+    const members = getMembersOfGroup(db, g.id);
+    const corrupt = members.find((m) => m.userId === USER_B);
+    assert.ok(corrupt, 'member with corrupt role should still be returned');
+    // Hardened decode defaults to least-privileged 'member'
+    assert.equal(corrupt.role, 'member');
+  });
+});
+
+// MINOR — FK cascade tests (PR #230 review pr-test-analyzer)
+describe('FK cascades', () => {
+  it('deleting a user removes all their group memberships', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'CAS001' });
+    addMember(db, g.id, USER_B);
+    assert.equal(countMembersOfGroup(db, g.id), 2);
+
+    // Delete USER_B
+    db.prepare('DELETE FROM users WHERE chat_id = ?').run(USER_B);
+
+    // group_members.user_id FK CASCADE removes the membership row
+    assert.equal(countMembersOfGroup(db, g.id), 1);
+    // The group itself still exists (owner is USER_A, not USER_B)
+    assert.ok(findGroupById(db, g.id));
+  });
+
+  it('deleting the owner cascades to remove the entire group', () => {
+    const g = createGroup(db, { name: 'x', ownerId: USER_A, inviteCode: 'CAS002' });
+    addMember(db, g.id, USER_B);
+
+    // Delete USER_A (the owner)
+    db.prepare('DELETE FROM users WHERE chat_id = ?').run(USER_A);
+
+    // groups.owner_id FK CASCADE removes the group, then group_members CASCADE removes all members
+    assert.equal(findGroupById(db, g.id), undefined);
+    const remaining = db.prepare('SELECT * FROM group_members WHERE group_id = ?').all(g.id);
+    assert.equal(remaining.length, 0);
+  });
+});

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -12,6 +12,7 @@ import { registerPrivacyHandler } from './privacyHandler.js';
 import { registerTodayHandler } from './todayHandler.js';
 import { registerLegendHandler } from './legendHandler.js';
 import { registerSafetyStatusHandler } from './safetyStatusHandler.js';
+import { registerGroupHandler } from './groupHandler.js';
 import { log } from '../logger.js';
 
 export async function setupBotHandlers(bot: Bot): Promise<void> {
@@ -28,6 +29,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerStatsHandler(bot);
   registerHistoryHandler(bot);
   registerConnectHandler(bot);
+  registerGroupHandler(bot);
   registerPrivacyHandler(bot);
   registerTodayHandler(bot);
   registerLegendHandler(bot);
@@ -47,6 +49,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
     { command: 'history',  description: 'היסטוריית התראות לאזורך' },
     { command: 'connect',  description: 'חיבור עם חברים' },
     { command: 'contacts', description: 'אנשי הקשר שלי' },
+    { command: 'group',    description: 'ניהול קבוצות חוסן' },
     { command: 'privacy',  description: 'הגדרות פרטיות' },
     { command: 'today',    description: 'סיכום יומי' },
     { command: 'legend',   description: 'מקרא אזורי ההתראה' },

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -2,13 +2,15 @@ import crypto from 'crypto';
 import type Database from 'better-sqlite3';
 import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
-import { upsertUser } from '../db/userRepository.js';
+import { upsertUser, getUser } from '../db/userRepository.js';
+import type { User } from '../db/userRepository.js';
 import {
   createGroup,
   findGroupByInviteCode,
   findGroupById,
   getGroupsForUser,
   getMembersOfGroup,
+  getMemberStatusesForGroup,
   addMember,
   removeMember,
   deleteGroup,
@@ -19,7 +21,7 @@ import {
 } from '../db/groupRepository.js';
 import { getDb } from '../db/schema.js';
 import { log } from '../logger.js';
-import { escapeHtml } from '../textUtils.js';
+import { escapeHtml, formatRelativeTime } from '../textUtils.js';
 
 // ─── Constants (fallbacks until Task 4 #225 wires configResolver) ────────────
 
@@ -385,6 +387,132 @@ async function handleLeave(ctx: Context, groupIdArg: string | undefined): Promis
   await performLeave(ctx, groupId, chatId);
 }
 
+// ─── /group status — group-wide safety status aggregation ───────────────────
+
+/**
+ * Subset of `User` fields needed by the group status renderer. Tests inject
+ * a stub function returning this shape so they can drive renderGroupStatus
+ * with a `:memory:` DB that the production `getUser()` (singleton-backed)
+ * cannot see. Pattern: `pattern_getuser_singleton_vs_di.md` in memory.
+ */
+type GroupStatusUserLookup = (chatId: number) => Pick<User, 'display_name' | 'home_city'> | undefined;
+
+async function handleStatus(ctx: Context, groupIdArg: string | undefined): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+  const db = getDb();
+
+  // Resolve target group: explicit id, single group auto-pick, or picker
+  let groupId: number;
+  if (groupIdArg) {
+    const parsed = Number(groupIdArg);
+    if (!Number.isInteger(parsed) || parsed <= 0) {
+      await ctx.reply('❌ מזהה קבוצה לא תקין.');
+      return;
+    }
+    groupId = parsed;
+  } else {
+    const groups = getGroupsForUser(db, chatId);
+    if (groups.length === 0) {
+      await ctx.reply('אינך חבר באף קבוצה.');
+      return;
+    }
+    if (groups.length === 1) {
+      const onlyGroup = groups[0];
+      if (!onlyGroup) return;
+      groupId = onlyGroup.id;
+    } else {
+      // Multi-group picker — show inline keyboard with one button per group
+      const kb = new InlineKeyboard();
+      for (const g of groups) {
+        kb.text(`👥 ${g.name}`, cb(`g:s:${g.id}`)).row();
+      }
+      await ctx.reply('בחר קבוצה לצפייה בסטטוס:', { reply_markup: kb });
+      return;
+    }
+  }
+
+  // Membership check (auth invariant) — only members can view a group's status
+  const members = getMembersOfGroup(db, groupId);
+  if (!members.some((m) => m.userId === chatId)) {
+    await ctx.reply('❌ אינך חבר בקבוצה זו.');
+    return;
+  }
+
+  await renderGroupStatus(ctx, db, groupId);
+}
+
+/**
+ * Renders the group status card. Used by both `/group status` (initial reply)
+ * and the `g:s:<id>` / `g:refresh:<id>` callbacks (in-place edit).
+ *
+ * Exported so tests can drive it directly with an injected `lookupUser` that
+ * reads from the test's `:memory:` DB instead of the `getDb()` singleton that
+ * `getUser()` reads from internally.
+ */
+export async function renderGroupStatus(
+  ctx: Context,
+  db: Database.Database,
+  groupId: number,
+  lookupUser: GroupStatusUserLookup = getUser,
+): Promise<void> {
+  const group = findGroupById(db, groupId);
+  if (!group) {
+    const message = '❌ הקבוצה לא נמצאה.';
+    if (ctx.callbackQuery) {
+      await ctx
+        .editMessageText(message)
+        .catch((e) => log('warn', 'Groups', `editMessageText (status not-found) failed: ${formatError(e)}`));
+    } else {
+      await ctx.reply(message);
+    }
+    return;
+  }
+
+  const statuses = getMemberStatusesForGroup(db, groupId);
+
+  let okCount = 0;
+  const lines: string[] = [`👥 <b>${escapeHtml(group.name)}</b>`, ''];
+  for (const { userId, status } of statuses) {
+    const user = lookupUser(userId);
+    const displayName = escapeHtml(user?.display_name ?? `משתמש #${userId}`);
+    const homeCity = user?.home_city ? ` · ${escapeHtml(user.home_city)}` : '';
+
+    let emoji = '❓';
+    let label = 'לא דיווח';
+    if (status?.status === 'ok') {
+      emoji = '✅';
+      label = 'בסדר';
+      okCount++;
+    } else if (status?.status === 'help') {
+      emoji = '⚠️';
+      label = 'צריך עזרה';
+    } else if (status?.status === 'dismissed') {
+      emoji = '🔇';
+      label = 'התעלם';
+    }
+
+    const when = status ? ` · ${formatRelativeTime(status.updated_at)}` : '';
+    lines.push(`${emoji} <b>${displayName}</b> · ${label}${homeCity}${when}`);
+  }
+  lines.push('', `<b>${okCount}/${statuses.length} בסדר</b>`);
+  // Hint: there's no "safety:menu" callback — use the slash command instead.
+  // Verified during planning against safetyStatusHandler.ts (only safety:back,
+  // safety:contacts, safety:ok:N, safety:help:N, safety:dismiss:N exist).
+  lines.push('', '<i>לעדכון הסטטוס שלך: /status</i>');
+
+  const kb = new InlineKeyboard().text('🔄 רענן', cb(`g:refresh:${groupId}`));
+  const text = lines.join('\n');
+
+  if (ctx.callbackQuery) {
+    await ctx
+      .editMessageText(text, { parse_mode: 'HTML', reply_markup: kb })
+      .catch((e) => log('warn', 'Groups', `editMessageText (status render) failed: ${formatError(e)}`));
+  } else {
+    await ctx.reply(text, { parse_mode: 'HTML', reply_markup: kb });
+  }
+}
+
 async function performLeave(
   ctx: Context,
   groupId: number,
@@ -469,6 +597,9 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
     case 'leave':
       await handleLeave(ctx, args[1]);
       return;
+    case 'status':
+      await handleStatus(ctx, args[1]);
+      return;
     default:
       await ctx.reply(
         '❌ פקודה לא מוכרת.\n\n' +
@@ -476,7 +607,8 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
           '<code>/group</code> — רשימת הקבוצות שלי\n' +
           '<code>/group create &lt;שם&gt;</code> — יצירת קבוצה\n' +
           '<code>/group join &lt;קוד&gt;</code> — הצטרפות עם קוד\n' +
-          '<code>/group leave [id]</code> — עזיבת קבוצה',
+          '<code>/group leave [id]</code> — עזיבת קבוצה\n' +
+          '<code>/group status [id]</code> — סטטוס קבוצתי',
         { parse_mode: 'HTML' }
       );
   }
@@ -566,6 +698,59 @@ export function registerGroupHandler(bot: Bot): void {
         .catch((err) => {
           log('warn', 'Groups', `editMessageText (g:c) failed: ${formatError(err)}`);
         });
+    }),
+  );
+
+  // g:s:<id> — render group status (from multi-group picker)
+  bot.callbackQuery(
+    /^g:s:(\d+)$/,
+    wrapCallback('g:s', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:s) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
+
+      const db = getDb();
+      // Auth check before render — non-members must NOT see status (privacy invariant).
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) {
+        await ctx
+          .editMessageText('❌ אינך חבר בקבוצה זו.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:s non-member) failed: ${formatError(e)}`));
+        return;
+      }
+      await renderGroupStatus(ctx, db, groupId);
+    }),
+  );
+
+  // g:refresh:<id> — re-render in place (the 🔄 רענן button)
+  bot.callbackQuery(
+    /^g:refresh:(\d+)$/,
+    wrapCallback('g:refresh', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:refresh) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
+
+      const db = getDb();
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) {
+        await ctx
+          .editMessageText('❌ אינך חבר בקבוצה זו.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:refresh non-member) failed: ${formatError(e)}`));
+        return;
+      }
+      await renderGroupStatus(ctx, db, groupId);
     }),
   );
 

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -22,13 +22,45 @@ import {
 import { getDb } from '../db/schema.js';
 import { log } from '../logger.js';
 import { escapeHtml, formatRelativeTime } from '../textUtils.js';
+import { resolveConfig } from '../config/configResolver.js';
 
-// ─── Constants (fallbacks until Task 4 #225 wires configResolver) ────────────
+// ─── Hot-config caps (resolved per call via configResolver) ──────────────────
 
-/** Max groups a single user may own. Task 4 will replace with hot-config. */
+/**
+ * Default max groups a single user may own. Overridable via the dashboard
+ * Settings page (writes to the `groups_max_per_user` key in the `settings`
+ * table). Read on every /group create call so dashboard changes take effect
+ * immediately without restart.
+ */
 export const MAX_GROUPS_PER_USER_FALLBACK = 5;
-/** Max members per group, including owner. Task 4 will replace with hot-config. */
+/**
+ * Default max members per group, including owner. Overridable via the
+ * dashboard Settings page (`groups_max_members`). Read on every /group join.
+ */
 export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
+
+/**
+ * Resolves a hot-config integer cap with fallback. Wraps `resolveConfig`
+ * with parsing + fallback so the call sites stay clean. Reads on every
+ * call — appropriate for low-frequency user-triggered paths (/group create
+ * and /group join). For per-alert hot paths, prefer cached patterns.
+ */
+function resolveIntConfig(key: string, fallback: number): number {
+  const raw = resolveConfig(getDb(), key);
+  if (raw === null || raw === undefined) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && Number.isInteger(n) && n >= 0 ? n : fallback;
+}
+
+/** Hot-configurable — reads `groups_max_per_user` from DB→env→fallback. */
+function getMaxGroupsPerUser(): number {
+  return resolveIntConfig('groups_max_per_user', MAX_GROUPS_PER_USER_FALLBACK);
+}
+
+/** Hot-configurable — reads `groups_max_members` from DB→env→fallback. */
+function getMaxMembersPerGroup(): number {
+  return resolveIntConfig('groups_max_members', MAX_MEMBERS_PER_GROUP_FALLBACK);
+}
 
 const JOIN_COOLDOWN_MS = 5_000;
 const MAX_JOIN_FAILURES = 5;
@@ -247,9 +279,10 @@ async function handleCreate(ctx: Context, name: string): Promise<void> {
   }
 
   const db = getDb();
-  if (countGroupsOwnedBy(db, chatId) >= MAX_GROUPS_PER_USER_FALLBACK) {
+  const maxGroups = getMaxGroupsPerUser();
+  if (countGroupsOwnedBy(db, chatId) >= maxGroups) {
     await ctx.reply(
-      `❌ הגעת לגבול: ניתן ליצור עד ${MAX_GROUPS_PER_USER_FALLBACK} קבוצות.\nמחק קבוצה קיימת לפני יצירת חדשה.`
+      `❌ הגעת לגבול: ניתן ליצור עד ${maxGroups} קבוצות.\nמחק קבוצה קיימת לפני יצירת חדשה.`
     );
     return;
   }
@@ -326,9 +359,10 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
     return;
   }
 
-  if (members.length >= MAX_MEMBERS_PER_GROUP_FALLBACK) {
+  const maxMembers = getMaxMembersPerGroup();
+  if (members.length >= maxMembers) {
     await ctx.reply(
-      `❌ הקבוצה מלאה (מקסימום ${MAX_MEMBERS_PER_GROUP_FALLBACK} חברים).`
+      `❌ הקבוצה מלאה (מקסימום ${maxMembers} חברים).`
     );
     return;
   }

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -13,6 +13,8 @@ import {
   deleteGroup,
   countGroupsOwnedBy,
   countMembersOfGroup,
+  InviteCodeCollisionError,
+  type Group,
 } from '../db/groupRepository.js';
 import { getDb } from '../db/schema.js';
 import { log } from '../logger.js';
@@ -28,9 +30,21 @@ export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
 const JOIN_COOLDOWN_MS = 5_000;
 const MAX_JOIN_FAILURES = 5;
 const JOIN_FAILURE_BLOCK_MS = 60_000;
+/** Human-readable form of JOIN_FAILURE_BLOCK_MS for error messages. */
+const JOIN_FAILURE_BLOCK_LABEL_HE = 'דקה';
 const MAX_GROUP_NAME_LENGTH = 50;
 const INVITE_CODE_LENGTH = 6;
 const MAX_INVITE_CODE_RETRIES = 5;
+/** Number of times handleCreate will retry the full generate+insert cycle on UNIQUE collision race. */
+const MAX_CREATE_GROUP_COLLISION_RETRIES = 3;
+
+// ─── Error formatting ────────────────────────────────────────────────────────
+
+/** Preserve stack trace when available — String(err) drops it. */
+function formatError(err: unknown): string {
+  if (err instanceof Error) return err.stack ?? err.message;
+  return String(err);
+}
 
 // Unambiguous alphabet — no 0/O/I/1 to avoid copy-paste confusion
 const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
@@ -164,21 +178,36 @@ async function handleCreate(ctx: Context, name: string): Promise<void> {
     return;
   }
 
-  let inviteCode: string;
-  try {
-    inviteCode = generateInviteCode(db);
-  } catch (err) {
-    log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${String(err)}`);
-    await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
-    return;
+  // generate + insert in a retry loop — the pre-check in generateInviteCode
+  // is best-effort; UNIQUE collision under concurrent inserts is recoverable
+  // by retrying with a fresh code.
+  let group: Group | undefined;
+  let inviteCode: string | undefined;
+  for (let attempt = 0; attempt < MAX_CREATE_GROUP_COLLISION_RETRIES; attempt++) {
+    try {
+      inviteCode = generateInviteCode(db);
+    } catch (err) {
+      log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${formatError(err)}`);
+      await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
+      return;
+    }
+    try {
+      group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
+      break; // success
+    } catch (err) {
+      if (err instanceof InviteCodeCollisionError) {
+        log('warn', 'Groups', `Invite code collision for ${chatId} on attempt ${attempt + 1}: ${inviteCode} — retrying`);
+        continue; // generate a fresh code and retry
+      }
+      log('error', 'Groups', `createGroup failed for ${chatId}: ${formatError(err)}`);
+      await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+      return;
+    }
   }
 
-  let group;
-  try {
-    group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
-  } catch (err) {
-    log('error', 'Groups', `createGroup failed for ${chatId}: ${String(err)}`);
-    await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+  if (!group || !inviteCode) {
+    log('error', 'Groups', `createGroup exhausted ${MAX_CREATE_GROUP_COLLISION_RETRIES} collision retries for ${chatId}`);
+    await ctx.reply('❌ שגיאת שרת — לא הצלחנו ליצור קוד הזמנה ייחודי. נסה שוב.');
     return;
   }
 
@@ -198,16 +227,8 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
   const chatId = ctx.chat?.id;
   if (!chatId) return;
 
-  if (isJoinBlocked(chatId)) {
-    await ctx.reply('⏳ יותר מדי ניסיונות שגויים. נסה שוב בעוד דקה.');
-    return;
-  }
-  if (isJoinOnCooldown(chatId)) {
-    await ctx.reply('⏳ נסה שוב בעוד כמה שניות.');
-    return;
-  }
-  setJoinCooldown(chatId);
-
+  // Validate format BEFORE consuming cooldown — avoid penalizing users who
+  // typo `/group join` with no args. Mirrors connectHandler.ts:268-282 ordering.
   const code = codeArg.trim().toUpperCase();
   if (code.length === 0) {
     await ctx.reply(
@@ -216,6 +237,16 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
     );
     return;
   }
+
+  if (isJoinBlocked(chatId)) {
+    await ctx.reply(`⏳ יותר מדי ניסיונות שגויים. נסה שוב בעוד ${JOIN_FAILURE_BLOCK_LABEL_HE}.`);
+    return;
+  }
+  if (isJoinOnCooldown(chatId)) {
+    await ctx.reply('⏳ נסה שוב בעוד כמה שניות.');
+    return;
+  }
+  setJoinCooldown(chatId);
 
   const db = getDb();
   const group = findGroupByInviteCode(db, code);
@@ -245,7 +276,7 @@ async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
   try {
     addMember(db, group.id, chatId);
   } catch (err) {
-    log('error', 'Groups', `addMember failed for ${chatId} → ${group.id}: ${String(err)}`);
+    log('error', 'Groups', `addMember failed for ${chatId} → ${group.id}: ${formatError(err)}`);
     await ctx.reply('❌ שגיאת שרת בהצטרפות. נסה שוב.');
     return;
   }
@@ -312,9 +343,12 @@ async function performLeave(
   const memberCount = countMembersOfGroup(db, groupId);
 
   if (isOwner && memberCount > 1) {
+    // Tracked: github.com/yonatan2021/pikud-haoref-bot/issues/231 (escape
+    // hatch for orphan groups — transfer / delete / force-delete in v0.5.2).
     await ctx.reply(
-      '❌ אינך יכול לעזוב — אתה הבעלים. העבר בעלות או מחק את הקבוצה.\n' +
-        '<i>(מחיקת קבוצות תיתמך בגרסה הבאה)</i>',
+      '❌ אינך יכול לעזוב — אתה הבעלים, ויש חברים נוספים בקבוצה.\n\n' +
+        '<i>העברת בעלות ומחיקת קבוצות יתמכו ב-v0.5.2.\n' +
+        'בינתיים: בקש מהחברים לעזוב, ואז תוכל לעזוב גם אתה.</i>',
       { parse_mode: 'HTML' }
     );
     return;
@@ -341,13 +375,20 @@ async function performLeave(
 // ─── Main dispatch ───────────────────────────────────────────────────────────
 
 async function handleGroupCommand(ctx: Context): Promise<void> {
-  if (ctx.chat?.type !== 'private') return;
+  if (ctx.chat?.type !== 'private') {
+    // Reply rather than silent no-op so users in groups understand why
+    // /group did nothing. Mirrors safetyStatusHandler / connectHandler.
+    await ctx
+      .reply('ℹ️ הפקודה /group זמינה רק בשיחה פרטית עם הבוט.')
+      .catch((err) => log('warn', 'Groups', `non-private reply failed: ${formatError(err)}`));
+    return;
+  }
   const chatId = ctx.chat.id;
 
   try {
     upsertUser(chatId);
   } catch (err) {
-    log('error', 'Groups', `Failed to upsert user ${chatId}: ${String(err)}`);
+    log('error', 'Groups', `Failed to upsert user ${chatId}: ${formatError(err)}`);
     await ctx.reply('❌ שגיאת שרת — נסה שוב.');
     return;
   }
@@ -385,73 +426,112 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
 
 // ─── Registration ────────────────────────────────────────────────────────────
 
+/**
+ * Wraps a callback handler body with: (1) outer try/catch logging via the
+ * project logger (NOT stderr — Grammy's default handler bypasses src/logger.ts),
+ * (2) a user-facing answerCallbackQuery alert so users see something instead
+ * of a stuck spinner. Without this wrapper, any DB throw inside the body
+ * becomes an unhandled rejection.
+ */
+function wrapCallback(
+  tag: string,
+  body: (ctx: Context) => Promise<void>
+): (ctx: Context) => Promise<void> {
+  return async (ctx: Context): Promise<void> => {
+    try {
+      await body(ctx);
+    } catch (err) {
+      log('error', 'Groups', `${tag} callback error: ${formatError(err)}`);
+      await ctx
+        .answerCallbackQuery({ text: '⚠️ שגיאה — נסה שוב', show_alert: false })
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (error path) failed: ${formatError(e)}`));
+    }
+  };
+}
+
 export function registerGroupHandler(bot: Bot): void {
   bot.command('group', async (ctx) => {
     try {
       await handleGroupCommand(ctx);
     } catch (err) {
-      log('error', 'Groups', `handler error: ${String(err)}`);
-      await ctx.reply('⚠️ שגיאה בטיפול בקבוצה').catch(() => undefined);
+      log('error', 'Groups', `handler error: ${formatError(err)}`);
+      await ctx
+        .reply('⚠️ שגיאה בטיפול בקבוצה')
+        .catch((e) => log('warn', 'Groups', `error-reply failed: ${formatError(e)}`));
     }
   });
 
   // g:c:<id> — show group card
-  bot.callbackQuery(/^g:c:(\d+)$/, async (ctx) => {
-    await ctx.answerCallbackQuery().catch(() => undefined);
-    const chatId = ctx.chat?.id;
-    if (!chatId) return;
-    const raw = ctx.match?.[1];
-    if (!raw) return;
-    const groupId = parseInt(raw, 10);
-    if (isNaN(groupId)) return;
+  bot.callbackQuery(
+    /^g:c:(\d+)$/,
+    wrapCallback('g:c', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:c) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
 
-    const db = getDb();
-    const group = findGroupById(db, groupId);
-    if (!group) {
-      await ctx.editMessageText('❌ הקבוצה לא נמצאה.').catch(() => undefined);
-      return;
-    }
-    const members = getMembersOfGroup(db, groupId);
-    if (!members.some((m) => m.userId === chatId)) {
-      await ctx.editMessageText('❌ אינך חבר בקבוצה זו.').catch(() => undefined);
-      return;
-    }
+      const db = getDb();
+      const group = findGroupById(db, groupId);
+      if (!group) {
+        await ctx
+          .editMessageText('❌ הקבוצה לא נמצאה.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:c not-found) failed: ${formatError(e)}`));
+        return;
+      }
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) {
+        await ctx
+          .editMessageText('❌ אינך חבר בקבוצה זו.')
+          .catch((e) => log('warn', 'Groups', `editMessageText (g:c non-member) failed: ${formatError(e)}`));
+        return;
+      }
 
-    const isOwner = group.ownerId === chatId;
-    const lines = [
-      `📋 <b>${escapeHtml(group.name)}</b>`,
-      '',
-      `חברים: ${members.length}`,
-      `נוצרה: ${group.createdAt.split(' ')[0] ?? group.createdAt}`,
-    ];
-    if (isOwner) {
-      lines.push('', `קוד הזמנה: <code>${group.inviteCode}</code>`);
-    }
+      const isOwner = group.ownerId === chatId;
+      const lines = [
+        `📋 <b>${escapeHtml(group.name)}</b>`,
+        '',
+        `חברים: ${members.length}`,
+        `נוצרה: ${group.createdAt.split(' ')[0] ?? group.createdAt}`,
+      ];
+      if (isOwner) {
+        lines.push('', `קוד הזמנה: <code>${group.inviteCode}</code>`);
+      }
 
-    const kb = new InlineKeyboard().text('🚪 עזיבה', cb(`g:leaveY:${groupId}`));
-    await ctx
-      .editMessageText(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb })
-      .catch((err) => {
-        log('warn', 'Groups', `editMessageText (g:c) failed: ${String(err)}`);
-      });
-  });
+      const kb = new InlineKeyboard().text('🚪 עזיבה', cb(`g:leaveY:${groupId}`));
+      await ctx
+        .editMessageText(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb })
+        .catch((err) => {
+          log('warn', 'Groups', `editMessageText (g:c) failed: ${formatError(err)}`);
+        });
+    }),
+  );
 
-  // g:leaveY:<id> — confirm leave
-  bot.callbackQuery(/^g:leaveY:(\d+)$/, async (ctx) => {
-    await ctx.answerCallbackQuery().catch(() => undefined);
-    const chatId = ctx.chat?.id;
-    if (!chatId) return;
-    const raw = ctx.match?.[1];
-    if (!raw) return;
-    const groupId = parseInt(raw, 10);
-    if (isNaN(groupId)) return;
+  // g:leaveY:<id> — leave (no real confirm step yet — name preserved for stable callback_data)
+  bot.callbackQuery(
+    /^g:leaveY:(\d+)$/,
+    wrapCallback('g:leaveY', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (g:leaveY) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      const raw = ctx.match?.[1];
+      if (!raw) return;
+      const groupId = parseInt(raw, 10);
+      if (isNaN(groupId)) return;
 
-    const db = getDb();
-    const group = findGroupById(db, groupId);
-    if (!group) return;
-    const members = getMembersOfGroup(db, groupId);
-    if (!members.some((m) => m.userId === chatId)) return;
+      const db = getDb();
+      const group = findGroupById(db, groupId);
+      if (!group) return;
+      const members = getMembersOfGroup(db, groupId);
+      if (!members.some((m) => m.userId === chatId)) return;
 
-    await performLeave(ctx, groupId, chatId);
-  });
+      await performLeave(ctx, groupId, chatId);
+    }),
+  );
 }

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import type Database from 'better-sqlite3';
 import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
 import { upsertUser } from '../db/userRepository.js';
@@ -153,6 +154,79 @@ async function handleList(ctx: Context): Promise<void> {
   await ctx.reply(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb });
 }
 
+/**
+ * Outcome of a group-creation attempt with collision retry. Distinguishes
+ * three branches that the handler must surface differently to the user:
+ * - 'ok': group created, inviteCode is the final code that was inserted
+ * - 'codegen-failed': generateInviteCode threw (e.g. internal exhaustion);
+ *   the generic 'שגיאת שרת ביצירת קוד' message is shown
+ * - 'collision-exhausted': the generate+insert cycle hit InviteCodeCollisionError
+ *   on every attempt; the more specific exhaustion message is shown
+ * - 'createGroup-failed': createGroup threw a non-collision error (FK / lock /
+ *   disk); the generic 'שגיאת שרת ביצירת הקבוצה' message is shown
+ */
+type CreateGroupOutcome =
+  | { kind: 'ok'; group: Group; inviteCode: string }
+  | { kind: 'codegen-failed'; cause: unknown }
+  | { kind: 'collision-exhausted' }
+  | { kind: 'createGroup-failed'; cause: unknown };
+
+/**
+ * Dependencies for createGroupWithCollisionRetry — the seam that lets tests
+ * exercise the exhaustion branch directly without depending on real
+ * crypto.randomInt or actually inserting colliding rows.
+ */
+export interface CreateGroupRetryDeps {
+  generateInviteCodeFn?: (db: Database.Database) => string;
+  createGroupFn?: (db: Database.Database, input: { name: string; ownerId: number; inviteCode: string }) => Group;
+  maxRetries?: number;
+}
+
+/**
+ * Generates an invite code and inserts the group. On UNIQUE collision the
+ * cycle retries up to maxRetries times with a fresh code each time. The
+ * loop is extracted from handleCreate so that:
+ * (1) the exhaustion branch is unit-testable in isolation via injected deps
+ * (2) the return type is a discriminated union — handleCreate no longer
+ *     needs the `if (!group || !inviteCode)` dual-undefined guard
+ *
+ * Exported only for testing — handleCreate is the only production caller.
+ */
+export function createGroupWithCollisionRetry(
+  db: Database.Database,
+  input: { name: string; ownerId: number },
+  deps: CreateGroupRetryDeps = {},
+): CreateGroupOutcome {
+  const generateFn = deps.generateInviteCodeFn ?? generateInviteCode;
+  const createFn = deps.createGroupFn ?? createGroup;
+  const maxRetries = deps.maxRetries ?? MAX_CREATE_GROUP_COLLISION_RETRIES;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    let inviteCode: string;
+    try {
+      inviteCode = generateFn(db);
+    } catch (err) {
+      log('error', 'Groups', `generateInviteCode failed for ${input.ownerId}: ${formatError(err)}`);
+      return { kind: 'codegen-failed', cause: err };
+    }
+
+    try {
+      const group = createFn(db, { name: input.name, ownerId: input.ownerId, inviteCode });
+      return { kind: 'ok', group, inviteCode };
+    } catch (err) {
+      if (err instanceof InviteCodeCollisionError) {
+        log('warn', 'Groups', `Invite code collision for ${input.ownerId} on attempt ${attempt + 1}: ${inviteCode} — retrying`);
+        continue;
+      }
+      log('error', 'Groups', `createGroup failed for ${input.ownerId}: ${formatError(err)}`);
+      return { kind: 'createGroup-failed', cause: err };
+    }
+  }
+
+  log('error', 'Groups', `createGroup exhausted ${maxRetries} collision retries for ${input.ownerId}`);
+  return { kind: 'collision-exhausted' };
+}
+
 async function handleCreate(ctx: Context, name: string): Promise<void> {
   const chatId = ctx.chat?.id;
   if (!chatId) return;
@@ -178,49 +252,33 @@ async function handleCreate(ctx: Context, name: string): Promise<void> {
     return;
   }
 
-  // generate + insert in a retry loop — the pre-check in generateInviteCode
-  // is best-effort; UNIQUE collision under concurrent inserts is recoverable
-  // by retrying with a fresh code.
-  let group: Group | undefined;
-  let inviteCode: string | undefined;
-  for (let attempt = 0; attempt < MAX_CREATE_GROUP_COLLISION_RETRIES; attempt++) {
-    try {
-      inviteCode = generateInviteCode(db);
-    } catch (err) {
-      log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${formatError(err)}`);
+  const outcome = createGroupWithCollisionRetry(db, { name: trimmed, ownerId: chatId });
+
+  switch (outcome.kind) {
+    case 'codegen-failed':
       await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
       return;
-    }
-    try {
-      group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
-      break; // success
-    } catch (err) {
-      if (err instanceof InviteCodeCollisionError) {
-        log('warn', 'Groups', `Invite code collision for ${chatId} on attempt ${attempt + 1}: ${inviteCode} — retrying`);
-        continue; // generate a fresh code and retry
-      }
-      log('error', 'Groups', `createGroup failed for ${chatId}: ${formatError(err)}`);
+    case 'createGroup-failed':
       await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+      return;
+    case 'collision-exhausted':
+      await ctx.reply('❌ שגיאת שרת — לא הצלחנו ליצור קוד הזמנה ייחודי. נסה שוב.');
+      return;
+    case 'ok': {
+      const { group, inviteCode } = outcome;
+      log('info', 'Groups', `User ${chatId} created group ${group.id} (${trimmed})`);
+
+      const kb = new InlineKeyboard().text('📋 כרטיס הקבוצה', cb(`g:c:${group.id}`));
+      await ctx.reply(
+        `✅ <b>קבוצה נוצרה: ${escapeHtml(trimmed)}</b>\n\n` +
+          `קוד הזמנה: <code>${inviteCode}</code>\n\n` +
+          `שתפו את הקוד עם בני המשפחה / חברים — הם יוכלו להצטרף עם:\n` +
+          `<code>/group join ${inviteCode}</code>`,
+        { parse_mode: 'HTML', reply_markup: kb }
+      );
       return;
     }
   }
-
-  if (!group || !inviteCode) {
-    log('error', 'Groups', `createGroup exhausted ${MAX_CREATE_GROUP_COLLISION_RETRIES} collision retries for ${chatId}`);
-    await ctx.reply('❌ שגיאת שרת — לא הצלחנו ליצור קוד הזמנה ייחודי. נסה שוב.');
-    return;
-  }
-
-  log('info', 'Groups', `User ${chatId} created group ${group.id} (${trimmed})`);
-
-  const kb = new InlineKeyboard().text('📋 כרטיס הקבוצה', cb(`g:c:${group.id}`));
-  await ctx.reply(
-    `✅ <b>קבוצה נוצרה: ${escapeHtml(trimmed)}</b>\n\n` +
-      `קוד הזמנה: <code>${inviteCode}</code>\n\n` +
-      `שתפו את הקוד עם בני המשפחה / חברים — הם יוכלו להצטרף עם:\n` +
-      `<code>/group join ${inviteCode}</code>`,
-    { parse_mode: 'HTML', reply_markup: kb }
-  );
 }
 
 async function handleJoin(ctx: Context, codeArg: string): Promise<void> {

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -1,0 +1,457 @@
+import crypto from 'crypto';
+import { Bot, InlineKeyboard } from 'grammy';
+import type { Context } from 'grammy';
+import { upsertUser } from '../db/userRepository.js';
+import {
+  createGroup,
+  findGroupByInviteCode,
+  findGroupById,
+  getGroupsForUser,
+  getMembersOfGroup,
+  addMember,
+  removeMember,
+  deleteGroup,
+  countGroupsOwnedBy,
+  countMembersOfGroup,
+} from '../db/groupRepository.js';
+import { getDb } from '../db/schema.js';
+import { log } from '../logger.js';
+import { escapeHtml } from '../textUtils.js';
+
+// ─── Constants (fallbacks until Task 4 #225 wires configResolver) ────────────
+
+/** Max groups a single user may own. Task 4 will replace with hot-config. */
+export const MAX_GROUPS_PER_USER_FALLBACK = 5;
+/** Max members per group, including owner. Task 4 will replace with hot-config. */
+export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
+
+const JOIN_COOLDOWN_MS = 5_000;
+const MAX_JOIN_FAILURES = 5;
+const JOIN_FAILURE_BLOCK_MS = 60_000;
+const MAX_GROUP_NAME_LENGTH = 50;
+const INVITE_CODE_LENGTH = 6;
+const MAX_INVITE_CODE_RETRIES = 5;
+
+// Unambiguous alphabet — no 0/O/I/1 to avoid copy-paste confusion
+const CODE_ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+// ─── Anti-spam state (mirror of connectHandler) ──────────────────────────────
+
+/** chatId → cooldown expiry timestamp. Exposed for test reset. */
+export const joinCooldownMap = new Map<number, number>();
+/** chatId → { count, blockedUntil }. Exposed for test reset. */
+export const joinFailures = new Map<number, { count: number; blockedUntil: number }>();
+
+function isJoinOnCooldown(chatId: number): boolean {
+  const expiry = joinCooldownMap.get(chatId);
+  if (expiry === undefined) return false;
+  if (Date.now() >= expiry) {
+    joinCooldownMap.delete(chatId);
+    return false;
+  }
+  return true;
+}
+
+function setJoinCooldown(chatId: number): void {
+  joinCooldownMap.set(chatId, Date.now() + JOIN_COOLDOWN_MS);
+}
+
+function isJoinBlocked(chatId: number): boolean {
+  const entry = joinFailures.get(chatId);
+  if (!entry) return false;
+  if (Date.now() >= entry.blockedUntil) {
+    joinFailures.delete(chatId);
+    return false;
+  }
+  return entry.count >= MAX_JOIN_FAILURES;
+}
+
+function recordJoinFailure(chatId: number): void {
+  const entry = joinFailures.get(chatId);
+  const count = (entry?.count ?? 0) + 1;
+  joinFailures.set(chatId, {
+    count,
+    blockedUntil:
+      count >= MAX_JOIN_FAILURES
+        ? Date.now() + JOIN_FAILURE_BLOCK_MS
+        : entry?.blockedUntil ?? 0,
+  });
+}
+
+function clearJoinFailures(chatId: number): void {
+  joinFailures.delete(chatId);
+}
+
+// ─── Callback data byte-length guard ─────────────────────────────────────────
+
+/**
+ * Runtime guard — Telegram silently rejects callback_data > 64 bytes UTF-8
+ * with a vague "BUTTON_DATA_INVALID" error. Throw early at button construction
+ * time so any developer mistake (e.g. accidentally embedding a Hebrew name)
+ * fails loud in tests instead of silent in production.
+ */
+export function cb(data: string): string {
+  const bytes = Buffer.byteLength(data, 'utf8');
+  if (bytes > 64) {
+    throw new Error(`callback_data too long (${bytes} bytes): ${data}`);
+  }
+  return data;
+}
+
+// ─── Invite code generator ───────────────────────────────────────────────────
+
+function generateInviteCode(db: ReturnType<typeof getDb>): string {
+  for (let i = 0; i < MAX_INVITE_CODE_RETRIES; i++) {
+    let code = '';
+    for (let j = 0; j < INVITE_CODE_LENGTH; j++) {
+      code += CODE_ALPHABET[crypto.randomInt(0, CODE_ALPHABET.length)];
+    }
+    if (!findGroupByInviteCode(db, code)) return code;
+  }
+  log('error', 'Groups', `Invite code generation exhausted ${MAX_INVITE_CODE_RETRIES} retries`);
+  throw new Error('Failed to generate unique invite code after retries');
+}
+
+// ─── Command handlers ────────────────────────────────────────────────────────
+
+async function handleList(ctx: Context): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+  const db = getDb();
+  const groups = getGroupsForUser(db, chatId);
+
+  if (groups.length === 0) {
+    await ctx.reply(
+      '👥 <b>הקבוצות שלי</b>\n\nאינך חבר באף קבוצה.\nליצירה: <code>/group create &lt;שם&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  const lines = ['👥 <b>הקבוצות שלי</b>', ''];
+  const kb = new InlineKeyboard();
+  for (const g of groups) {
+    const memberCount = countMembersOfGroup(db, g.id);
+    lines.push(`• <b>${escapeHtml(g.name)}</b> — ${memberCount} חברים`);
+    kb.text(`📋 ${g.name}`, cb(`g:c:${g.id}`)).row();
+  }
+
+  await ctx.reply(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb });
+}
+
+async function handleCreate(ctx: Context, name: string): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    await ctx.reply(
+      '❌ חסר שם לקבוצה.\nשימוש: <code>/group create &lt;שם&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+  if (trimmed.length > MAX_GROUP_NAME_LENGTH) {
+    await ctx.reply(`❌ השם ארוך מדי (מקסימום ${MAX_GROUP_NAME_LENGTH} תווים).`);
+    return;
+  }
+
+  const db = getDb();
+  if (countGroupsOwnedBy(db, chatId) >= MAX_GROUPS_PER_USER_FALLBACK) {
+    await ctx.reply(
+      `❌ הגעת לגבול: ניתן ליצור עד ${MAX_GROUPS_PER_USER_FALLBACK} קבוצות.\nמחק קבוצה קיימת לפני יצירת חדשה.`
+    );
+    return;
+  }
+
+  let inviteCode: string;
+  try {
+    inviteCode = generateInviteCode(db);
+  } catch (err) {
+    log('error', 'Groups', `generateInviteCode failed for ${chatId}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת ביצירת קוד הזמנה. נסה שוב.');
+    return;
+  }
+
+  let group;
+  try {
+    group = createGroup(db, { name: trimmed, ownerId: chatId, inviteCode });
+  } catch (err) {
+    log('error', 'Groups', `createGroup failed for ${chatId}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת ביצירת הקבוצה. נסה שוב.');
+    return;
+  }
+
+  log('info', 'Groups', `User ${chatId} created group ${group.id} (${trimmed})`);
+
+  const kb = new InlineKeyboard().text('📋 כרטיס הקבוצה', cb(`g:c:${group.id}`));
+  await ctx.reply(
+    `✅ <b>קבוצה נוצרה: ${escapeHtml(trimmed)}</b>\n\n` +
+      `קוד הזמנה: <code>${inviteCode}</code>\n\n` +
+      `שתפו את הקוד עם בני המשפחה / חברים — הם יוכלו להצטרף עם:\n` +
+      `<code>/group join ${inviteCode}</code>`,
+    { parse_mode: 'HTML', reply_markup: kb }
+  );
+}
+
+async function handleJoin(ctx: Context, codeArg: string): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+
+  if (isJoinBlocked(chatId)) {
+    await ctx.reply('⏳ יותר מדי ניסיונות שגויים. נסה שוב בעוד דקה.');
+    return;
+  }
+  if (isJoinOnCooldown(chatId)) {
+    await ctx.reply('⏳ נסה שוב בעוד כמה שניות.');
+    return;
+  }
+  setJoinCooldown(chatId);
+
+  const code = codeArg.trim().toUpperCase();
+  if (code.length === 0) {
+    await ctx.reply(
+      '❌ חסר קוד הזמנה.\nשימוש: <code>/group join &lt;קוד&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  const db = getDb();
+  const group = findGroupByInviteCode(db, code);
+  if (!group) {
+    recordJoinFailure(chatId);
+    await ctx.reply('❌ קוד לא תקין. בדקו שהעתקתם נכון.');
+    return;
+  }
+
+  // Already a member?
+  const members = getMembersOfGroup(db, group.id);
+  if (members.some((m) => m.userId === chatId)) {
+    clearJoinFailures(chatId);
+    await ctx.reply(`ℹ️ אתה כבר חבר בקבוצה <b>${escapeHtml(group.name)}</b>.`, {
+      parse_mode: 'HTML',
+    });
+    return;
+  }
+
+  if (members.length >= MAX_MEMBERS_PER_GROUP_FALLBACK) {
+    await ctx.reply(
+      `❌ הקבוצה מלאה (מקסימום ${MAX_MEMBERS_PER_GROUP_FALLBACK} חברים).`
+    );
+    return;
+  }
+
+  try {
+    addMember(db, group.id, chatId);
+  } catch (err) {
+    log('error', 'Groups', `addMember failed for ${chatId} → ${group.id}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת בהצטרפות. נסה שוב.');
+    return;
+  }
+
+  clearJoinFailures(chatId);
+  log('info', 'Groups', `User ${chatId} joined group ${group.id} (${group.name})`);
+
+  await ctx.reply(`✅ הצטרפת לקבוצה <b>${escapeHtml(group.name)}</b>!`, {
+    parse_mode: 'HTML',
+  });
+}
+
+async function handleLeave(ctx: Context, groupIdArg: string | undefined): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+  const db = getDb();
+
+  if (!groupIdArg) {
+    // No id — show picker
+    const groups = getGroupsForUser(db, chatId);
+    if (groups.length === 0) {
+      await ctx.reply('אינך חבר באף קבוצה.');
+      return;
+    }
+    const kb = new InlineKeyboard();
+    for (const g of groups) kb.text(`❌ ${g.name}`, cb(`g:leaveY:${g.id}`)).row();
+    await ctx.reply('בחר קבוצה לעזיבה:', { reply_markup: kb });
+    return;
+  }
+
+  const groupId = Number(groupIdArg);
+  if (!Number.isInteger(groupId) || groupId <= 0) {
+    await ctx.reply('❌ מזהה קבוצה לא תקין.');
+    return;
+  }
+
+  const group = findGroupById(db, groupId);
+  if (!group) {
+    await ctx.reply('❌ הקבוצה לא נמצאה.');
+    return;
+  }
+  const members = getMembersOfGroup(db, groupId);
+  if (!members.some((m) => m.userId === chatId)) {
+    await ctx.reply('❌ אינך חבר בקבוצה זו.');
+    return;
+  }
+
+  await performLeave(ctx, groupId, chatId);
+}
+
+async function performLeave(
+  ctx: Context,
+  groupId: number,
+  chatId: number
+): Promise<void> {
+  const db = getDb();
+  const group = findGroupById(db, groupId);
+  if (!group) {
+    await ctx.reply('❌ הקבוצה לא נמצאה.');
+    return;
+  }
+
+  const isOwner = group.ownerId === chatId;
+  const memberCount = countMembersOfGroup(db, groupId);
+
+  if (isOwner && memberCount > 1) {
+    await ctx.reply(
+      '❌ אינך יכול לעזוב — אתה הבעלים. העבר בעלות או מחק את הקבוצה.\n' +
+        '<i>(מחיקת קבוצות תיתמך בגרסה הבאה)</i>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  if (isOwner && memberCount === 1) {
+    // Last member + owner: delete the whole group (CASCADE removes membership)
+    deleteGroup(db, groupId);
+    log('info', 'Groups', `Group ${groupId} (${group.name}) deleted by owner ${chatId} (last member)`);
+    await ctx.reply(`🗑 הקבוצה <b>${escapeHtml(group.name)}</b> נמחקה.`, {
+      parse_mode: 'HTML',
+    });
+    return;
+  }
+
+  // Regular member leaving
+  removeMember(db, groupId, chatId);
+  log('info', 'Groups', `User ${chatId} left group ${groupId} (${group.name})`);
+  await ctx.reply(`✅ עזבת את הקבוצה <b>${escapeHtml(group.name)}</b>.`, {
+    parse_mode: 'HTML',
+  });
+}
+
+// ─── Main dispatch ───────────────────────────────────────────────────────────
+
+async function handleGroupCommand(ctx: Context): Promise<void> {
+  if (ctx.chat?.type !== 'private') return;
+  const chatId = ctx.chat.id;
+
+  try {
+    upsertUser(chatId);
+  } catch (err) {
+    log('error', 'Groups', `Failed to upsert user ${chatId}: ${String(err)}`);
+    await ctx.reply('❌ שגיאת שרת — נסה שוב.');
+    return;
+  }
+
+  const args = (ctx.message?.text ?? '').split(/\s+/).slice(1);
+  const sub = args[0]?.toLowerCase();
+  const rest = args.slice(1).join(' ');
+
+  switch (sub) {
+    case undefined:
+    case 'list':
+      await handleList(ctx);
+      return;
+    case 'create':
+      await handleCreate(ctx, rest);
+      return;
+    case 'join':
+      await handleJoin(ctx, rest);
+      return;
+    case 'leave':
+      await handleLeave(ctx, args[1]);
+      return;
+    default:
+      await ctx.reply(
+        '❌ פקודה לא מוכרת.\n\n' +
+          'שימוש:\n' +
+          '<code>/group</code> — רשימת הקבוצות שלי\n' +
+          '<code>/group create &lt;שם&gt;</code> — יצירת קבוצה\n' +
+          '<code>/group join &lt;קוד&gt;</code> — הצטרפות עם קוד\n' +
+          '<code>/group leave [id]</code> — עזיבת קבוצה',
+        { parse_mode: 'HTML' }
+      );
+  }
+}
+
+// ─── Registration ────────────────────────────────────────────────────────────
+
+export function registerGroupHandler(bot: Bot): void {
+  bot.command('group', async (ctx) => {
+    try {
+      await handleGroupCommand(ctx);
+    } catch (err) {
+      log('error', 'Groups', `handler error: ${String(err)}`);
+      await ctx.reply('⚠️ שגיאה בטיפול בקבוצה').catch(() => undefined);
+    }
+  });
+
+  // g:c:<id> — show group card
+  bot.callbackQuery(/^g:c:(\d+)$/, async (ctx) => {
+    await ctx.answerCallbackQuery().catch(() => undefined);
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    const raw = ctx.match?.[1];
+    if (!raw) return;
+    const groupId = parseInt(raw, 10);
+    if (isNaN(groupId)) return;
+
+    const db = getDb();
+    const group = findGroupById(db, groupId);
+    if (!group) {
+      await ctx.editMessageText('❌ הקבוצה לא נמצאה.').catch(() => undefined);
+      return;
+    }
+    const members = getMembersOfGroup(db, groupId);
+    if (!members.some((m) => m.userId === chatId)) {
+      await ctx.editMessageText('❌ אינך חבר בקבוצה זו.').catch(() => undefined);
+      return;
+    }
+
+    const isOwner = group.ownerId === chatId;
+    const lines = [
+      `📋 <b>${escapeHtml(group.name)}</b>`,
+      '',
+      `חברים: ${members.length}`,
+      `נוצרה: ${group.createdAt.split(' ')[0] ?? group.createdAt}`,
+    ];
+    if (isOwner) {
+      lines.push('', `קוד הזמנה: <code>${group.inviteCode}</code>`);
+    }
+
+    const kb = new InlineKeyboard().text('🚪 עזיבה', cb(`g:leaveY:${groupId}`));
+    await ctx
+      .editMessageText(lines.join('\n'), { parse_mode: 'HTML', reply_markup: kb })
+      .catch((err) => {
+        log('warn', 'Groups', `editMessageText (g:c) failed: ${String(err)}`);
+      });
+  });
+
+  // g:leaveY:<id> — confirm leave
+  bot.callbackQuery(/^g:leaveY:(\d+)$/, async (ctx) => {
+    await ctx.answerCallbackQuery().catch(() => undefined);
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    const raw = ctx.match?.[1];
+    if (!raw) return;
+    const groupId = parseInt(raw, 10);
+    if (isNaN(groupId)) return;
+
+    const db = getDb();
+    const group = findGroupById(db, groupId);
+    if (!group) return;
+    const members = getMembersOfGroup(db, groupId);
+    if (!members.some((m) => m.userId === chatId)) return;
+
+    await performLeave(ctx, groupId, chatId);
+  });
+}

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -433,6 +433,14 @@ async function handleStatus(ctx: Context, groupIdArg: string | undefined): Promi
   }
 
   // Membership check (auth invariant) — only members can view a group's status
+  // TODO(#213): consolidate this membership check pattern into a shared
+  // assertGroupMember(ctx, db, groupId, chatId) helper. The pattern is
+  // duplicated across 6 sites today (handleLeave, handleStatus, g:c, g:s,
+  // g:refresh, g:leaveY) and #213 will add a 7th. The helper should branch
+  // on ctx.callbackQuery for reply vs editMessageText. See PR #232 review
+  // item I1 for the proposed signature. Also kills the redundant
+  // getMembersOfGroup call (review I2): pass the resolved members list to
+  // getMemberStatusesForGroup so renderGroupStatus doesn't re-query.
   const members = getMembersOfGroup(db, groupId);
   if (!members.some((m) => m.userId === chatId)) {
     await ctx.reply('❌ אינך חבר בקבוצה זו.');
@@ -470,6 +478,23 @@ export async function renderGroupStatus(
   }
 
   const statuses = getMemberStatusesForGroup(db, groupId);
+
+  // Defensive — should not happen in practice because the last member
+  // leaving deletes the group via performLeave's auto-delete branch.
+  // But if it ever does, render a clean "empty" state instead of an
+  // ugly "0/0 בסדר" line.
+  if (statuses.length === 0) {
+    const emptyText =
+      `👥 <b>${escapeHtml(group.name)}</b>\n\n<i>הקבוצה ריקה.</i>`;
+    if (ctx.callbackQuery) {
+      await ctx
+        .editMessageText(emptyText, { parse_mode: 'HTML' })
+        .catch((e) => log('warn', 'Groups', `editMessageText (status empty) failed: ${formatError(e)}`));
+    } else {
+      await ctx.reply(emptyText, { parse_mode: 'HTML' });
+    }
+    return;
+  }
 
   let okCount = 0;
   const lines: string[] = [`👥 <b>${escapeHtml(group.name)}</b>`, ''];

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -44,22 +44,49 @@ export const MAX_MEMBERS_PER_GROUP_FALLBACK = 20;
  * with parsing + fallback so the call sites stay clean. Reads on every
  * call — appropriate for low-frequency user-triggered paths (/group create
  * and /group join). For per-alert hot paths, prefer cached patterns.
+ *
+ * PR #234 review #1 (3 reviewers converged): the dashboard validator
+ * `validatePositiveInt` rejects 0 at the PATCH boundary, but env vars
+ * and direct SQL writes bypass it. The `minimum` parameter enforces the
+ * floor at the runtime layer too — defense in depth. For cap keys, pass
+ * `minimum: 1` so a stray 0 falls back to the safe default instead of
+ * silently bricking the feature.
+ *
+ * PR #234 review #3: when raw is set but unparseable (e.g. an admin typo'd
+ * "five" into the dashboard, bypassing the validator via direct env var,
+ * or the row got corrupted), log a warn so the issue is visible. Without
+ * this, the bot would silently keep using the fallback forever with no
+ * trace in the logs that the override is being ignored.
  */
-function resolveIntConfig(key: string, fallback: number): number {
+function resolveIntConfig(key: string, fallback: number, minimum: number = 0): number {
   const raw = resolveConfig(getDb(), key);
   if (raw === null || raw === undefined) return fallback;
   const n = Number(raw);
-  return Number.isFinite(n) && Number.isInteger(n) && n >= 0 ? n : fallback;
+  if (Number.isFinite(n) && Number.isInteger(n) && n >= minimum) return n;
+  log(
+    'warn',
+    'Groups',
+    `invalid config value for "${key}": ${JSON.stringify(raw)} (minimum=${minimum}) — falling back to ${fallback}`,
+  );
+  return fallback;
 }
 
-/** Hot-configurable — reads `groups_max_per_user` from DB→env→fallback. */
+/**
+ * Hot-configurable — reads `groups_max_per_user` from DB→env→fallback.
+ * Minimum 1 enforced at the runtime layer (defense in depth — see
+ * resolveIntConfig docstring).
+ */
 function getMaxGroupsPerUser(): number {
-  return resolveIntConfig('groups_max_per_user', MAX_GROUPS_PER_USER_FALLBACK);
+  return resolveIntConfig('groups_max_per_user', MAX_GROUPS_PER_USER_FALLBACK, 1);
 }
 
-/** Hot-configurable — reads `groups_max_members` from DB→env→fallback. */
+/**
+ * Hot-configurable — reads `groups_max_members` from DB→env→fallback.
+ * Minimum 1 enforced at the runtime layer (defense in depth — see
+ * resolveIntConfig docstring).
+ */
 function getMaxMembersPerGroup(): number {
-  return resolveIntConfig('groups_max_members', MAX_MEMBERS_PER_GROUP_FALLBACK);
+  return resolveIntConfig('groups_max_members', MAX_MEMBERS_PER_GROUP_FALLBACK, 1);
 }
 
 const JOIN_COOLDOWN_MS = 5_000;

--- a/src/bot/safetyStatusHandler.ts
+++ b/src/bot/safetyStatusHandler.ts
@@ -9,6 +9,7 @@ import { createUserCooldown } from './userCooldown.js';
 import { formatRelativeTime, formatTimeUntil, escapeHtml } from '../textUtils.js';
 import { log } from '../logger.js';
 import { notifyContactsOfStatusChange } from '../services/safetyNotificationService.js';
+import { notifyGroupMembersOfStatusChange } from '../services/groupNotificationService.js';
 
 // Set before registering (called from index.ts after initDb).
 let _db: Database.Database | null = null;
@@ -194,6 +195,13 @@ export function registerSafetyStatusHandler(bot: Bot): void {
 
       await ctx.editMessageText(CONFIRMATION[status], { parse_mode: 'HTML' });
       await notifyContactsOfStatusChange(_db, bot, chatId, status);
+      // Fire-and-forget — group propagation must not block the user's UX or
+      // the contact-notification path. Errors are logged via the project
+      // logger; the shared dmQueue handles 429 retries internally. Mirrors
+      // the dispatchSafetyPrompts pattern in alertHandler.ts.
+      notifyGroupMembersOfStatusChange(_db, bot, chatId, status).catch((err) =>
+        log('error', 'GroupNotify', `propagate failed for ${chatId}: ${String(err)}`),
+      );
     } catch (err) {
       log('error', 'SafetyStatus', `כישלון בטיפול בסטטוס בטיחות: ${err}`);
     } finally {

--- a/src/config/configResolver.ts
+++ b/src/config/configResolver.ts
@@ -47,6 +47,10 @@ export const CONFIG_KEYS: ReadonlySet<string> = new Set([
   'all_clear_topic_id',
   'landing_url',
   'privacy_defaults',
+  // v0.5.1 — group feature hot-config (refs #225)
+  'groups_max_per_user',
+  'groups_max_members',
+  'groups_invite_code_ttl_hours',
 ]);
 
 /** Keys whose change requires a process restart to take effect. */

--- a/src/dashboard/router.ts
+++ b/src/dashboard/router.ts
@@ -11,6 +11,7 @@ import { createWhatsAppRouter } from './routes/whatsapp.js';
 import { createListenersRouter } from './routes/whatsappListeners.js';
 import { createTelegramListenerRouter } from './routes/telegramListeners.js';
 import { createSecretsRouter } from './routes/secrets.js';
+import { createGroupsRouter } from './routes/groups.js';
 import * as whatsappService from '../whatsapp/whatsappService.js';
 import { getEnabledGroupsForAlertType } from '../db/whatsappGroupRepository.js';
 
@@ -30,5 +31,6 @@ export function createApiRouter(db: Database.Database, bot: Bot): Router {
   router.use('/whatsapp', createWhatsAppRouter(db, whatsappService));
   router.use('/telegram', createTelegramListenerRouter(db, bot));
   router.use('/secrets', createSecretsRouter(db));
+  router.use('/groups', createGroupsRouter(db));
   return router;
 }

--- a/src/dashboard/routes/groups.ts
+++ b/src/dashboard/routes/groups.ts
@@ -1,0 +1,177 @@
+import { Router } from 'express';
+import type Database from 'better-sqlite3';
+import { log } from '../../logger.js';
+import {
+  listAllGroupsWithStats,
+  findGroupById,
+  getMembersOfGroup,
+  deleteGroup,
+} from '../../db/groupRepository.js';
+import { getUser } from '../../db/userRepository.js';
+import { createRateLimitMiddleware } from '../rateLimiter.js';
+
+/**
+ * Mutation endpoints (DELETE) are rate-limited per IP — admin moderation
+ * actions should be deliberate. 5 deletes per minute is generous for normal
+ * use and tight enough to prevent runaway scripts.
+ *
+ * Exported so tests can call `.clearStore()` between cases — same pattern
+ * as the other dashboard route limiters. Per memory:
+ * pattern_rate_limiter_test_isolation.md.
+ */
+export const groupMutateLimiter = createRateLimitMiddleware({
+  maxRequests: 5,
+  windowMs: 60_000,
+  message: 'יותר מדי פעולות מחיקה — נסה שוב בעוד דקה',
+});
+
+export function createGroupsRouter(db: Database.Database): Router {
+  const router = Router();
+
+  /**
+   * GET /api/groups
+   * Lists every group in the system with member count, owner display name,
+   * and creation timestamp. Used by the dashboard Groups page table.
+   */
+  router.get('/', (_req, res) => {
+    try {
+      const rows = listAllGroupsWithStats(db);
+      // Enrich each row with the owner's display name (single getUser call
+      // per group — bounded by the total number of groups in the system,
+      // which is small for the foreseeable future).
+      const groups = rows.map((g) => {
+        const owner = getUser(g.ownerId);
+        return {
+          id: g.id,
+          name: g.name,
+          inviteCode: g.inviteCode,
+          ownerId: g.ownerId,
+          ownerDisplayName: owner?.display_name ?? null,
+          createdAt: g.createdAt,
+          memberCount: g.memberCount,
+        };
+      });
+      res.json({ ok: true, groups });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `list failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to list groups' });
+    }
+  });
+
+  /**
+   * GET /api/groups/stats
+   * Aggregate statistics for the dashboard KPI cards: total groups, average
+   * members per group, and the top-10 most-populated groups.
+   *
+   * Must come BEFORE /:id so the static segment doesn't get matched as an id.
+   */
+  router.get('/stats', (_req, res) => {
+    try {
+      const rows = listAllGroupsWithStats(db);
+      const total = rows.length;
+      const avgMembers =
+        total === 0 ? 0 : rows.reduce((s, g) => s + g.memberCount, 0) / total;
+      const top10 = [...rows]
+        .sort((a, b) => b.memberCount - a.memberCount)
+        .slice(0, 10)
+        .map((g) => ({ id: g.id, name: g.name, memberCount: g.memberCount }));
+
+      res.json({
+        ok: true,
+        total,
+        avgMembers: Number(avgMembers.toFixed(2)),
+        top10,
+      });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `stats failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to compute stats' });
+    }
+  });
+
+  /**
+   * GET /api/groups/:id
+   * Drill-down detail for a single group: full member list with display
+   * names + roles + joined_at + notify_group flag. Used by the dashboard
+   * Groups drawer when clicking a row.
+   */
+  router.get('/:id', (req, res) => {
+    try {
+      const idParam = req.params['id'];
+      const id = Number(idParam);
+      if (!Number.isInteger(id) || id <= 0) {
+        res.status(400).json({ ok: false, error: 'Invalid group id' });
+        return;
+      }
+
+      const group = findGroupById(db, id);
+      if (!group) {
+        res.status(404).json({ ok: false, error: 'Group not found' });
+        return;
+      }
+
+      const members = getMembersOfGroup(db, id).map((m) => {
+        const user = getUser(m.userId);
+        return {
+          userId: m.userId,
+          role: m.role,
+          joinedAt: m.joinedAt,
+          notifyGroup: m.notifyGroup,
+          displayName: user?.display_name ?? null,
+          homeCity: user?.home_city ?? null,
+        };
+      });
+
+      res.json({
+        ok: true,
+        group: {
+          id: group.id,
+          name: group.name,
+          inviteCode: group.inviteCode,
+          ownerId: group.ownerId,
+          createdAt: group.createdAt,
+        },
+        members,
+      });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `get failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to fetch group' });
+    }
+  });
+
+  /**
+   * DELETE /api/groups/:id
+   * Admin moderation — deletes a group and CASCADE removes all member rows.
+   * Rate-limited via groupMutateLimiter (5 per minute per IP).
+   * Logs at WARN level to make moderation actions visible in the operations
+   * log.
+   */
+  router.delete('/:id', groupMutateLimiter, (req, res) => {
+    try {
+      const idParam = req.params['id'];
+      const id = Number(idParam);
+      if (!Number.isInteger(id) || id <= 0) {
+        res.status(400).json({ ok: false, error: 'Invalid group id' });
+        return;
+      }
+
+      const group = findGroupById(db, id);
+      if (!group) {
+        res.status(404).json({ ok: false, error: 'Group not found' });
+        return;
+      }
+
+      deleteGroup(db, id);
+      log(
+        'warn',
+        'Dashboard/Groups',
+        `admin deleted group ${id} (${group.name}, owner=${group.ownerId})`,
+      );
+      res.json({ ok: true });
+    } catch (err) {
+      log('error', 'Dashboard/Groups', `delete failed: ${String(err)}`);
+      res.status(500).json({ ok: false, error: 'Failed to delete group' });
+    }
+  });
+
+  return router;
+}

--- a/src/dashboard/routes/groups.ts
+++ b/src/dashboard/routes/groups.ts
@@ -32,25 +32,23 @@ export function createGroupsRouter(db: Database.Database): Router {
    * GET /api/groups
    * Lists every group in the system with member count, owner display name,
    * and creation timestamp. Used by the dashboard Groups page table.
+   *
+   * PR #234 review #2: previously this called `getUser(g.ownerId)` per row
+   * (N+1). The owner display name now comes from the LEFT JOIN inside
+   * `listAllGroupsWithStats` itself — single SQL query regardless of row count.
    */
   router.get('/', (_req, res) => {
     try {
       const rows = listAllGroupsWithStats(db);
-      // Enrich each row with the owner's display name (single getUser call
-      // per group — bounded by the total number of groups in the system,
-      // which is small for the foreseeable future).
-      const groups = rows.map((g) => {
-        const owner = getUser(g.ownerId);
-        return {
-          id: g.id,
-          name: g.name,
-          inviteCode: g.inviteCode,
-          ownerId: g.ownerId,
-          ownerDisplayName: owner?.display_name ?? null,
-          createdAt: g.createdAt,
-          memberCount: g.memberCount,
-        };
-      });
+      const groups = rows.map((g) => ({
+        id: g.id,
+        name: g.name,
+        inviteCode: g.inviteCode,
+        ownerId: g.ownerId,
+        ownerDisplayName: g.ownerDisplayName,
+        createdAt: g.createdAt,
+        memberCount: g.memberCount,
+      }));
       res.json({ ok: true, groups });
     } catch (err) {
       log('error', 'Dashboard/Groups', `list failed: ${String(err)}`);

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -60,6 +60,22 @@ function validateNonNegativeInt(value: string): string | null {
   return null;
 }
 
+/**
+ * Strict positive integer validator (n ≥ 1). Use for caps where 0 would
+ * silently disable the feature instead of expressing "no limit". For example:
+ * `groups_max_per_user = 0` would make `countGroupsOwnedBy(...) >= 0` always
+ * true, blocking every group creation with no error visible to the admin
+ * who set the value via the dashboard. Three reviewer agents independently
+ * flagged this on PR #234.
+ */
+function validatePositiveInt(value: string): string | null {
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
+    return `הערך חייב להיות מספר שלם חיובי (≥1), התקבל: ${value}`;
+  }
+  return null;
+}
+
 function validateBoolish(value: string): string | null {
   return value === 'true' || value === 'false'
     ? null
@@ -88,8 +104,12 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   whatsapp_enabled:              validateBoolish,
   privacy_defaults:              validateJson,
   // v0.5.1 — group feature hot-config (refs #225)
-  groups_max_per_user:           validateNonNegativeInt,
-  groups_max_members:            validateNonNegativeInt,
+  // PR #234 review: caps must be ≥1 because 0 would brick the feature
+  // (countGroupsOwnedBy(...) >= 0 is always true → every create rejected).
+  // groups_invite_code_ttl_hours stays non-negative because 0 plausibly
+  // means "never expire" (semantics to be defined when v0.5.2 enforces TTL).
+  groups_max_per_user:           validatePositiveInt,
+  groups_max_members:            validatePositiveInt,
   groups_invite_code_ttl_hours:  validateNonNegativeInt,
 };
 

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -35,6 +35,10 @@ const ALLOWED_KEYS = new Set([
   'dm_relevance_in_area',
   'dm_relevance_nearby',
   'dm_relevance_not_area',
+  // v0.5.1 — group feature hot-config (refs #225)
+  'groups_max_per_user',
+  'groups_max_members',
+  'groups_invite_code_ttl_hours',
 ]);
 
 // ─── Per-key value validators ─────────────────────────────────────────────
@@ -83,6 +87,10 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   quiet_hours_global:            validateBoolish,
   whatsapp_enabled:              validateBoolish,
   privacy_defaults:              validateJson,
+  // v0.5.1 — group feature hot-config (refs #225)
+  groups_max_per_user:           validateNonNegativeInt,
+  groups_max_members:            validateNonNegativeInt,
+  groups_invite_code_ttl_hours:  validateNonNegativeInt,
 };
 
 export function createSettingsRouter(db: Database.Database): Router {

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -1,5 +1,7 @@
 import type Database from 'better-sqlite3';
 import { log } from '../logger.js';
+import { getActiveStatusesForContacts } from './safetyStatusRepository.js';
+import type { SafetyStatusRow } from './safetyStatusRepository.js';
 
 // ─── Public types ────────────────────────────────────────────────────────────
 
@@ -246,5 +248,36 @@ export function listAllGroupsWithStats(
   return rows.map((r) => ({ ...decodeGroup(r), memberCount: r.member_count }));
 }
 
-// NOTE: `getMemberStatusesForGroup` (joining members with safetyStatusRepository)
-// will be added in Task 2 (#212) to keep this PR tight around #211.
+/**
+ * Aggregates each group member's current active safety_status row, or `null`
+ * if the member has no active status (never reported, or status expired past
+ * the 24h TTL). Used by the `/group status` command and the `g:s:<id>` /
+ * `g:refresh:<id>` callbacks added in #212.
+ *
+ * IMPORTANT: `getActiveStatusesForContacts` returns `SafetyStatusRow[]` (a
+ * plain array, NOT a Map). Verified: safetyStatusRepository.ts:62. The
+ * lookup Map is built locally so each member lookup is O(1).
+ *
+ * Member iteration order matches `getMembersOfGroup` (joined_at ASC), which
+ * gives a stable display order — the rendered card doesn't shuffle on refresh.
+ */
+export function getMemberStatusesForGroup(
+  db: Database.Database,
+  groupId: number,
+): Array<{ userId: number; status: SafetyStatusRow | null }> {
+  const members = getMembersOfGroup(db, groupId);
+  if (members.length === 0) return [];
+
+  const memberIds = members.map((m) => m.userId);
+  const statusRows = getActiveStatusesForContacts(db, memberIds);
+
+  // Build O(1) lookup keyed on chat_id (snake_case at the boundary —
+  // see SafetyStatusRow definition in safetyStatusRepository.ts:3-8).
+  const statusMap = new Map<number, SafetyStatusRow>();
+  for (const row of statusRows) statusMap.set(row.chat_id, row);
+
+  return members.map((m) => ({
+    userId: m.userId,
+    status: statusMap.get(m.userId) ?? null,
+  }));
+}

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -231,21 +231,37 @@ export function countMembersOfGroup(
 }
 
 /**
- * Dashboard listing helper — joins group with its member count in a single query.
- * Used by `src/dashboard/routes/groups.ts` in Task 4.
+ * Dashboard listing helper — joins group with its member count AND owner's
+ * display_name in a single query. Used by `src/dashboard/routes/groups.ts`.
+ *
+ * PR #234 review #2: previously this returned only the group + memberCount
+ * and the route called `getUser(g.ownerId)` once per row to enrich the owner
+ * display name — a classic N+1. At thousands of groups the dashboard would
+ * stall. The LEFT JOIN to `users` makes the entire enrichment a single query.
+ *
+ * LEFT JOIN (not INNER JOIN) defends against soft-corruption: if a group's
+ * owner row was deleted without CASCADE (shouldn't happen — FK enforces it,
+ * but defense in depth), we still return the group with `ownerDisplayName: null`
+ * instead of dropping the row from the result.
  */
 export function listAllGroupsWithStats(
   db: Database.Database
-): Array<Group & { memberCount: number }> {
+): Array<Group & { memberCount: number; ownerDisplayName: string | null }> {
   const rows = db
     .prepare(
       `SELECT g.*,
-              (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id) AS member_count
+              (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id) AS member_count,
+              u.display_name AS owner_display_name
        FROM groups g
+       LEFT JOIN users u ON u.chat_id = g.owner_id
        ORDER BY g.created_at DESC`
     )
-    .all() as Array<RawGroup & { member_count: number }>;
-  return rows.map((r) => ({ ...decodeGroup(r), memberCount: r.member_count }));
+    .all() as Array<RawGroup & { member_count: number; owner_display_name: string | null }>;
+  return rows.map((r) => ({
+    ...decodeGroup(r),
+    memberCount: r.member_count,
+    ownerDisplayName: r.owner_display_name,
+  }));
 }
 
 /**

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -48,10 +48,23 @@ function decodeGroup(raw: RawGroup): Group {
 }
 
 function decodeMember(raw: RawMember): GroupMember {
+  // Hardened role decode — refuses to lie about an invalid union value.
+  // SQLite has a CHECK constraint, so 'owner'|'member' is the only legal
+  // value at write-time, but a corrupted/migrated DB row could still slip
+  // through. Default to 'member' (least-privileged) and log a warn rather
+  // than producing an unsafe `as` cast.
+  let role: 'owner' | 'member';
+  if (raw.role === 'owner' || raw.role === 'member') {
+    role = raw.role;
+  } else {
+    log('warn', 'GroupRepo', `unexpected role value for group_id=${raw.group_id} user_id=${raw.user_id}: ${JSON.stringify(raw.role)} — defaulting to 'member'`);
+    role = 'member';
+  }
+
   return {
     groupId: raw.group_id,
     userId: raw.user_id,
-    role: raw.role as 'owner' | 'member',
+    role,
     joinedAt: raw.joined_at,
     notifyGroup: raw.notify_group === 1, // strict INTEGER→boolean
   };
@@ -60,26 +73,57 @@ function decodeMember(raw: RawMember): GroupMember {
 // ─── Writes ──────────────────────────────────────────────────────────────────
 
 /**
+ * Sentinel error thrown when the invite_code UNIQUE constraint fires.
+ * Callers (groupHandler.handleCreate) catch this to retry with a fresh code.
+ *
+ * The pre-check in `generateInviteCode` is best-effort and is not safe under
+ * concurrent inserts — this sentinel makes the race recoverable.
+ */
+export class InviteCodeCollisionError extends Error {
+  constructor(code: string) {
+    super(`Invite code collision: ${code}`);
+    this.name = 'InviteCodeCollisionError';
+  }
+}
+
+/**
  * Creates a new group and inserts the owner as a member in a single transaction.
  * Rolls back atomically if either insert fails (e.g. invalid ownerId FK).
+ *
+ * Throws `InviteCodeCollisionError` if `invite_code` UNIQUE constraint fires
+ * (e.g. concurrent insert raced past the pre-check). Other errors propagate.
  */
 export function createGroup(
   db: Database.Database,
   input: { name: string; ownerId: number; inviteCode: string }
 ): Group {
-  return db.transaction(() => {
-    const raw = db
-      .prepare(
-        'INSERT INTO groups (name, invite_code, owner_id) VALUES (?, ?, ?) RETURNING *'
-      )
-      .get(input.name, input.inviteCode, input.ownerId) as RawGroup;
+  try {
+    return db.transaction(() => {
+      const raw = db
+        .prepare(
+          'INSERT INTO groups (name, invite_code, owner_id) VALUES (?, ?, ?) RETURNING *'
+        )
+        .get(input.name, input.inviteCode, input.ownerId) as RawGroup;
 
-    db.prepare(
-      "INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'owner')"
-    ).run(raw.id, input.ownerId);
+      db.prepare(
+        "INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'owner')"
+      ).run(raw.id, input.ownerId);
 
-    return decodeGroup(raw);
-  })();
+      return decodeGroup(raw);
+    })();
+  } catch (err: unknown) {
+    // better-sqlite3 throws SqliteError with `.code` property — narrow to the
+    // UNIQUE-constraint case so handlers can retry. Other errors propagate.
+    if (
+      err instanceof Error &&
+      'code' in err &&
+      (err as { code?: string }).code === 'SQLITE_CONSTRAINT_UNIQUE' &&
+      err.message.includes('groups.invite_code')
+    ) {
+      throw new InviteCodeCollisionError(input.inviteCode);
+    }
+    throw err;
+  }
 }
 
 /**

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -1,0 +1,206 @@
+import type Database from 'better-sqlite3';
+import { log } from '../logger.js';
+
+// ─── Public types ────────────────────────────────────────────────────────────
+
+export interface Group {
+  id: number;
+  name: string;
+  inviteCode: string;
+  ownerId: number;
+  createdAt: string;
+}
+
+export interface GroupMember {
+  groupId: number;
+  userId: number;
+  role: 'owner' | 'member';
+  joinedAt: string;
+  notifyGroup: boolean;
+}
+
+// ─── Internal raw rows (match SQLite column names exactly) ───────────────────
+
+interface RawGroup {
+  id: number;
+  name: string;
+  invite_code: string;
+  owner_id: number;
+  created_at: string;
+}
+
+interface RawMember {
+  group_id: number;
+  user_id: number;
+  role: string;
+  joined_at: string;
+  notify_group: number; // SQLite INTEGER (0|1) — decoded to boolean at boundary
+}
+
+function decodeGroup(raw: RawGroup): Group {
+  return {
+    id: raw.id,
+    name: raw.name,
+    inviteCode: raw.invite_code,
+    ownerId: raw.owner_id,
+    createdAt: raw.created_at,
+  };
+}
+
+function decodeMember(raw: RawMember): GroupMember {
+  return {
+    groupId: raw.group_id,
+    userId: raw.user_id,
+    role: raw.role as 'owner' | 'member',
+    joinedAt: raw.joined_at,
+    notifyGroup: raw.notify_group === 1, // strict INTEGER→boolean
+  };
+}
+
+// ─── Writes ──────────────────────────────────────────────────────────────────
+
+/**
+ * Creates a new group and inserts the owner as a member in a single transaction.
+ * Rolls back atomically if either insert fails (e.g. invalid ownerId FK).
+ */
+export function createGroup(
+  db: Database.Database,
+  input: { name: string; ownerId: number; inviteCode: string }
+): Group {
+  return db.transaction(() => {
+    const raw = db
+      .prepare(
+        'INSERT INTO groups (name, invite_code, owner_id) VALUES (?, ?, ?) RETURNING *'
+      )
+      .get(input.name, input.inviteCode, input.ownerId) as RawGroup;
+
+    db.prepare(
+      "INSERT INTO group_members (group_id, user_id, role) VALUES (?, ?, 'owner')"
+    ).run(raw.id, input.ownerId);
+
+    return decodeGroup(raw);
+  })();
+}
+
+/**
+ * Idempotent — uses INSERT OR IGNORE on the (group_id, user_id) composite PK.
+ * Logs a warn when the user was already a member, but does not throw.
+ */
+export function addMember(
+  db: Database.Database,
+  groupId: number,
+  userId: number
+): void {
+  const result = db
+    .prepare(
+      "INSERT OR IGNORE INTO group_members (group_id, user_id, role) VALUES (?, ?, 'member')"
+    )
+    .run(groupId, userId);
+  if (result.changes === 0) {
+    log('warn', 'GroupRepo', `addMember: user ${userId} already in group ${groupId}`);
+  }
+}
+
+export function removeMember(
+  db: Database.Database,
+  groupId: number,
+  userId: number
+): void {
+  db.prepare(
+    'DELETE FROM group_members WHERE group_id = ? AND user_id = ?'
+  ).run(groupId, userId);
+}
+
+/**
+ * Deletes the group row; `group_members` rows are removed by the CASCADE FK.
+ */
+export function deleteGroup(db: Database.Database, groupId: number): void {
+  db.prepare('DELETE FROM groups WHERE id = ?').run(groupId);
+}
+
+// ─── Reads ───────────────────────────────────────────────────────────────────
+
+export function findGroupByInviteCode(
+  db: Database.Database,
+  code: string
+): Group | undefined {
+  const raw = db
+    .prepare('SELECT * FROM groups WHERE invite_code = ?')
+    .get(code) as RawGroup | undefined;
+  return raw ? decodeGroup(raw) : undefined;
+}
+
+export function findGroupById(
+  db: Database.Database,
+  id: number
+): Group | undefined {
+  const raw = db.prepare('SELECT * FROM groups WHERE id = ?').get(id) as
+    | RawGroup
+    | undefined;
+  return raw ? decodeGroup(raw) : undefined;
+}
+
+export function getGroupsForUser(db: Database.Database, userId: number): Group[] {
+  const rows = db
+    .prepare(
+      `SELECT g.* FROM groups g
+       INNER JOIN group_members gm ON gm.group_id = g.id
+       WHERE gm.user_id = ?
+       ORDER BY g.created_at DESC`
+    )
+    .all(userId) as RawGroup[];
+  return rows.map(decodeGroup);
+}
+
+export function getMembersOfGroup(
+  db: Database.Database,
+  groupId: number
+): GroupMember[] {
+  const rows = db
+    .prepare(
+      'SELECT * FROM group_members WHERE group_id = ? ORDER BY joined_at ASC'
+    )
+    .all(groupId) as RawMember[];
+  return rows.map(decodeMember);
+}
+
+export function countGroupsOwnedBy(
+  db: Database.Database,
+  ownerId: number
+): number {
+  const row = db
+    .prepare('SELECT COUNT(*) as c FROM groups WHERE owner_id = ?')
+    .get(ownerId) as { c: number };
+  return row.c;
+}
+
+export function countMembersOfGroup(
+  db: Database.Database,
+  groupId: number
+): number {
+  const row = db
+    .prepare('SELECT COUNT(*) as c FROM group_members WHERE group_id = ?')
+    .get(groupId) as { c: number };
+  return row.c;
+}
+
+/**
+ * Dashboard listing helper — joins group with its member count in a single query.
+ * Used by `src/dashboard/routes/groups.ts` in Task 4.
+ */
+export function listAllGroupsWithStats(
+  db: Database.Database
+): Array<Group & { memberCount: number }> {
+  const rows = db
+    .prepare(
+      `SELECT g.*,
+              (SELECT COUNT(*) FROM group_members gm WHERE gm.group_id = g.id) AS member_count
+       FROM groups g
+       ORDER BY g.created_at DESC`
+    )
+    .all() as Array<RawGroup & { member_count: number }>;
+  return rows.map((r) => ({ ...decodeGroup(r), memberCount: r.member_count }));
+}
+
+// NOTE: `getMemberStatusesForGroup` (joining members with safetyStatusRepository)
+// will be added in Task 2 (#212) to keep this PR tight around #211.

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -184,6 +184,30 @@ export function initSchema(database: Database.Database): void {
       FOREIGN KEY (contact_id) REFERENCES contacts(id) ON DELETE CASCADE
     );
 
+    -- v0.5.1 — resilience groups (family/friends/work cells)
+    CREATE TABLE IF NOT EXISTS groups (
+      id           INTEGER PRIMARY KEY AUTOINCREMENT,
+      name         TEXT NOT NULL,
+      invite_code  TEXT NOT NULL UNIQUE,
+      owner_id     INTEGER NOT NULL,
+      created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+      FOREIGN KEY (owner_id) REFERENCES users(chat_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_groups_invite_code ON groups(invite_code);
+    CREATE INDEX IF NOT EXISTS idx_groups_owner ON groups(owner_id);
+
+    CREATE TABLE IF NOT EXISTS group_members (
+      group_id     INTEGER NOT NULL,
+      user_id      INTEGER NOT NULL,
+      role         TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('owner', 'member')),
+      joined_at    TEXT NOT NULL DEFAULT (datetime('now')),
+      notify_group INTEGER NOT NULL DEFAULT 1,
+      PRIMARY KEY (group_id, user_id),
+      FOREIGN KEY (group_id) REFERENCES groups(id) ON DELETE CASCADE,
+      FOREIGN KEY (user_id)  REFERENCES users(chat_id) ON DELETE CASCADE
+    );
+    CREATE INDEX IF NOT EXISTS idx_group_members_user ON group_members(user_id);
+
     CREATE TABLE IF NOT EXISTS safety_status (
       chat_id     INTEGER PRIMARY KEY,
       status      TEXT CHECK (status IN ('ok', 'help', 'dismissed')) NOT NULL,

--- a/src/services/groupNotificationService.ts
+++ b/src/services/groupNotificationService.ts
@@ -1,0 +1,101 @@
+import type { Bot } from 'grammy';
+import type Database from 'better-sqlite3';
+import { getGroupsForUser, getMembersOfGroup } from '../db/groupRepository.js';
+import { getUser } from '../db/userRepository.js';
+import type { User } from '../db/userRepository.js';
+import { dmQueue } from './dmQueue.js';
+import { escapeHtml } from '../textUtils.js';
+import { log } from '../logger.js';
+
+/**
+ * Dependencies for `notifyGroupMembersOfStatusChange`. The `getUser` seam is
+ * MANDATORY for tests using `:memory:` databases — the production `getUser()`
+ * reads from the `getDb()` singleton, which is a different instance from a
+ * test-owned `new Database(':memory:')`. Without injection, tests would
+ * silently get `undefined` display names. Pattern documented in memory:
+ * `pattern_getuser_singleton_vs_di.md`.
+ */
+export interface GroupNotificationDeps {
+  enqueueAll?: (tasks: Array<{ chatId: string; text: string }>) => void;
+  getUser?: (chatId: number) => Pick<User, 'display_name'> | undefined;
+}
+
+/**
+ * Notify all members of every group the sender belongs to — except the sender
+ * themselves — that their safety status just changed. Mirrors
+ * `safetyNotificationService.notifyContactsOfStatusChange` in shape and
+ * intent, but operates over groups instead of contacts.
+ *
+ * Behaviour:
+ * - Skips entirely when `status === 'dismissed'` (the user explicitly chose
+ *   not to broadcast)
+ * - Skips when sender belongs to no groups
+ * - Iterates every group the sender is a member of (via `getGroupsForUser`)
+ *   and collects every other member who has not opted out via
+ *   `notify_group = 0`
+ * - **Dedupes** recipients across overlapping groups — a user who shares
+ *   two groups with the sender gets one DM, not two
+ * - Each task carries the group name where the recipient first appeared
+ *   (iteration order is `getGroupsForUser` ORDER BY created_at DESC)
+ * - HTML-escapes both display name and group name to prevent injection
+ *   when tasks reach Telegram's HTML parse mode
+ *
+ * Reuses the **bot-wide** `dmQueue` singleton — never instantiate a second
+ * queue. The queue handles 429 backoff bot-globally and creating a parallel
+ * queue would break that pause semantics.
+ *
+ * `_bot` is accepted for API symmetry with `notifyContactsOfStatusChange`
+ * — `dmQueue` already holds a reference to the bot internally.
+ *
+ * Hooked into `safetyStatusHandler.ts` immediately after the existing
+ * `notifyContactsOfStatusChange` call (~line 197). Fire-and-forget pattern
+ * mirrors `dispatchSafetyPrompts` in `alertHandler.ts`.
+ */
+export async function notifyGroupMembersOfStatusChange(
+  db: Database.Database,
+  _bot: Bot,
+  fromChatId: number,
+  status: 'ok' | 'help' | 'dismissed',
+  deps: GroupNotificationDeps = {},
+): Promise<void> {
+  if (status === 'dismissed') return;
+
+  const groups = getGroupsForUser(db, fromChatId);
+  if (groups.length === 0) return;
+
+  const lookupUser = deps.getUser ?? getUser;
+  const sender = lookupUser(fromChatId);
+  const displayName = escapeHtml(sender?.display_name ?? `משתמש #${fromChatId}`);
+
+  // Dedupe recipients across overlapping groups. Map key is recipient chatId,
+  // value is the group name where they were first seen — that's what gets
+  // shown in the DM ("👥 [groupName] ..."). The first-seen iteration order
+  // matches `getGroupsForUser` (ORDER BY created_at DESC), giving newest
+  // groups priority.
+  const recipients = new Map<number, string>();
+  for (const group of groups) {
+    const members = getMembersOfGroup(db, group.id);
+    for (const m of members) {
+      if (m.userId === fromChatId) continue;
+      if (!m.notifyGroup) continue;
+      if (!recipients.has(m.userId)) {
+        recipients.set(m.userId, group.name);
+      }
+    }
+  }
+  if (recipients.size === 0) return;
+
+  const tasks: Array<{ chatId: string; text: string }> = [];
+  for (const [userId, groupName] of recipients) {
+    const escapedGroup = escapeHtml(groupName);
+    const text =
+      status === 'ok'
+        ? `👥 <b>[${escapedGroup}]</b> ${displayName} דיווח/ה: ✅ בסדר`
+        : `👥 <b>[${escapedGroup}]</b> ⚠️ ${displayName} מדווח/ת: זקוק/ה לעזרה\n\nשקול/י ליצור קשר ישירות.`;
+    tasks.push({ chatId: String(userId), text });
+  }
+
+  log('info', 'GroupNotify', `${fromChatId} → ${tasks.length} recipients (${status})`);
+  const enqueueAll = deps.enqueueAll ?? ((t) => dmQueue.enqueueAll(t));
+  enqueueAll(tasks);
+}


### PR DESCRIPTION
## Summary

Each push to a PR branch was triggering **TWO** Type-check & Test runs because the workflow listened to both \`push\` and \`pull_request\` events. The \`pull_request: synchronize\` event fires for every push to a PR branch, duplicating the \`push\` event against the same SHA. Both ran the same jobs, both burned ~2m17s of runner time, both wasted compute.

## The fix

One-line addition: filter \`pull_request\` to only \`[opened, reopened]\` types.

\`\`\`yaml
on:
  push:
    branches: ['**']
  pull_request:
    types: [opened, reopened]   # ← was: no types filter (== all types)
    branches: ['**']
\`\`\`

## Behaviour matrix

| Action | Before | After |
|---|---|---|
| Push to any branch (no PR) | 1 run | 1 run |
| **Push to PR branch** | **2 runs** | **1 run** ✅ |
| Open PR on already-pushed branch | 1 run (\`pull_request:opened\`) | 1 run (unchanged) |
| Reopen closed PR | 1 run (\`pull_request:reopened\`) | 1 run (unchanged) |

## Evidence of the duplication

Today on PR #234 (v0.5.1 dashboard groups), two completed runs against the same commit:
- Run 24216126273 — \`event: pull_request\` — 2m17s
- Run 24216078660 — \`event: push\` — 2m15s

Both green, both running identical \`Type-check & Test\` + \`dashboard-build\` + \`Docker Build Validation\` + \`CI Gate\` jobs. Pure waste.

This pattern was visible across all four v0.5.1 PRs (#230, #232, #233, #234) — every push doubled the runner cost.

## Why not use concurrency to dedupe instead?

The current \`concurrency: group: ci-\${{ github.ref }}\` uses different group names for the two events (\`refs/heads/branch\` vs \`refs/pull/N/merge\`), so \`cancel-in-progress: true\` doesn't help. Unifying them would require \`github.event.pull_request.head.ref\` — flagged by the security hook as untrusted input, and risky because branch names can theoretically contain shell metacharacters that interpolate into env vars.

The types filter is simpler, safer, and addresses the root cause (one event source for one commit).

## Test plan

- [x] Workflow YAML diff is 5 lines added (4 comment + 1 type filter), 0 deletions
- [x] No change to \`concurrency\` block (avoids untrusted input)
- [x] Branched off main directly — does NOT touch v0.5.1 stack
- [ ] Verify after merge: next push to any v0.5.1 PR branch produces exactly 1 run, not 2