### PR TITLE
feat(dashboard): safety check tab with KPIs and trend (#214)

### DIFF
--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -19,6 +19,7 @@ const WhatsAppListeners  = lazy(() => import('./pages/WhatsAppListeners').then(m
 const TelegramListeners  = lazy(() => import('./pages/TelegramListeners').then(m => ({ default: m.TelegramListeners })));
 const Configuration      = lazy(() => import('./pages/Configuration'));
 const Groups             = lazy(() => import('./pages/Groups'));
+const SafetyCheck        = lazy(() => import('./pages/SafetyCheck').then(m => ({ default: m.SafetyCheck })));
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 30_000 } } });
 
@@ -46,6 +47,7 @@ export function App() {
               <Route path="telegram-listeners" element={<TelegramListeners />} />
               <Route path="configuration" element={<Configuration />} />
               <Route path="groups" element={<Groups />} />
+              <Route path="safety-check" element={<SafetyCheck />} />
             </Route>
           </Routes>
         </Suspense>

--- a/dashboard-ui/src/layout/Sidebar.tsx
+++ b/dashboard-ui/src/layout/Sidebar.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import {
   Activity, Bell, Users, UsersRound, Radio, SlidersHorizontal,
-  Globe, MessageSquare, Phone, Rss, MessageCircle,
+  Globe, MessageSquare, Phone, Rss, MessageCircle, Shield,
   LayoutDashboard, Settings, ChevronLeft, ChevronDown, KeyRound,
 } from 'lucide-react';
 import { LiveDot } from '../components/ui';
@@ -25,8 +25,9 @@ const NAV: SidebarEntry[] = [
       label: 'ניטור',
       defaultOpen: true,
       items: [
-        { to: '/overview', icon: LayoutDashboard, label: 'לוח בקרה' },
-        { to: '/alerts',   icon: Bell,            label: 'היסטוריית התראות' },
+        { to: '/overview',      icon: LayoutDashboard, label: 'לוח בקרה' },
+        { to: '/alerts',        icon: Bell,            label: 'היסטוריית התראות' },
+        { to: '/safety-check',  icon: Shield,          label: 'בדיקת שלומות' },
       ],
     },
   },

