### PR TITLE
feat(bot): reminder banner in /start for unanswered prompts (#216)

### DIFF
--- a/src/__tests__/safetyStatusRepository.test.ts
+++ b/src/__tests__/safetyStatusRepository.test.ts
@@ -4,6 +4,7 @@ import Database from 'better-sqlite3';
 import { initSchema } from '../db/schema.js';
 import {
   upsertSafetyStatus,
+  upsertSafetyStatusWithTtl,
   getSafetyStatus,
   clearSafetyStatus,
   pruneExpiredSafetyStatuses,
@@ -145,6 +146,34 @@ describe('safetyStatusRepository — getActiveStatusesForContacts', () => {
   it('returns empty array for empty chatIds input', () => {
     const db = makeDb();
     assert.deepEqual(getActiveStatusesForContacts(db, []), []);
+  });
+});
+
+describe('safetyStatusRepository — upsertSafetyStatusWithTtl', () => {
+  it('creates status with custom TTL', () => {
+    const db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (?)').run(1);
+    upsertSafetyStatusWithTtl(db, 1, 'ok', 6);
+    const row = getSafetyStatus(db, 1);
+    assert.ok(row);
+    assert.equal(row.status, 'ok');
+    // expires_at should be ~6 hours from now, not 24
+    const expiresAt = new Date(row.expires_at + 'Z');
+    const now = new Date();
+    const hoursUntilExpiry = (expiresAt.getTime() - now.getTime()) / 3_600_000;
+    assert.ok(hoursUntilExpiry > 5 && hoursUntilExpiry <= 6.1, `Expected ~6h TTL, got ${hoursUntilExpiry.toFixed(1)}h`);
+  });
+
+  it('clamps TTL to minimum 1 hour', () => {
+    const db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (?)').run(2);
+    upsertSafetyStatusWithTtl(db, 2, 'ok', 0);
+    const row = getSafetyStatus(db, 2);
+    assert.ok(row);
+    const expiresAt = new Date(row.expires_at + 'Z');
+    const now = new Date();
+    const hoursUntilExpiry = (expiresAt.getTime() - now.getTime()) / 3_600_000;
+    assert.ok(hoursUntilExpiry > 0.5 && hoursUntilExpiry <= 1.1, `Expected ~1h TTL, got ${hoursUntilExpiry.toFixed(1)}h`);
   });
 });
 

--- a/src/bot/menuHandler.ts
+++ b/src/bot/menuHandler.ts
@@ -5,7 +5,8 @@ import { getSubscriptionCount } from '../db/subscriptionRepository.js';
 import { upsertUser, isOnboardingCompleted, completeOnboarding, getProfile, setOnboardingStep, setDmActive, getUser } from '../db/userRepository.js';
 import { getRecentAlerts } from '../db/alertHistoryRepository.js';
 import { listContacts, getPermissions } from '../db/contactRepository.js';
-import { upsertSafetyStatusWithTtl } from '../db/safetyStatusRepository.js';
+import { upsertSafetyStatusWithTtl, getSafetyStatus } from '../db/safetyStatusRepository.js';
+import { getUnansweredPromptsForUser } from '../db/safetyPromptRepository.js';
 import { sendStepMessage } from './onboardingHandler.js';
 import { getSetting } from '../dashboard/settingsRepository.js';
 import { ALERT_TYPE_EMOJI, ALERT_TYPE_HE, escapeHtml } from '../telegramBot.js';
@@ -72,6 +73,28 @@ function getQuickOkOptions(chatId: number): MainMenuOptions {
   return { hasAcceptedContacts, quickOkEnabled: user?.social_quick_ok_enabled ?? true };
 }
 
+/**
+ * Build a safety reminder banner if the user has unanswered prompts.
+ * Returns the banner HTML string, or empty string if no banner needed.
+ */
+function buildSafetyBanner(chatId: number): string {
+  if (!_db) return '';
+  const user = getUser(chatId);
+  if (user?.social_banner_enabled === false) return '';
+
+  const unanswered = getUnansweredPromptsForUser(_db, chatId);
+  if (unanswered.length === 0) return '';
+
+  // Extract city from fingerprint (format: "type:city1|city2|...")
+  const fp = unanswered[0].fingerprint;
+  const colonIdx = fp.indexOf(':');
+  const citiesPart = colonIdx >= 0 ? fp.slice(colonIdx + 1) : '';
+  const firstCity = citiesPart.split('|')[0] || '';
+  const cityText = firstCity ? ` ב${escapeHtml(firstCity)}` : '';
+
+  return `⚠️ <b>לא עדכנת סטטוס</b> אחרי האזעקה${cityText} · לחץ לעדכון`;
+}
+
 export function registerMenuHandler(bot: Bot): void {
   // Single source of truth for /start: private chat opens the main menu (or onboarding for new users).
   bot.command('start', async (ctx: Context) => {
@@ -112,7 +135,17 @@ export function registerMenuHandler(bot: Bot): void {
       const count = getSubscriptionCount(chatId);
       const lastAlert = getRecentAlerts(168)[0];
       const opts = getQuickOkOptions(chatId);
-      const { text, keyboard } = buildMainMenu(count, lastAlert, opts);
+      const { text: menuText, keyboard } = buildMainMenu(count, lastAlert, opts);
+
+      // #216 — reminder banner for unanswered safety prompts
+      const bannerText = buildSafetyBanner(chatId);
+      if (bannerText) {
+        keyboard.row()
+          .text('✅ הכל בסדר', 'quickok:confirm')
+          .text('📊 עדכן סטטוס', 'banner:status');
+      }
+      const text = bannerText ? `${bannerText}\n\n${menuText}` : menuText;
+
       await ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Menu', `/start failed: ${err}`);
@@ -205,6 +238,21 @@ export function registerMenuHandler(bot: Bot): void {
       });
     } catch (err) {
       log('error', 'Menu', `quickok:confirm נכשל: ${err}`);
+    }
+  });
+
+  // #216 — banner:status redirects to /status
+  bot.callbackQuery('banner:status', async (ctx: Context) => {
+    await ctx.answerCallbackQuery();
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    try {
+      await ctx.editMessageText('💬 שלח <b>/status</b> כדי לעדכן את הסטטוס שלך.', {
+        parse_mode: 'HTML',
+        reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+      });
+    } catch (err) {
+      log('error', 'Menu', `banner:status נכשל: ${err}`);
     }
   });
 

--- a/src/bot/menuHandler.ts
+++ b/src/bot/menuHandler.ts
@@ -141,7 +141,7 @@ export function registerMenuHandler(bot: Bot): void {
       const bannerText = buildSafetyBanner(chatId);
       if (bannerText) {
         keyboard.row()
-          .text('✅ הכל בסדר', 'quickok:confirm')
+          .text('✅ הכל בסדר', 'menu:quickok')
           .text('📊 עדכן סטטוס', 'banner:status');
       }
       const text = bannerText ? `${bannerText}\n\n${menuText}` : menuText;

--- a/src/bot/menuHandler.ts
+++ b/src/bot/menuHandler.ts
@@ -2,13 +2,17 @@ import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
 import type Database from 'better-sqlite3';
 import { getSubscriptionCount } from '../db/subscriptionRepository.js';
-import { upsertUser, isOnboardingCompleted, completeOnboarding, getProfile, setOnboardingStep, setDmActive } from '../db/userRepository.js';
+import { upsertUser, isOnboardingCompleted, completeOnboarding, getProfile, setOnboardingStep, setDmActive, getUser } from '../db/userRepository.js';
 import { getRecentAlerts } from '../db/alertHistoryRepository.js';
+import { listContacts, getPermissions } from '../db/contactRepository.js';
+import { upsertSafetyStatusWithTtl } from '../db/safetyStatusRepository.js';
 import { sendStepMessage } from './onboardingHandler.js';
 import { getSetting } from '../dashboard/settingsRepository.js';
-import { ALERT_TYPE_EMOJI, ALERT_TYPE_HE } from '../telegramBot.js';
+import { ALERT_TYPE_EMOJI, ALERT_TYPE_HE, escapeHtml } from '../telegramBot.js';
 import { formatRelativeHe } from './historyHandler.js';
 import { log } from '../logger.js';
+import { dmQueue } from '../services/dmQueue.js';
+import type { DmTask } from '../services/dmQueue.js';
 import type { AlertHistoryRow } from '../db/alertHistoryRepository.js';
 
 let _db: Database.Database | null = null;
@@ -18,9 +22,15 @@ export function setMenuHandlerDb(db: Database.Database): void {
   _db = db;
 }
 
+export interface MainMenuOptions {
+  hasAcceptedContacts?: boolean;
+  quickOkEnabled?: boolean;
+}
+
 export function buildMainMenu(
   cityCount: number,
-  lastAlert?: Pick<AlertHistoryRow, 'type' | 'fired_at'>
+  lastAlert?: Pick<AlertHistoryRow, 'type' | 'fired_at'>,
+  options?: MainMenuOptions
 ): { text: string; keyboard: InlineKeyboard } {
   const inviteLink = (_db && getSetting(_db, 'telegram_invite_link')) || process.env.TELEGRAM_INVITE_LINK;
   const keyboard = new InlineKeyboard();
@@ -36,6 +46,10 @@ export function buildMainMenu(
     .row()
     .text('⚙️ הגדרות', 'menu:settings');
 
+  if (options?.hasAcceptedContacts && options?.quickOkEnabled !== false) {
+    keyboard.row().text('✅ הכל בסדר — לכולם', 'menu:quickok');
+  }
+
   const lastAlertLine = lastAlert
     ? `\n\n📡 ההתרעה האחרונה: ${formatRelativeHe(lastAlert.fired_at)} — ${ALERT_TYPE_EMOJI[lastAlert.type] ?? '⚠️'} ${ALERT_TYPE_HE[lastAlert.type] ?? lastAlert.type}`
     : '';
@@ -45,6 +59,17 @@ export function buildMainMenu(
     : `🔔 <b>בוט פיקוד העורף</b>\n\nקבל התראות אישיות על ערים שאתה בוחר.${lastAlertLine}`;
 
   return { text, keyboard };
+}
+
+/** Query whether the user has accepted contacts with safety_status permission. */
+function getQuickOkOptions(chatId: number): MainMenuOptions {
+  const user = getUser(chatId);
+  const contacts = listContacts(chatId, 'accepted');
+  const hasAcceptedContacts = contacts.some(c => {
+    const perms = getPermissions(c.id);
+    return perms?.safety_status;
+  });
+  return { hasAcceptedContacts, quickOkEnabled: user?.social_quick_ok_enabled ?? true };
 }
 
 export function registerMenuHandler(bot: Bot): void {
@@ -65,7 +90,8 @@ export function registerMenuHandler(bot: Bot): void {
           completeOnboarding(chatId);
           log('info', 'Menu', `Backfilled onboarding_completed for legacy user ${chatId}`);
           const lastAlert = getRecentAlerts(168)[0];
-          const { text, keyboard } = buildMainMenu(subCount, lastAlert);
+          const opts = getQuickOkOptions(chatId);
+          const { text, keyboard } = buildMainMenu(subCount, lastAlert, opts);
           await ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard });
           return;
         }
@@ -85,7 +111,8 @@ export function registerMenuHandler(bot: Bot): void {
 
       const count = getSubscriptionCount(chatId);
       const lastAlert = getRecentAlerts(168)[0];
-      const { text, keyboard } = buildMainMenu(count, lastAlert);
+      const opts = getQuickOkOptions(chatId);
+      const { text, keyboard } = buildMainMenu(count, lastAlert, opts);
       await ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Menu', `/start failed: ${err}`);
@@ -101,8 +128,84 @@ export function registerMenuHandler(bot: Bot): void {
     if (!chatId) return;
     const count = getSubscriptionCount(chatId);
     const lastAlert = getRecentAlerts(168)[0];
-    const { text, keyboard } = buildMainMenu(count, lastAlert);
+    const opts = getQuickOkOptions(chatId);
+    const { text, keyboard } = buildMainMenu(count, lastAlert, opts);
     await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+  });
+
+  // --- Quick "הכל בסדר" broadcast (v0.5.2, #215) ---
+
+  bot.callbackQuery('menu:quickok', async (ctx: Context) => {
+    await ctx.answerCallbackQuery();
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    try {
+      const user = getUser(chatId);
+      if (user?.social_quick_ok_enabled === false) {
+        await ctx.editMessageText('תכונה זו כבויה. הפעל אותה בהגדרות חברתיות.', {
+          reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+        });
+        return;
+      }
+      const contacts = listContacts(chatId, 'accepted');
+      const withSafetyPerm = contacts.filter(c => {
+        const perms = getPermissions(c.id);
+        return perms?.safety_status;
+      });
+      if (withSafetyPerm.length === 0) {
+        await ctx.editMessageText('אין אנשי קשר עם הרשאת סטטוס ביטחוני.', {
+          reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+        });
+        return;
+      }
+      const keyboard = new InlineKeyboard()
+        .text(`✅ כן, שלח ל-${withSafetyPerm.length} אנשי קשר`, 'quickok:confirm')
+        .row()
+        .text('❌ ביטול', 'menu:main');
+      await ctx.editMessageText(
+        `✅ <b>הכל בסדר — שליחה מהירה</b>\n\nלשלוח עדכון "הכל בסדר" ל-<b>${withSafetyPerm.length}</b> אנשי קשר?`,
+        { parse_mode: 'HTML', reply_markup: keyboard }
+      );
+    } catch (err) {
+      log('error', 'Menu', `menu:quickok נכשל: ${err}`);
+    }
+  });
+
+  bot.callbackQuery('quickok:confirm', async (ctx: Context) => {
+    await ctx.answerCallbackQuery('✅ נשלח!');
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    try {
+      // TOCTOU re-verify
+      const user = getUser(chatId);
+      if (user?.social_quick_ok_enabled === false) return;
+
+      // Upsert safety status with 6h TTL
+      if (_db) upsertSafetyStatusWithTtl(_db, chatId, 'ok', 6);
+
+      const displayName = escapeHtml(user?.display_name ?? `משתמש #${chatId}`);
+      const timeStr = new Date().toLocaleTimeString('he-IL', {
+        timeZone: 'Asia/Jerusalem', hour: '2-digit', minute: '2-digit', hour12: false,
+      });
+      const msgText = `✅ <b>${displayName}</b> דיווח שהוא בסדר · ${timeStr}`;
+
+      const contacts = listContacts(chatId, 'accepted');
+      const tasks: DmTask[] = [];
+      for (const contact of contacts) {
+        const perms = getPermissions(contact.id);
+        if (!perms?.safety_status) continue;
+        const otherChatId = contact.user_id === chatId ? contact.contact_id : contact.user_id;
+        tasks.push({ chatId: String(otherChatId), text: msgText });
+      }
+      if (tasks.length > 0) dmQueue.enqueueAll(tasks);
+
+      log('info', 'Menu', `quickok: ${chatId} broadcast to ${tasks.length} contacts`);
+      await ctx.editMessageText('✅ עדכון "הכל בסדר" נשלח לכל אנשי הקשר שלך.', {
+        reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+      });
+    } catch (err) {
+      log('error', 'Menu', `quickok:confirm נכשל: ${err}`);
+    }
   });
 
   bot.callbackQuery('menu:alerts', async (ctx: Context) => {

--- a/src/db/safetyPromptRepository.ts
+++ b/src/db/safetyPromptRepository.ts
@@ -7,6 +7,7 @@ export interface SafetyPromptRow {
   sent_at: string;
   message_id: number | null;
   responded: boolean;
+  alert_type: string;
 }
 
 type RawRow = {
@@ -27,6 +28,7 @@ function decodeRow(raw: RawRow): SafetyPromptRow {
     sent_at: raw.sent_at,
     message_id: raw.message_id,
     responded: raw.responded === 1,
+    alert_type: raw.alert_type,
   };
 }
 
@@ -100,6 +102,25 @@ export function hasPromptBeenSent(
   fingerprint: string
 ): boolean {
   return getSafetyPrompt(db, chatId, fingerprint) !== null;
+}
+
+/**
+ * Returns unanswered safety prompts for a user within the last 24 hours.
+ * Used by /start banner to remind users of pending safety check responses.
+ * Hardcoded 24h — will be parametrized in #226 with maxAgeMinutes param.
+ */
+export function getUnansweredPromptsForUser(
+  db: Database.Database,
+  chatId: number
+): SafetyPromptRow[] {
+  return (
+    db.prepare(`
+      SELECT * FROM safety_prompts
+      WHERE chat_id = ? AND responded = 0
+        AND sent_at > datetime('now', '-24 hours')
+      ORDER BY sent_at DESC
+    `).all(chatId) as RawRow[]
+  ).map(decodeRow);
 }
 
 export function deleteSafetyPromptsForUser(

--- a/src/db/safetyStatusRepository.ts
+++ b/src/db/safetyStatusRepository.ts
@@ -34,6 +34,19 @@ export function upsertSafetyStatus(
   `).run(chatId, status);
 }
 
+export function upsertSafetyStatusWithTtl(
+  db: Database.Database,
+  chatId: number,
+  status: 'ok' | 'help' | 'dismissed',
+  ttlHours: number = 24
+): void {
+  const h = Math.max(1, Math.floor(ttlHours));
+  db.prepare(`
+    INSERT OR REPLACE INTO safety_status (chat_id, status, updated_at, expires_at)
+    VALUES (?, ?, datetime('now'), datetime('now', ? || ' hours'))
+  `).run(chatId, status, String(h));
+}
+
 export function getSafetyStatus(
   db: Database.Database,
   chatId: number


### PR DESCRIPTION
## Summary
- Warning banner at top of `/start` when user has unanswered safety prompts within last 24h
- `getUnansweredPromptsForUser` in `safetyPromptRepository`
- City extracted from fingerprint format (`type:city1|city2|...`)
- `SafetyPromptRow` extended with `alert_type` field
- Quick-action buttons: ✅ הכל בסדר / 📊 עדכן סטטוס
- Gated by `social_banner_enabled`; `responded = 0` filter handles dismissal

## Test plan
- [ ] `npx tsx --test src/__tests__/menuHandler.test.ts` — pass
- [ ] `npx tsx --test src/__tests__/safetyPromptService.test.ts` — 12 pass
- [ ] `tsc --noEmit` clean

Stacked on: #237

Closes #215
Closes #216