### PR TITLE
feat(settings): social preferences toggles (#218)

### DIFF
--- a/src/__tests__/safetyPromptService.test.ts
+++ b/src/__tests__/safetyPromptService.test.ts
@@ -24,6 +24,11 @@ function makeUser(overrides: Partial<User> = {}): User {
     connection_code: null,
     onboarding_step: null,
     is_dm_active: true,
+    social_prompt_enabled: true,
+    social_banner_enabled: true,
+    social_contact_count_enabled: true,
+    social_group_alerts_enabled: true,
+    social_quick_ok_enabled: true,
     created_at: new Date().toISOString(),
     ...overrides,
   };

--- a/src/__tests__/userRepository.test.ts
+++ b/src/__tests__/userRepository.test.ts
@@ -23,6 +23,7 @@ import {
   setQuietHours,
   setMutedUntil,
   deleteUser,
+  setSocialPref,
 } from '../db/userRepository';
 
 describe('userRepository — v0.4.1 profile fields', () => {
@@ -343,5 +344,54 @@ describe('getUsersWithHomeCity', () => {
   it('returns empty array when no users have home_city set', () => {
     db.prepare('INSERT INTO users (chat_id) VALUES (1001)').run();
     assert.equal(getUsersWithHomeCity(db).length, 0);
+  });
+});
+
+describe('social preferences (v0.5.2)', () => {
+  before(() => { initDb(); });
+  after(() => { closeDb(); });
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM subscriptions').run();
+    getDb().prepare('DELETE FROM users').run();
+  });
+
+  it('new user has all social prefs enabled by default', () => {
+    upsertUser(9001);
+    const user = getUser(9001);
+    assert.equal(user?.social_prompt_enabled, true);
+    assert.equal(user?.social_banner_enabled, true);
+    assert.equal(user?.social_contact_count_enabled, true);
+    assert.equal(user?.social_group_alerts_enabled, true);
+    assert.equal(user?.social_quick_ok_enabled, true);
+  });
+
+  it('setSocialPref toggles a field off and on', () => {
+    upsertUser(9002);
+    setSocialPref(9002, 'social_prompt_enabled', false);
+    assert.equal(getUser(9002)?.social_prompt_enabled, false);
+
+    setSocialPref(9002, 'social_prompt_enabled', true);
+    assert.equal(getUser(9002)?.social_prompt_enabled, true);
+  });
+
+  it('setSocialPref works for each field independently', () => {
+    upsertUser(9003);
+    setSocialPref(9003, 'social_banner_enabled', false);
+    setSocialPref(9003, 'social_quick_ok_enabled', false);
+
+    const user = getUser(9003)!;
+    assert.equal(user.social_banner_enabled, false);
+    assert.equal(user.social_quick_ok_enabled, false);
+    assert.equal(user.social_prompt_enabled, true);
+    assert.equal(user.social_contact_count_enabled, true);
+    assert.equal(user.social_group_alerts_enabled, true);
+  });
+
+  it('setSocialPref throws on invalid field', () => {
+    upsertUser(9004);
+    assert.throws(
+      () => setSocialPref(9004, 'bad_field' as any, false),
+      /Invalid social pref/
+    );
   });
 });

--- a/src/bot/settingsHandler.ts
+++ b/src/bot/settingsHandler.ts
@@ -1,6 +1,10 @@
 import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
-import { getUser, setQuietHours, setMutedUntil, isMuted, upsertUser } from '../db/userRepository.js';
+import {
+  getUser, setQuietHours, setMutedUntil, isMuted, upsertUser,
+  setSocialPref, VALID_SOCIAL_FIELDS,
+  type SocialPrefField,
+} from '../db/userRepository.js';
 import {
   removeSubscription,
   removeAllSubscriptions,
@@ -37,6 +41,8 @@ export function buildSettingsMenu(chatId: number): { text: string; keyboard: Inl
   keyboard
     .text('🔕 בטל כל המנויים', 'settings:clearall')
     .row()
+    .text('👥 הגדרות חברתיות', 'social:settings')
+    .row()
     .text('↩️ חזור', 'menu:main');
 
   const muteNote = muted && user?.muted_until
@@ -49,6 +55,32 @@ export function buildSettingsMenu(chatId: number): { text: string; keyboard: Inl
     muteNote;
 
   return { text, keyboard };
+}
+
+const SOCIAL_TOGGLE_LABELS: ReadonlyArray<{ label: string; field: SocialPrefField }> = [
+  { label: '📢 שאלת "הכל בסדר" אחרי אזעקה', field: 'social_prompt_enabled' },
+  { label: '⚠️ באנר תזכורת ב/start', field: 'social_banner_enabled' },
+  { label: '👥 מספר אנשי קשר בהתראה', field: 'social_contact_count_enabled' },
+  { label: '🏘️ התראות קבוצתיות', field: 'social_group_alerts_enabled' },
+  { label: '✅ כפתור "הכל בסדר" מהיר', field: 'social_quick_ok_enabled' },
+];
+
+export function buildSocialSettingsMenu(chatId: number): { text: string; keyboard: InlineKeyboard } {
+  const user = getUser(chatId);
+  const keyboard = new InlineKeyboard();
+
+  for (const { label, field } of SOCIAL_TOGGLE_LABELS) {
+    const enabled = user?.[field] ?? true;
+    const status = enabled ? '✓' : '✗';
+    keyboard.text(`${label}: ${status}`, `social:toggle:${field}`).row();
+  }
+
+  keyboard.text('↩️ חזור', 'menu:settings');
+
+  return {
+    text: '👥 <b>הגדרות חברתיות</b>\n\nשלוט באילו תכונות חברתיות פעילות עבורך.',
+    keyboard,
+  };
 }
 
 export function buildMyCitiesPage(chatId: number, page: number): { text: string; keyboard: InlineKeyboard } {
@@ -285,6 +317,42 @@ export function registerSettingsHandler(bot: Bot, writeCooldownMs = 1500): void 
       await ctx.answerCallbackQuery().catch((e) =>
         log('error', 'Settings', `כישלון ב-answerCallbackQuery אחרי שגיאת rm: ${e}`)
       );
+    }
+  });
+
+  // --- Social preferences (v0.5.2, #218) ---
+
+  bot.callbackQuery('social:settings', async (ctx: Context) => {
+    await ctx.answerCallbackQuery();
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    try {
+      const { text, keyboard } = buildSocialSettingsMenu(chatId);
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('error', 'Settings', `social:settings נכשל: ${err}`);
+    }
+  });
+
+  bot.callbackQuery(/^social:toggle:(.+)$/, async (ctx: Context) => {
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    if (settingsWriteCooldown.isOnCooldown(chatId)) {
+      await ctx.answerCallbackQuery('⏳ נסה שוב בעוד רגע');
+      return;
+    }
+    await ctx.answerCallbackQuery();
+    settingsWriteCooldown.setCooldown(chatId);
+    try {
+      const field = ctx.match?.[1];
+      if (!field || !VALID_SOCIAL_FIELDS.has(field)) return;
+      const user = getUser(chatId);
+      const current = user?.[field as SocialPrefField] ?? true;
+      setSocialPref(chatId, field as SocialPrefField, !current);
+      const { text, keyboard } = buildSocialSettingsMenu(chatId);
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('error', 'Settings', `social:toggle נכשל: ${err}`);
     }
   });
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -281,6 +281,13 @@ export function initSchema(database: Database.Database): void {
   // v0.4.6 — encrypted secrets support: flag column for settings table
   addColumnIfMissing(database, 'ALTER TABLE settings ADD COLUMN encrypted INTEGER NOT NULL DEFAULT 0');
 
+  // v0.5.2 — social preferences (refs #218)
+  addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN social_prompt_enabled INTEGER NOT NULL DEFAULT 1');
+  addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN social_banner_enabled INTEGER NOT NULL DEFAULT 1');
+  addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN social_contact_count_enabled INTEGER NOT NULL DEFAULT 1');
+  addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN social_group_alerts_enabled INTEGER NOT NULL DEFAULT 1');
+  addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN social_quick_ok_enabled INTEGER NOT NULL DEFAULT 1');
+
   database.prepare('CREATE UNIQUE INDEX IF NOT EXISTS idx_users_connection_code ON users(connection_code) WHERE connection_code IS NOT NULL').run();
 
   // Seed the all-clear template so it appears in the dashboard Messages page on first run.

--- a/src/db/userRepository.ts
+++ b/src/db/userRepository.ts
@@ -19,6 +19,11 @@ export interface User {
   connection_code: string | null;
   onboarding_step: OnboardingStep | null;
   is_dm_active: boolean;
+  social_prompt_enabled: boolean;
+  social_banner_enabled: boolean;
+  social_contact_count_enabled: boolean;
+  social_group_alerts_enabled: boolean;
+  social_quick_ok_enabled: boolean;
   created_at: string;
 }
 
@@ -41,6 +46,11 @@ interface RawUserRow {
   connection_code: string | null;
   onboarding_step: string | null;
   is_dm_active: number;
+  social_prompt_enabled: number;
+  social_banner_enabled: number;
+  social_contact_count_enabled: number;
+  social_group_alerts_enabled: number;
+  social_quick_ok_enabled: number;
   created_at: string;
 }
 
@@ -57,6 +67,11 @@ function mapRowToUser(raw: RawUserRow): User {
     onboarding_step: raw.onboarding_step && VALID_ONBOARDING_STEPS.has(raw.onboarding_step)
       ? (raw.onboarding_step as OnboardingStep)
       : null,
+    social_prompt_enabled: raw.social_prompt_enabled === 1,
+    social_banner_enabled: raw.social_banner_enabled === 1,
+    social_contact_count_enabled: raw.social_contact_count_enabled === 1,
+    social_group_alerts_enabled: raw.social_group_alerts_enabled === 1,
+    social_quick_ok_enabled: raw.social_quick_ok_enabled === 1,
   };
 }
 
@@ -125,6 +140,29 @@ export function deleteUser(chatId: number): void {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   (require('./subscriptionRepository.js') as { evictSubscriberFromCache: (id: number) => void })
     .evictSubscriberFromCache(chatId);
+}
+
+// --- Social preferences (v0.5.2) ---
+
+export type SocialPrefField =
+  | 'social_prompt_enabled'
+  | 'social_banner_enabled'
+  | 'social_contact_count_enabled'
+  | 'social_group_alerts_enabled'
+  | 'social_quick_ok_enabled';
+
+export const VALID_SOCIAL_FIELDS: ReadonlySet<string> = new Set<string>([
+  'social_prompt_enabled',
+  'social_banner_enabled',
+  'social_contact_count_enabled',
+  'social_group_alerts_enabled',
+  'social_quick_ok_enabled',
+]);
+
+export function setSocialPref(chatId: number, field: SocialPrefField, enabled: boolean): void {
+  if (!VALID_SOCIAL_FIELDS.has(field)) throw new Error(`Invalid social pref: ${field}`);
+  upsertUser(chatId);
+  getDb().prepare(`UPDATE users SET ${field} = ? WHERE chat_id = ?`).run(enabled ? 1 : 0, chatId);
 }
 
 // --- Profile functions (v0.4.1) ---


### PR DESCRIPTION
## Summary
- Add 5 boolean columns to `users` table: `social_prompt_enabled`, `social_banner_enabled`, `social_contact_count_enabled`, `social_group_alerts_enabled`, `social_quick_ok_enabled` (all default ON)
- New "👥 הגדרות חברתיות" section in `/settings` with per-user toggles
- `setSocialPref` validates field names against whitelist before SQL interpolation

## Test plan
- [ ] `npx tsx --test src/__tests__/userRepository.test.ts` — 4 new tests pass
- [ ] `npx tsx --test src/__tests__/settingsHandler.test.ts` — existing tests pass
- [ ] `tsc --noEmit` clean

Foundation for #215, #216, #217.

Closes #218