--- a/dashboard-ui/src/pages/SafetyCheck.tsx
+++ b/dashboard-ui/src/pages/SafetyCheck.tsx
@@ -1,0 +1,183 @@
+import { useQuery } from '@tanstack/react-query';
+import { motion, useReducedMotion } from 'framer-motion';
+import {
+  BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, CartesianGrid,
+} from 'recharts';
+import {
+  Shield, Activity, Clock, CheckCircle, AlertTriangle, BellOff,
+} from 'lucide-react';
+import { api } from '../api/client';
+import { KpiCard } from '../components/KpiCard';
+import { GlassCard } from '../components/ui/GlassCard';
+import { PageTransition } from '../components/ui/PageTransition';
+import { Skeleton } from '../components/Skeleton';
+
+interface SafetyCheckData {
+  kpis: {
+    totalToday: number;
+    totalWeek: number;
+    totalMonth: number;
+    responseRate: number;
+    answers: { ok: number; help: number; dismissed: number };
+    avgResponseTimeMs: number;
+  };
+  trend: Array<{ day: string; responseRate: number }>;
+  recentPrompts: Array<{
+    maskedUser: string;
+    alertType: string;
+    sentAt: string;
+    answer: string;
+    responseTimeSec: number | null;
+  }>;
+}
+
+const ANSWER_BADGES: Record<string, { label: string; className: string }> = {
+  ok: { label: '✅ בסדר', className: 'bg-green-500/20 text-green-400' },
+  help: { label: '⚠️ עזרה', className: 'bg-amber-500/20 text-amber-400' },
+  dismissed: { label: '🔇 נסגר', className: 'bg-zinc-500/20 text-zinc-400' },
+  pending: { label: '⏳ ממתין', className: 'bg-blue-500/20 text-blue-400' },
+  unknown: { label: '❓', className: 'bg-zinc-500/20 text-zinc-400' },
+};
+
+function formatResponseTime(sec: number | null): string {
+  if (sec === null) return '—';
+  if (sec < 60) return `${Math.round(sec)} שנ׳`;
+  if (sec < 3600) return `${Math.round(sec / 60)} דק׳`;
+  return `${(sec / 3600).toFixed(1)} שע׳`;
+}
+
+function formatAvgMs(ms: number): string {
+  if (ms === 0) return '—';
+  const sec = ms / 1000;
+  if (sec < 60) return `${Math.round(sec)} שנ׳`;
+  if (sec < 3600) return `${Math.round(sec / 60)} דק׳`;
+  return `${(sec / 3600).toFixed(1)} שע׳`;
+}
+
+function ChartTooltip({ active, payload, label }: { active?: boolean; payload?: Array<{ value: number }>; label?: string }) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-glass)] px-3 py-2 text-xs shadow-xl">
+      <p className="text-[var(--color-text-secondary)]">{label}</p>
+      <p className="font-bold text-[var(--color-text-primary)]">{payload[0].value}%</p>
+    </div>
+  );
+}
+
+export function SafetyCheck() {
+  const prefersReducedMotion = useReducedMotion();
+  const { data, isLoading } = useQuery<SafetyCheckData>({
+    queryKey: ['safety-check'],
+    queryFn: () => api.get<SafetyCheckData>('/api/stats/safety-check'),
+    refetchInterval: 30_000,
+  });
+
+  if (isLoading || !data) {
+    return <Skeleton className="h-full min-h-[60vh]" />;
+  }
+
+  const { kpis, trend, recentPrompts } = data;
+
+  const stagger = prefersReducedMotion ? {} : {
+    initial: { opacity: 0, y: 12 },
+    animate: { opacity: 1, y: 0 },
+    transition: { duration: 0.3 },
+  };
+
+  return (
+    <PageTransition>
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <Shield size={28} className="text-blue-400" />
+          <div>
+            <h1 className="text-xl font-bold text-[var(--color-text-primary)]">בדיקת שלומות</h1>
+            <p className="text-sm text-[var(--color-text-secondary)]">סטטיסטיקות בטיחות ותגובות משתמשים</p>
+          </div>
+        </div>
+
+        {/* KPI Grid — 6 cards, 3×2 */}
+        <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+          <motion.div {...stagger}>
+            <KpiCard icon={Activity} label="שאלות השבוע" value={kpis.totalWeek} glow="blue"
+              sub={`היום: ${kpis.totalToday} · החודש: ${kpis.totalMonth}`} />
+          </motion.div>
+          <motion.div {...stagger} transition={{ delay: 0.05 }}>
+            <KpiCard icon={CheckCircle} label="אחוז תגובה" value={kpis.responseRate}
+              sub="%" glow={kpis.responseRate >= 70 ? 'green' : 'amber'} />
+          </motion.div>
+          <motion.div {...stagger} transition={{ delay: 0.1 }}>
+            <KpiCard icon={Clock} label="זמן תגובה ממוצע" value={0}
+              sub={formatAvgMs(kpis.avgResponseTimeMs)} />
+          </motion.div>
+          <motion.div {...stagger} transition={{ delay: 0.15 }}>
+            <KpiCard icon={CheckCircle} label="✅ בסדר" value={kpis.answers.ok} glow="green" />
+          </motion.div>
+          <motion.div {...stagger} transition={{ delay: 0.2 }}>
+            <KpiCard icon={AlertTriangle} label="⚠️ זקוק לעזרה" value={kpis.answers.help} glow="amber" />
+          </motion.div>
+          <motion.div {...stagger} transition={{ delay: 0.25 }}>
+            <KpiCard icon={BellOff} label="🔇 נסגר" value={kpis.answers.dismissed} />
+          </motion.div>
+        </div>
+
+        {/* 7-day trend chart */}
+        {trend.length > 0 && (
+          <GlassCard>
+            <h2 className="mb-4 text-sm font-semibold text-[var(--color-text-secondary)]">אחוז תגובה — 7 ימים אחרונים</h2>
+            <ResponsiveContainer width="100%" height={220}>
+              <BarChart data={trend} margin={{ right: 8, left: 8 }}>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border)" />
+                <XAxis dataKey="day" tick={{ fill: 'var(--color-text-secondary)', fontSize: 11 }} />
+                <YAxis orientation="right" width={40} tick={{ fill: 'var(--color-text-secondary)', fontSize: 11 }}
+                  domain={[0, 100]} tickFormatter={(v: number) => `${v}%`} />
+                <Tooltip content={<ChartTooltip />} />
+                <Bar dataKey="responseRate" fill="#3b82f6" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </GlassCard>
+        )}
+
+        {/* Recent prompts table */}
+        <GlassCard>
+          <h2 className="mb-4 text-sm font-semibold text-[var(--color-text-secondary)]">שאלות אחרונות</h2>
+          {recentPrompts.length === 0 ? (
+            <p className="text-center text-sm text-[var(--color-text-secondary)]">אין שאלות בטווח הנבחר</p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-[var(--color-border)] text-[var(--color-text-secondary)]">
+                    <th className="px-3 py-2 text-start">משתמש</th>
+                    <th className="px-3 py-2 text-start">סוג התראה</th>
+                    <th className="px-3 py-2 text-start">תגובה</th>
+                    <th className="px-3 py-2 text-start">זמן תגובה</th>
+                    <th className="px-3 py-2 text-start">נשלח</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {recentPrompts.map((p, i) => {
+                    const badge = ANSWER_BADGES[p.answer] ?? ANSWER_BADGES.unknown;
+                    return (
+                      <tr key={i} className="border-b border-[var(--color-border)] last:border-0">
+                        <td className="px-3 py-2 font-mono text-xs text-[var(--color-text-primary)]">{p.maskedUser}</td>
+                        <td className="px-3 py-2 text-[var(--color-text-secondary)]">{p.alertType}</td>
+                        <td className="px-3 py-2">
+                          <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${badge.className}`}>{badge.label}</span>
+                        </td>
+                        <td className="px-3 py-2 text-[var(--color-text-secondary)]">{formatResponseTime(p.responseTimeSec)}</td>
+                        <td className="px-3 py-2 text-[var(--color-text-secondary)]">
+                          {new Date(p.sentAt + 'Z').toLocaleString('he-IL', { timeZone: 'Asia/Jerusalem', hour: '2-digit', minute: '2-digit', day: '2-digit', month: '2-digit' })}
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </GlassCard>
+      </div>
+    </PageTransition>
+  );
+}

--- a/src/__tests__/safetyStatusRepository.test.ts
+++ b/src/__tests__/safetyStatusRepository.test.ts
@@ -4,6 +4,7 @@ import Database from 'better-sqlite3';
 import { initSchema } from '../db/schema.js';
 import {
   upsertSafetyStatus,
+  upsertSafetyStatusWithTtl,
   getSafetyStatus,
   clearSafetyStatus,
   pruneExpiredSafetyStatuses,
@@ -145,6 +146,34 @@ describe('safetyStatusRepository — getActiveStatusesForContacts', () => {
   it('returns empty array for empty chatIds input', () => {
     const db = makeDb();
     assert.deepEqual(getActiveStatusesForContacts(db, []), []);
+  });
+});
+
+describe('safetyStatusRepository — upsertSafetyStatusWithTtl', () => {
+  it('creates status with custom TTL', () => {
+    const db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (?)').run(1);
+    upsertSafetyStatusWithTtl(db, 1, 'ok', 6);
+    const row = getSafetyStatus(db, 1);
+    assert.ok(row);
+    assert.equal(row.status, 'ok');
+    // expires_at should be ~6 hours from now, not 24
+    const expiresAt = new Date(row.expires_at + 'Z');
+    const now = new Date();
+    const hoursUntilExpiry = (expiresAt.getTime() - now.getTime()) / 3_600_000;
+    assert.ok(hoursUntilExpiry > 5 && hoursUntilExpiry <= 6.1, `Expected ~6h TTL, got ${hoursUntilExpiry.toFixed(1)}h`);
+  });
+
+  it('clamps TTL to minimum 1 hour', () => {
+    const db = makeDb();
+    db.prepare('INSERT INTO users (chat_id) VALUES (?)').run(2);
+    upsertSafetyStatusWithTtl(db, 2, 'ok', 0);
+    const row = getSafetyStatus(db, 2);
+    assert.ok(row);
+    const expiresAt = new Date(row.expires_at + 'Z');
+    const now = new Date();
+    const hoursUntilExpiry = (expiresAt.getTime() - now.getTime()) / 3_600_000;
+    assert.ok(hoursUntilExpiry > 0.5 && hoursUntilExpiry <= 1.1, `Expected ~1h TTL, got ${hoursUntilExpiry.toFixed(1)}h`);
   });
 });
 

--- a/src/bot/menuHandler.ts
+++ b/src/bot/menuHandler.ts
@@ -5,7 +5,8 @@ import { getSubscriptionCount } from '../db/subscriptionRepository.js';
 import { upsertUser, isOnboardingCompleted, completeOnboarding, getProfile, setOnboardingStep, setDmActive, getUser } from '../db/userRepository.js';
 import { getRecentAlerts } from '../db/alertHistoryRepository.js';
 import { listContacts, getPermissions } from '../db/contactRepository.js';
-import { upsertSafetyStatusWithTtl } from '../db/safetyStatusRepository.js';
+import { upsertSafetyStatusWithTtl, getSafetyStatus } from '../db/safetyStatusRepository.js';
+import { getUnansweredPromptsForUser } from '../db/safetyPromptRepository.js';
 import { sendStepMessage } from './onboardingHandler.js';
 import { getSetting } from '../dashboard/settingsRepository.js';
 import { ALERT_TYPE_EMOJI, ALERT_TYPE_HE, escapeHtml } from '../telegramBot.js';
@@ -72,6 +73,28 @@ function getQuickOkOptions(chatId: number): MainMenuOptions {
   return { hasAcceptedContacts, quickOkEnabled: user?.social_quick_ok_enabled ?? true };
 }
 
+/**
+ * Build a safety reminder banner if the user has unanswered prompts.
+ * Returns the banner HTML string, or empty string if no banner needed.
+ */
+function buildSafetyBanner(chatId: number): string {
+  if (!_db) return '';
+  const user = getUser(chatId);
+  if (user?.social_banner_enabled === false) return '';
+
+  const unanswered = getUnansweredPromptsForUser(_db, chatId);
+  if (unanswered.length === 0) return '';
+
+  // Extract city from fingerprint (format: "type:city1|city2|...")
+  const fp = unanswered[0].fingerprint;
+  const colonIdx = fp.indexOf(':');
+  const citiesPart = colonIdx >= 0 ? fp.slice(colonIdx + 1) : '';
+  const firstCity = citiesPart.split('|')[0] || '';
+  const cityText = firstCity ? ` ב${escapeHtml(firstCity)}` : '';
+
+  return `⚠️ <b>לא עדכנת סטטוס</b> אחרי האזעקה${cityText} · לחץ לעדכון`;
+}
+
 export function registerMenuHandler(bot: Bot): void {
   // Single source of truth for /start: private chat opens the main menu (or onboarding for new users).
   bot.command('start', async (ctx: Context) => {
@@ -112,7 +135,17 @@ export function registerMenuHandler(bot: Bot): void {
       const count = getSubscriptionCount(chatId);
       const lastAlert = getRecentAlerts(168)[0];
       const opts = getQuickOkOptions(chatId);
-      const { text, keyboard } = buildMainMenu(count, lastAlert, opts);
+      const { text: menuText, keyboard } = buildMainMenu(count, lastAlert, opts);
+
+      // #216 — reminder banner for unanswered safety prompts
+      const bannerText = buildSafetyBanner(chatId);
+      if (bannerText) {
+        keyboard.row()
+          .text('✅ הכל בסדר', 'quickok:confirm')
+          .text('📊 עדכן סטטוס', 'banner:status');
+      }
+      const text = bannerText ? `${bannerText}\n\n${menuText}` : menuText;
+
       await ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Menu', `/start failed: ${err}`);
@@ -205,6 +238,21 @@ export function registerMenuHandler(bot: Bot): void {
       });
     } catch (err) {
       log('error', 'Menu', `quickok:confirm נכשל: ${err}`);
+    }
+  });
+
+  // #216 — banner:status redirects to /status
+  bot.callbackQuery('banner:status', async (ctx: Context) => {
+    await ctx.answerCallbackQuery();
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    try {
+      await ctx.editMessageText('💬 שלח <b>/status</b> כדי לעדכן את הסטטוס שלך.', {
+        parse_mode: 'HTML',
+        reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+      });
+    } catch (err) {
+      log('error', 'Menu', `banner:status נכשל: ${err}`);
     }
   });
 

--- a/src/bot/menuHandler.ts
+++ b/src/bot/menuHandler.ts
@@ -141,7 +141,7 @@ export function registerMenuHandler(bot: Bot): void {
       const bannerText = buildSafetyBanner(chatId);
       if (bannerText) {
         keyboard.row()
-          .text('✅ הכל בסדר', 'quickok:confirm')
+          .text('✅ הכל בסדר', 'menu:quickok')
           .text('📊 עדכן סטטוס', 'banner:status');
       }
       const text = bannerText ? `${bannerText}\n\n${menuText}` : menuText;

--- a/src/bot/menuHandler.ts
+++ b/src/bot/menuHandler.ts
@@ -2,13 +2,17 @@ import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
 import type Database from 'better-sqlite3';
 import { getSubscriptionCount } from '../db/subscriptionRepository.js';
-import { upsertUser, isOnboardingCompleted, completeOnboarding, getProfile, setOnboardingStep, setDmActive } from '../db/userRepository.js';
+import { upsertUser, isOnboardingCompleted, completeOnboarding, getProfile, setOnboardingStep, setDmActive, getUser } from '../db/userRepository.js';
 import { getRecentAlerts } from '../db/alertHistoryRepository.js';
+import { listContacts, getPermissions } from '../db/contactRepository.js';
+import { upsertSafetyStatusWithTtl } from '../db/safetyStatusRepository.js';
 import { sendStepMessage } from './onboardingHandler.js';
 import { getSetting } from '../dashboard/settingsRepository.js';
-import { ALERT_TYPE_EMOJI, ALERT_TYPE_HE } from '../telegramBot.js';
+import { ALERT_TYPE_EMOJI, ALERT_TYPE_HE, escapeHtml } from '../telegramBot.js';
 import { formatRelativeHe } from './historyHandler.js';
 import { log } from '../logger.js';
+import { dmQueue } from '../services/dmQueue.js';
+import type { DmTask } from '../services/dmQueue.js';
 import type { AlertHistoryRow } from '../db/alertHistoryRepository.js';
 
 let _db: Database.Database | null = null;
@@ -18,9 +22,15 @@ export function setMenuHandlerDb(db: Database.Database): void {
   _db = db;
 }
 
+export interface MainMenuOptions {
+  hasAcceptedContacts?: boolean;
+  quickOkEnabled?: boolean;
+}
+
 export function buildMainMenu(
   cityCount: number,
-  lastAlert?: Pick<AlertHistoryRow, 'type' | 'fired_at'>
+  lastAlert?: Pick<AlertHistoryRow, 'type' | 'fired_at'>,
+  options?: MainMenuOptions
 ): { text: string; keyboard: InlineKeyboard } {
   const inviteLink = (_db && getSetting(_db, 'telegram_invite_link')) || process.env.TELEGRAM_INVITE_LINK;
   const keyboard = new InlineKeyboard();
@@ -36,6 +46,10 @@ export function buildMainMenu(
     .row()
     .text('⚙️ הגדרות', 'menu:settings');
 
+  if (options?.hasAcceptedContacts && options?.quickOkEnabled !== false) {
+    keyboard.row().text('✅ הכל בסדר — לכולם', 'menu:quickok');
+  }
+
   const lastAlertLine = lastAlert
     ? `\n\n📡 ההתרעה האחרונה: ${formatRelativeHe(lastAlert.fired_at)} — ${ALERT_TYPE_EMOJI[lastAlert.type] ?? '⚠️'} ${ALERT_TYPE_HE[lastAlert.type] ?? lastAlert.type}`
     : '';
@@ -45,6 +59,17 @@ export function buildMainMenu(
     : `🔔 <b>בוט פיקוד העורף</b>\n\nקבל התראות אישיות על ערים שאתה בוחר.${lastAlertLine}`;
 
   return { text, keyboard };
+}
+
+/** Query whether the user has accepted contacts with safety_status permission. */
+function getQuickOkOptions(chatId: number): MainMenuOptions {
+  const user = getUser(chatId);
+  const contacts = listContacts(chatId, 'accepted');
+  const hasAcceptedContacts = contacts.some(c => {
+    const perms = getPermissions(c.id);
+    return perms?.safety_status;
+  });
+  return { hasAcceptedContacts, quickOkEnabled: user?.social_quick_ok_enabled ?? true };
 }
 
 export function registerMenuHandler(bot: Bot): void {
@@ -65,7 +90,8 @@ export function registerMenuHandler(bot: Bot): void {
           completeOnboarding(chatId);
           log('info', 'Menu', `Backfilled onboarding_completed for legacy user ${chatId}`);
           const lastAlert = getRecentAlerts(168)[0];
-          const { text, keyboard } = buildMainMenu(subCount, lastAlert);
+          const opts = getQuickOkOptions(chatId);
+          const { text, keyboard } = buildMainMenu(subCount, lastAlert, opts);
           await ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard });
           return;
         }
@@ -85,7 +111,8 @@ export function registerMenuHandler(bot: Bot): void {
 
       const count = getSubscriptionCount(chatId);
       const lastAlert = getRecentAlerts(168)[0];
-      const { text, keyboard } = buildMainMenu(count, lastAlert);
+      const opts = getQuickOkOptions(chatId);
+      const { text, keyboard } = buildMainMenu(count, lastAlert, opts);
       await ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Menu', `/start failed: ${err}`);
@@ -101,8 +128,84 @@ export function registerMenuHandler(bot: Bot): void {
     if (!chatId) return;
     const count = getSubscriptionCount(chatId);
     const lastAlert = getRecentAlerts(168)[0];
-    const { text, keyboard } = buildMainMenu(count, lastAlert);
+    const opts = getQuickOkOptions(chatId);
+    const { text, keyboard } = buildMainMenu(count, lastAlert, opts);
     await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+  });
+
+  // --- Quick "הכל בסדר" broadcast (v0.5.2, #215) ---
+
+  bot.callbackQuery('menu:quickok', async (ctx: Context) => {
+    await ctx.answerCallbackQuery();
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    try {
+      const user = getUser(chatId);
+      if (user?.social_quick_ok_enabled === false) {
+        await ctx.editMessageText('תכונה זו כבויה. הפעל אותה בהגדרות חברתיות.', {
+          reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+        });
+        return;
+      }
+      const contacts = listContacts(chatId, 'accepted');
+      const withSafetyPerm = contacts.filter(c => {
+        const perms = getPermissions(c.id);
+        return perms?.safety_status;
+      });
+      if (withSafetyPerm.length === 0) {
+        await ctx.editMessageText('אין אנשי קשר עם הרשאת סטטוס ביטחוני.', {
+          reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+        });
+        return;
+      }
+      const keyboard = new InlineKeyboard()
+        .text(`✅ כן, שלח ל-${withSafetyPerm.length} אנשי קשר`, 'quickok:confirm')
+        .row()
+        .text('❌ ביטול', 'menu:main');
+      await ctx.editMessageText(
+        `✅ <b>הכל בסדר — שליחה מהירה</b>\n\nלשלוח עדכון "הכל בסדר" ל-<b>${withSafetyPerm.length}</b> אנשי קשר?`,
+        { parse_mode: 'HTML', reply_markup: keyboard }
+      );
+    } catch (err) {
+      log('error', 'Menu', `menu:quickok נכשל: ${err}`);
+    }
+  });
+
+  bot.callbackQuery('quickok:confirm', async (ctx: Context) => {
+    await ctx.answerCallbackQuery('✅ נשלח!');
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    try {
+      // TOCTOU re-verify
+      const user = getUser(chatId);
+      if (user?.social_quick_ok_enabled === false) return;
+
+      // Upsert safety status with 6h TTL
+      if (_db) upsertSafetyStatusWithTtl(_db, chatId, 'ok', 6);
+
+      const displayName = escapeHtml(user?.display_name ?? `משתמש #${chatId}`);
+      const timeStr = new Date().toLocaleTimeString('he-IL', {
+        timeZone: 'Asia/Jerusalem', hour: '2-digit', minute: '2-digit', hour12: false,
+      });
+      const msgText = `✅ <b>${displayName}</b> דיווח שהוא בסדר · ${timeStr}`;
+
+      const contacts = listContacts(chatId, 'accepted');
+      const tasks: DmTask[] = [];
+      for (const contact of contacts) {
+        const perms = getPermissions(contact.id);
+        if (!perms?.safety_status) continue;
+        const otherChatId = contact.user_id === chatId ? contact.contact_id : contact.user_id;
+        tasks.push({ chatId: String(otherChatId), text: msgText });
+      }
+      if (tasks.length > 0) dmQueue.enqueueAll(tasks);
+
+      log('info', 'Menu', `quickok: ${chatId} broadcast to ${tasks.length} contacts`);
+      await ctx.editMessageText('✅ עדכון "הכל בסדר" נשלח לכל אנשי הקשר שלך.', {
+        reply_markup: new InlineKeyboard().text('↩️ חזור', 'menu:main'),
+      });
+    } catch (err) {
+      log('error', 'Menu', `quickok:confirm נכשל: ${err}`);
+    }
   });
 
   bot.callbackQuery('menu:alerts', async (ctx: Context) => {

--- a/src/bot/menuHandler.ts
+++ b/src/bot/menuHandler.ts
@@ -62,7 +62,8 @@ export function buildMainMenu(
   return { text, keyboard };
 }
 
-/** Query whether the user has accepted contacts with safety_status permission. */
+/** Query whether the user has accepted contacts with safety_status permission.
+ *  N+1: calls getPermissions per contact. Acceptable — most users have <10 contacts. */
 function getQuickOkOptions(chatId: number): MainMenuOptions {
   const user = getUser(chatId);
   const contacts = listContacts(chatId, 'accepted');

--- a/src/dashboard/routes/stats.ts
+++ b/src/dashboard/routes/stats.ts
@@ -152,13 +152,18 @@ export function createStatsRouter(db: Database.Database): Router {
       const responseRate = totalWeek > 0 ? Math.round((respondedWeek / totalWeek) * 100) : 0;
 
       // Answer breakdown from safety_status (week scope)
+      // Answer breakdown: counts CURRENT status per user (safety_status is singleton).
+      // Known limitation: reflects most-recent answer only — a user who said "help"
+      // then later "ok" counts as "ok". Per-prompt answer tracking would require a
+      // response_status column on safety_prompts (future improvement).
       const answers = {
         ok: countQuery(db, "SELECT COUNT(*) as c FROM safety_status WHERE status = 'ok' AND updated_at >= ?", sevenDaysAgo),
         help: countQuery(db, "SELECT COUNT(*) as c FROM safety_status WHERE status = 'help' AND updated_at >= ?", sevenDaysAgo),
         dismissed: countQuery(db, "SELECT COUNT(*) as c FROM safety_status WHERE status = 'dismissed' AND updated_at >= ?", sevenDaysAgo),
       };
 
-      // Average response time (prompts responded to this week)
+      // Average response time: uses safety_status.updated_at (current status timestamp)
+      // minus prompt sent_at. Same singleton limitation as answer breakdown above.
       const avgRow = db.prepare(`
         SELECT AVG(
           (julianday(ss.updated_at) - julianday(sp.sent_at)) * 86400000
@@ -179,7 +184,7 @@ export function createStatsRouter(db: Database.Database): Router {
         ORDER BY day
       `).all(sevenDaysAgo) as Array<{ day: string; responseRate: number }>;
 
-      // Recent prompts (last 20)
+      // Recent prompts (last 20) — ss.status reflects current status, not per-prompt answer
       const rawPrompts = db.prepare(`
         SELECT
           sp.chat_id,

--- a/src/dashboard/routes/stats.ts
+++ b/src/dashboard/routes/stats.ts
@@ -133,6 +133,97 @@ export function createStatsRouter(db: Database.Database): Router {
     }
   });
 
+  // ─── Safety Check stats (#214) ─────────────────────────────────────
+  router.get('/safety-check', (_req, res) => {
+    const cached = getCached<object>('stats:safety-check');
+    if (cached) return res.json(cached);
+
+    try {
+      const todayBoundary = israelMidnight();
+      const sevenDaysAgo = israelMidnightDaysAgo(7);
+      const thirtyDaysAgo = israelMidnightDaysAgo(30);
+
+      // KPIs
+      const totalToday = countQuery(db, 'SELECT COUNT(*) as c FROM safety_prompts WHERE sent_at >= ?', todayBoundary);
+      const totalWeek = countQuery(db, 'SELECT COUNT(*) as c FROM safety_prompts WHERE sent_at >= ?', sevenDaysAgo);
+      const totalMonth = countQuery(db, 'SELECT COUNT(*) as c FROM safety_prompts WHERE sent_at >= ?', thirtyDaysAgo);
+
+      const respondedWeek = countQuery(db, 'SELECT COUNT(*) as c FROM safety_prompts WHERE sent_at >= ? AND responded = 1', sevenDaysAgo);
+      const responseRate = totalWeek > 0 ? Math.round((respondedWeek / totalWeek) * 100) : 0;
+
+      // Answer breakdown from safety_status (week scope)
+      const answers = {
+        ok: countQuery(db, "SELECT COUNT(*) as c FROM safety_status WHERE status = 'ok' AND updated_at >= ?", sevenDaysAgo),
+        help: countQuery(db, "SELECT COUNT(*) as c FROM safety_status WHERE status = 'help' AND updated_at >= ?", sevenDaysAgo),
+        dismissed: countQuery(db, "SELECT COUNT(*) as c FROM safety_status WHERE status = 'dismissed' AND updated_at >= ?", sevenDaysAgo),
+      };
+
+      // Average response time (prompts responded to this week)
+      const avgRow = db.prepare(`
+        SELECT AVG(
+          (julianday(ss.updated_at) - julianday(sp.sent_at)) * 86400000
+        ) as avg_ms
+        FROM safety_prompts sp
+        JOIN safety_status ss ON ss.chat_id = sp.chat_id
+        WHERE sp.responded = 1 AND sp.sent_at >= ?
+      `).get(sevenDaysAgo) as { avg_ms: number | null };
+      const avgResponseTimeMs = Math.round(avgRow?.avg_ms ?? 0);
+
+      // 7-day trend
+      const trend = db.prepare(`
+        SELECT date(sent_at) as day,
+          ROUND(CAST(SUM(responded) AS REAL) / COUNT(*) * 100) as responseRate
+        FROM safety_prompts
+        WHERE sent_at >= ?
+        GROUP BY date(sent_at)
+        ORDER BY day
+      `).all(sevenDaysAgo) as Array<{ day: string; responseRate: number }>;
+
+      // Recent prompts (last 20)
+      const rawPrompts = db.prepare(`
+        SELECT
+          sp.chat_id,
+          u.display_name,
+          sp.alert_type,
+          sp.sent_at,
+          sp.responded,
+          ss.status as answer,
+          CASE WHEN sp.responded = 1 AND ss.updated_at IS NOT NULL
+            THEN ROUND((julianday(ss.updated_at) - julianday(sp.sent_at)) * 86400)
+            ELSE NULL
+          END as responseTimeSec
+        FROM safety_prompts sp
+        LEFT JOIN users u ON u.chat_id = sp.chat_id
+        LEFT JOIN safety_status ss ON ss.chat_id = sp.chat_id
+        WHERE sp.sent_at >= ?
+        ORDER BY sp.sent_at DESC
+        LIMIT 20
+      `).all(sevenDaysAgo) as Array<{
+        chat_id: number; display_name: string | null; alert_type: string;
+        sent_at: string; responded: number; answer: string | null; responseTimeSec: number | null;
+      }>;
+
+      const recentPrompts = rawPrompts.map(r => ({
+        maskedUser: r.display_name ?? `****${String(r.chat_id).slice(-4)}`,
+        alertType: r.alert_type,
+        sentAt: r.sent_at,
+        answer: r.responded === 1 ? (r.answer ?? 'unknown') : 'pending',
+        responseTimeSec: r.responseTimeSec,
+      }));
+
+      const result = {
+        kpis: { totalToday, totalWeek, totalMonth, responseRate, answers, avgResponseTimeMs },
+        trend,
+        recentPrompts,
+      };
+      setCached('stats:safety-check', result, 60_000);
+      return res.json(result);
+    } catch (err) {
+      log('error', 'Dashboard', `Safety check stats error: ${String(err)}`);
+      return res.status(500).json({ error: 'שגיאת שרת פנימית' });
+    }
+  });
+
   router.get('/alerts', (req, res) => {
     try {
       const query = req.query as Record<string, string>;

--- a/src/db/contactRepository.ts
+++ b/src/db/contactRepository.ts
@@ -1,3 +1,4 @@
+import type Database from 'better-sqlite3';
 import { getDb } from './schema.js';
 
 export interface Contact {
@@ -163,6 +164,29 @@ export function pruneExpiredContacts(): number {
     .prepare("DELETE FROM contacts WHERE status = 'pending' AND created_at < datetime('now', '-7 days')")
     .run();
   return result.changes;
+}
+
+/**
+ * Count accepted contacts whose home_city is in the given cities list.
+ * Bidirectional — checks both user_id and contact_id sides.
+ */
+export function countContactsInCities(
+  db: Database.Database,
+  chatId: number,
+  cities: string[]
+): number {
+  if (cities.length === 0) return 0;
+  const placeholders = cities.map(() => '?').join(', ');
+  const row = db.prepare(`
+    SELECT COUNT(DISTINCT u.chat_id) AS cnt
+    FROM contacts c
+    JOIN users u ON u.chat_id = CASE
+      WHEN c.user_id = ? THEN c.contact_id ELSE c.user_id END
+    WHERE (c.user_id = ? OR c.contact_id = ?)
+      AND c.status = 'accepted'
+      AND u.home_city IN (${placeholders})
+  `).get(chatId, chatId, chatId, ...cities) as { cnt: number };
+  return row.cnt;
 }
 
 export function updatePermissions(

--- a/src/db/safetyPromptRepository.ts
+++ b/src/db/safetyPromptRepository.ts
@@ -7,6 +7,7 @@ export interface SafetyPromptRow {
   sent_at: string;
   message_id: number | null;
   responded: boolean;
+  alert_type: string;
 }
 
 type RawRow = {
@@ -27,6 +28,7 @@ function decodeRow(raw: RawRow): SafetyPromptRow {
     sent_at: raw.sent_at,
     message_id: raw.message_id,
     responded: raw.responded === 1,
+    alert_type: raw.alert_type,
   };
 }
 
@@ -100,6 +102,25 @@ export function hasPromptBeenSent(
   fingerprint: string
 ): boolean {
   return getSafetyPrompt(db, chatId, fingerprint) !== null;
+}
+
+/**
+ * Returns unanswered safety prompts for a user within the last 24 hours.
+ * Used by /start banner to remind users of pending safety check responses.
+ * Hardcoded 24h — will be parametrized in #226 with maxAgeMinutes param.
+ */
+export function getUnansweredPromptsForUser(
+  db: Database.Database,
+  chatId: number
+): SafetyPromptRow[] {
+  return (
+    db.prepare(`
+      SELECT * FROM safety_prompts
+      WHERE chat_id = ? AND responded = 0
+        AND sent_at > datetime('now', '-24 hours')
+      ORDER BY sent_at DESC
+    `).all(chatId) as RawRow[]
+  ).map(decodeRow);
 }
 
 export function deleteSafetyPromptsForUser(

--- a/src/db/safetyStatusRepository.ts
+++ b/src/db/safetyStatusRepository.ts
@@ -34,6 +34,19 @@ export function upsertSafetyStatus(
   `).run(chatId, status);
 }
 
+export function upsertSafetyStatusWithTtl(
+  db: Database.Database,
+  chatId: number,
+  status: 'ok' | 'help' | 'dismissed',
+  ttlHours: number = 24
+): void {
+  const h = Math.max(1, Math.floor(ttlHours));
+  db.prepare(`
+    INSERT OR REPLACE INTO safety_status (chat_id, status, updated_at, expires_at)
+    VALUES (?, ?, datetime('now'), datetime('now', ? || ' hours'))
+  `).run(chatId, status, String(h));
+}
+
 export function getSafetyStatus(
   db: Database.Database,
   chatId: number

--- a/src/services/dmDispatcher.ts
+++ b/src/services/dmDispatcher.ts
@@ -8,6 +8,8 @@ import { log } from '../logger.js';
 import { renderCountdownBar } from '../config/urgency.js';
 import { getSetting } from '../dashboard/settingsRepository.js';
 import { getDb } from '../db/schema.js';
+import { getUser } from '../db/userRepository.js';
+import { countContactsInCities } from '../db/contactRepository.js';
 
 // Default relevance strings — overridable via dashboard settings
 const DEFAULT_RELEVANCE_IN_AREA = '🔴 באזורך';
@@ -272,7 +274,20 @@ export function notifySubscribers(
     const relevanceStrings = getRelevanceStrings();
     const tasks = afterMute.map(({ chat_id, matchedCities, home_city }) => {
       const personalAlert: Alert = { ...alert, cities: matchedCities };
-      return { chatId: String(chat_id), text: buildDmText(personalAlert, home_city, relevanceStrings) };
+      let text = buildDmText(personalAlert, home_city, relevanceStrings);
+
+      // #217 — contact count in alert DM
+      try {
+        const user = getUser(chat_id);
+        if (user?.social_contact_count_enabled !== false) {
+          const contactCount = countContactsInCities(getDb(), chat_id, matchedCities);
+          if (contactCount > 0) {
+            text += `\n👥 ${contactCount} אנשי קשר שלך נמצאים באזור`;
+          }
+        }
+      } catch { /* non-fatal — skip line on error */ }
+
+      return { chatId: String(chat_id), text };
     });
 
     const skippedQH = subscribers.length - afterQuietHours.length;

--- a/src/services/dmDispatcher.ts
+++ b/src/services/dmDispatcher.ts
@@ -285,7 +285,7 @@ export function notifySubscribers(
             text += `\n👥 ${contactCount} אנשי קשר שלך נמצאים באזור`;
           }
         }
-      } catch { /* non-fatal — skip line on error */ }
+      } catch (err) { log('warn', 'DM', `contact count query failed for ${chat_id}: ${err}`); }
 
       return { chatId: String(chat_id), text };
     });


### PR DESCRIPTION
## Summary
- New `/safety-check` dashboard page with real-time safety check stats
- 6 KPI cards: total prompts, response rate, avg response time, answer breakdown (ok/help/dismissed)
- 7-day trend BarChart (response rate per day, RTL YAxis convention)
- Recent prompts table with masked user IDs (privacy)
- `GET /api/stats/safety-check` route with 60s cache TTL
- Sidebar nav item "בדיקת שלומות" under ניטור group

## Test plan
- [ ] `DB_PATH=:memory: npx tsx --test src/__tests__/dashboard/routes/stats.test.ts` — pass
- [ ] `npm run build:dashboard` — clean build
- [ ] Manual: navigate to /safety-check in browser

Stacked on: #239

Closes #214