### PR TITLE
feat: v0.5.3 community features (pulse, stories, skills, neighbor check, groups)

### DIFF
--- a/dashboard-ui/src/App.tsx
+++ b/dashboard-ui/src/App.tsx
@@ -20,6 +20,7 @@ const TelegramListeners  = lazy(() => import('./pages/TelegramListeners').then(m
 const Configuration      = lazy(() => import('./pages/Configuration'));
 const Groups             = lazy(() => import('./pages/Groups'));
 const SafetyCheck        = lazy(() => import('./pages/SafetyCheck').then(m => ({ default: m.SafetyCheck })));
+const Community          = lazy(() => import('./pages/Community').then(m => ({ default: m.Community })));
 
 const queryClient = new QueryClient({ defaultOptions: { queries: { staleTime: 30_000 } } });
 
@@ -48,6 +49,7 @@ export function App() {
               <Route path="configuration" element={<Configuration />} />
               <Route path="groups" element={<Groups />} />
               <Route path="safety-check" element={<SafetyCheck />} />
+              <Route path="community" element={<Community />} />
             </Route>
           </Routes>
         </Suspense>

--- a/dashboard-ui/src/layout/Sidebar.tsx
+++ b/dashboard-ui/src/layout/Sidebar.tsx
@@ -4,7 +4,7 @@ import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import {
   Activity, Bell, Users, UsersRound, Radio, SlidersHorizontal,
   Globe, MessageSquare, Phone, Rss, MessageCircle, Shield,
-  LayoutDashboard, Settings, ChevronLeft, ChevronDown, KeyRound,
+  LayoutDashboard, Settings, ChevronLeft, ChevronDown, KeyRound, Users2,
 } from 'lucide-react';
 import { LiveDot } from '../components/ui';
 
@@ -56,6 +56,7 @@ const NAV: SidebarEntry[] = [
       label: 'מערכת',
       defaultOpen: false,
       items: [
+        { to: '/community',     icon: Users2,         label: 'קהילה' },
         { to: '/configuration', icon: KeyRound,       label: 'הגדרות ואבטחה' },
         { to: '/settings',      icon: Settings,       label: 'הגדרות' },
         { to: '/messages',      icon: MessageSquare,  label: 'תבניות הודעות' },

--- a/dashboard-ui/src/pages/Community.tsx
+++ b/dashboard-ui/src/pages/Community.tsx
@@ -1,0 +1,169 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState, useEffect, useRef } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { CheckCircle, Loader2, Users2 } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { api } from '../api/client';
+import { Skeleton } from '../components/Skeleton';
+import { PageTransition } from '../components/ui/PageTransition';
+import { PulseSection } from './community/PulseSection';
+import { StoriesSection } from './community/StoriesSection';
+import { SkillsSection } from './community/SkillsSection';
+import { NeighborCheckSection } from './community/NeighborCheckSection';
+
+interface CommunityForm {
+  pulse_enabled: string;
+  pulse_cooldown_hours: string;
+  pulse_aggregate_threshold: string;
+  pulse_prompt_text: string;
+  topic_id_stories: string;
+  stories_enabled: string;
+  stories_rate_limit_minutes: string;
+  stories_max_length: string;
+  skills_public_enabled: string;
+  skills_need_radius_zones: string;
+  neighbor_check_enabled_default: string;
+  neighbor_check_delay_minutes: string;
+  neighbor_check_text: string;
+}
+
+const DEFAULTS: CommunityForm = {
+  pulse_enabled: 'false',
+  pulse_cooldown_hours: '24',
+  pulse_aggregate_threshold: '10',
+  pulse_prompt_text: '',
+  topic_id_stories: '0',
+  stories_enabled: 'false',
+  stories_rate_limit_minutes: '60',
+  stories_max_length: '500',
+  skills_public_enabled: 'false',
+  skills_need_radius_zones: '3',
+  neighbor_check_enabled_default: 'false',
+  neighbor_check_delay_minutes: '10',
+  neighbor_check_text: '',
+};
+
+export function Community() {
+  const queryClient = useQueryClient();
+
+  const { data: settings, isLoading, isError } = useQuery<Record<string, string>>({
+    queryKey: ['settings'],
+    queryFn: () => api.get('/api/settings'),
+  });
+
+  const [form, setForm] = useState<CommunityForm>(DEFAULTS);
+  const [dirty, setDirty] = useState(false);
+  const [saveState, setSaveState] = useState<'idle' | 'loading' | 'success'>('idle');
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current); }, []);
+
+  useEffect(() => {
+    if (settings) {
+      setForm({
+        pulse_enabled:                settings['pulse_enabled'] ?? DEFAULTS.pulse_enabled,
+        pulse_cooldown_hours:         settings['pulse_cooldown_hours'] ?? DEFAULTS.pulse_cooldown_hours,
+        pulse_aggregate_threshold:    settings['pulse_aggregate_threshold'] ?? DEFAULTS.pulse_aggregate_threshold,
+        pulse_prompt_text:            settings['pulse_prompt_text'] ?? DEFAULTS.pulse_prompt_text,
+        topic_id_stories:             settings['topic_id_stories'] ?? DEFAULTS.topic_id_stories,
+        stories_enabled:              settings['stories_enabled'] ?? DEFAULTS.stories_enabled,
+        stories_rate_limit_minutes:   settings['stories_rate_limit_minutes'] ?? DEFAULTS.stories_rate_limit_minutes,
+        stories_max_length:           settings['stories_max_length'] ?? DEFAULTS.stories_max_length,
+        skills_public_enabled:        settings['skills_public_enabled'] ?? DEFAULTS.skills_public_enabled,
+        skills_need_radius_zones:     settings['skills_need_radius_zones'] ?? DEFAULTS.skills_need_radius_zones,
+        neighbor_check_enabled_default: settings['neighbor_check_enabled_default'] ?? DEFAULTS.neighbor_check_enabled_default,
+        neighbor_check_delay_minutes: settings['neighbor_check_delay_minutes'] ?? DEFAULTS.neighbor_check_delay_minutes,
+        neighbor_check_text:          settings['neighbor_check_text'] ?? DEFAULTS.neighbor_check_text,
+      });
+      setDirty(false);
+    }
+  }, [settings]);
+
+  const saveMutation = useMutation({
+    mutationFn: () => api.patch('/api/settings', form as unknown as Record<string, string>),
+    onMutate: () => setSaveState('loading'),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['settings'] });
+      toast.success('הגדרות קהילה נשמרו');
+      setDirty(false);
+      setSaveState('success');
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = setTimeout(() => setSaveState('idle'), 2000);
+    },
+    onError: () => {
+      toast.error('שגיאה בשמירה');
+      setSaveState('idle');
+    },
+  });
+
+  const updateField = (key: keyof CommunityForm, value: string) => {
+    setForm(f => ({ ...f, [key]: value }));
+    setDirty(true);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-16" />)}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-8 text-center text-text-muted text-sm">
+        שגיאה בטעינת הגדרות — רענן את הדף
+      </div>
+    );
+  }
+
+  return (
+    <PageTransition>
+      <div className="space-y-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <Users2 size={22} className="text-[var(--color-tg)] flex-shrink-0" />
+            <div>
+              <h1 className="text-2xl font-bold text-text-primary leading-tight">קהילה</h1>
+              <p className="text-sm text-text-muted mt-0.5">הגדרות תכונות קהילה — דופק, סיפורים, מיומנויות ובדיקת שכנים</p>
+            </div>
+          </div>
+          <button
+            disabled={!dirty || saveState === 'loading'}
+            onClick={() => saveMutation.mutate()}
+            className={`px-6 py-2 text-sm font-bold rounded-lg disabled:opacity-40 transition-colors flex items-center gap-2 min-w-[140px] justify-center ${
+              saveState === 'success'
+                ? 'bg-green text-white'
+                : 'bg-amber hover:bg-amber-dark text-black'
+            }`}
+          >
+            <AnimatePresence mode="wait">
+              {saveState === 'idle' && (
+                <motion.span key="idle" initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -4 }} transition={{ duration: 0.15 }}>
+                  שמור שינויים
+                </motion.span>
+              )}
+              {saveState === 'loading' && (
+                <motion.span key="loading" initial={{ opacity: 0, y: 4 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -4 }} transition={{ duration: 0.15 }} className="flex items-center gap-2">
+                  <Loader2 className="w-4 h-4 animate-spin" />
+                  שומר...
+                </motion.span>
+              )}
+              {saveState === 'success' && (
+                <motion.span key="success" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }} exit={{ opacity: 0, scale: 0.8 }} transition={{ duration: 0.15 }} className="flex items-center gap-2">
+                  <CheckCircle className="w-4 h-4" />
+                  נשמר!
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </button>
+        </div>
+
+        <PulseSection form={form} updateField={updateField} />
+        <StoriesSection form={form} updateField={updateField} />
+        <SkillsSection form={form} updateField={updateField} />
+        <NeighborCheckSection form={form} updateField={updateField} />
+      </div>
+    </PageTransition>
+  );
+}

--- a/dashboard-ui/src/pages/Community.tsx
+++ b/dashboard-ui/src/pages/Community.tsx
@@ -29,17 +29,17 @@ interface CommunityForm {
 
 const DEFAULTS: CommunityForm = {
   pulse_enabled: 'false',
-  pulse_cooldown_hours: '24',
+  pulse_cooldown_hours: '6',
   pulse_aggregate_threshold: '10',
   pulse_prompt_text: '',
   topic_id_stories: '0',
   stories_enabled: 'false',
   stories_rate_limit_minutes: '60',
-  stories_max_length: '500',
+  stories_max_length: '200',
   skills_public_enabled: 'false',
   skills_need_radius_zones: '3',
   neighbor_check_enabled_default: 'false',
-  neighbor_check_delay_minutes: '10',
+  neighbor_check_delay_minutes: '7',
   neighbor_check_text: '',
 };
 

--- a/dashboard-ui/src/pages/Operations.tsx
+++ b/dashboard-ui/src/pages/Operations.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Loader2, CheckCircle, Radio } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -10,6 +10,7 @@ import { GlassCard } from '../components/ui/GlassCard';
 import { PageTransition } from '../components/ui/PageTransition';
 import { AnimatedCounter } from '../components/ui/AnimatedCounter';
 import { LiveDot } from '../components/ui/LiveDot';
+import { StoryCard } from './stories/StoryCard';
 
 interface QueueStats {
   pending: number;
@@ -26,6 +27,19 @@ interface AlertWindowRow {
 
 interface OverviewStats {
   totalSubscribers: number;
+}
+
+interface StoryRowData {
+  id: number;
+  chatId: number;
+  body: string;
+  status: 'pending' | 'approved' | 'rejected' | 'published';
+  createdAt: string;
+}
+
+interface StoriesResponse {
+  stories: StoryRowData[];
+  counts: Record<string, number>;
 }
 
 function relTime(ms: number): string {
@@ -115,6 +129,36 @@ export function Operations() {
     onSuccess: () => toast.success('שולח 6 הודעות בדיקה...'),
     onError: () => toast.error('שגיאה בשליחת בדיקה'),
   });
+
+  const { data: storiesData, refetch: refetchStories } = useQuery<StoriesResponse>({
+    queryKey: ['stories-pending'],
+    queryFn: () => api.get('/api/stories?status=pending&limit=20'),
+    refetchInterval: 30_000,
+  });
+
+  const [storyLoadingId, setStoryLoadingId] = useState<number | null>(null);
+
+  const approveMutation = useMutation({
+    mutationFn: (id: number) => api.post(`/api/stories/${id}/approve`, {}),
+    onMutate: (id) => setStoryLoadingId(id),
+    onSuccess: () => { toast.success('הסיפור אושר ופורסם'); void refetchStories(); },
+    onError: () => toast.error('שגיאה באישור הסיפור'),
+    onSettled: () => setStoryLoadingId(null),
+  });
+
+  const rejectMutation = useMutation({
+    mutationFn: (id: number) => api.post(`/api/stories/${id}/reject`, {}),
+    onMutate: (id) => setStoryLoadingId(id),
+    onSuccess: () => { toast.success('הסיפור נדחה'); void refetchStories(); },
+    onError: () => toast.error('שגיאה בדחיית הסיפור'),
+    onSettled: () => setStoryLoadingId(null),
+  });
+
+  const handleApprove = useCallback((id: number) => approveMutation.mutate(id), [approveMutation]);
+  const handleReject = useCallback((id: number) => rejectMutation.mutate(id), [rejectMutation]);
+
+  const pendingStories = storiesData?.stories ?? [];
+  const pendingStoriesCount = storiesData?.counts?.['pending'] ?? 0;
 
   const parsedCities = (row: AlertWindowRow): string[] => {
     try { return JSON.parse(row.cities) as string[]; }
@@ -357,6 +401,41 @@ export function Operations() {
               {testAllMutation.isPending ? 'שולח...' : 'שלח לכל 6 הקטגוריות'}
             </button>
           </div>
+        </GlassCard>
+
+        {/* Shelter Stories */}
+        <GlassCard className="p-4">
+          <div className="flex items-center justify-between mb-1">
+            <h2 className="font-semibold text-text-primary flex items-center gap-2">
+              🏠 הודעות מהמקלט
+              {pendingStoriesCount > 0 && (
+                <span className="text-xs bg-yellow-500/20 text-yellow-400 px-2 py-0.5 rounded-full font-medium">
+                  {pendingStoriesCount} ממתינות
+                </span>
+              )}
+            </h2>
+          </div>
+          <p className="text-text-muted text-xs mb-4">
+            חוויות שמשתמשים שיתפו מהמקלט — ממתינות לאישור לפני פרסום בערוץ
+          </p>
+          {pendingStories.length === 0 ? (
+            <EmptyState icon="🏠" message="אין הודעות ממתינות לסקירה" />
+          ) : (
+            <div className="flex flex-col gap-3">
+              {pendingStories.map((story) => (
+                <StoryCard
+                  key={story.id}
+                  id={story.id}
+                  body={story.body}
+                  status={story.status}
+                  createdAt={story.createdAt}
+                  onApprove={handleApprove}
+                  onReject={handleReject}
+                  loading={storyLoadingId === story.id}
+                />
+              ))}
+            </div>
+          )}
         </GlassCard>
 
         {/* Modals */}

--- a/dashboard-ui/src/pages/community/NeighborCheckSection.tsx
+++ b/dashboard-ui/src/pages/community/NeighborCheckSection.tsx
@@ -1,0 +1,73 @@
+import { GlassCard } from '../../components/ui/GlassCard';
+import { ToggleSwitch } from '../../components/ui/ToggleSwitch';
+
+interface CommunityForm {
+  pulse_enabled: string;
+  pulse_cooldown_hours: string;
+  pulse_aggregate_threshold: string;
+  pulse_prompt_text: string;
+  topic_id_stories: string;
+  stories_enabled: string;
+  stories_rate_limit_minutes: string;
+  stories_max_length: string;
+  skills_public_enabled: string;
+  skills_need_radius_zones: string;
+  neighbor_check_enabled_default: string;
+  neighbor_check_delay_minutes: string;
+  neighbor_check_text: string;
+}
+
+interface NeighborCheckSectionProps {
+  form: CommunityForm;
+  updateField: (key: keyof CommunityForm, value: string) => void;
+}
+
+export function NeighborCheckSection({ form, updateField }: NeighborCheckSectionProps) {
+  return (
+    <GlassCard className="p-4 space-y-5">
+      <h2 className="font-semibold text-text-primary border-b border-border pb-3">
+        בדיקת שכנים (Neighbor Check)
+      </h2>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-text-secondary text-sm">בדיקת שכנים — ברירת מחדל פעילה</label>
+          <p className="text-text-muted text-xs">האם בדיקת שכנים מופעלת כברירת מחדל למנויים חדשים</p>
+        </div>
+        <ToggleSwitch
+          value={form.neighbor_check_enabled_default === 'true'}
+          onChange={v => updateField('neighbor_check_enabled_default', v ? 'true' : 'false')}
+        />
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          עיכוב לפני שליחת בדיקה (דקות)
+        </label>
+        <input
+          type="number"
+          min={1}
+          value={form.neighbor_check_delay_minutes}
+          onChange={e => updateField('neighbor_check_delay_minutes', e.target.value)}
+          className="bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber w-48"
+        />
+        <p className="text-text-muted text-xs mt-1">
+          כמה דקות לאחר ההתראה לשלוח בקשת בדיקת שלומות לשכנים
+        </p>
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          טקסט בקשת הבדיקה
+        </label>
+        <textarea
+          rows={3}
+          value={form.neighbor_check_text}
+          onChange={e => updateField('neighbor_check_text', e.target.value)}
+          placeholder="האם אתה בסדר? שכניך שואלים לשלומך."
+          className="w-full bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber resize-y"
+        />
+      </div>
+    </GlassCard>
+  );
+}

--- a/dashboard-ui/src/pages/community/PulseSection.tsx
+++ b/dashboard-ui/src/pages/community/PulseSection.tsx
@@ -1,0 +1,89 @@
+import { GlassCard } from '../../components/ui/GlassCard';
+import { ToggleSwitch } from '../../components/ui/ToggleSwitch';
+
+interface CommunityForm {
+  pulse_enabled: string;
+  pulse_cooldown_hours: string;
+  pulse_aggregate_threshold: string;
+  pulse_prompt_text: string;
+  topic_id_stories: string;
+  stories_enabled: string;
+  stories_rate_limit_minutes: string;
+  stories_max_length: string;
+  skills_public_enabled: string;
+  skills_need_radius_zones: string;
+  neighbor_check_enabled_default: string;
+  neighbor_check_delay_minutes: string;
+  neighbor_check_text: string;
+}
+
+interface PulseSectionProps {
+  form: CommunityForm;
+  updateField: (key: keyof CommunityForm, value: string) => void;
+}
+
+export function PulseSection({ form, updateField }: PulseSectionProps) {
+  return (
+    <GlassCard className="p-4 space-y-5">
+      <h2 className="font-semibold text-text-primary border-b border-border pb-3">
+        דופק קהילתי (Pulse)
+      </h2>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-text-secondary text-sm">דופק קהילתי פעיל</label>
+          <p className="text-text-muted text-xs">הפעל/כבה שליחת סקר דופק לאחר התראה</p>
+        </div>
+        <ToggleSwitch
+          value={form.pulse_enabled === 'true'}
+          onChange={v => updateField('pulse_enabled', v ? 'true' : 'false')}
+        />
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          מרווח שליחה (שעות)
+        </label>
+        <input
+          type="number"
+          min={1}
+          value={form.pulse_cooldown_hours}
+          onChange={e => updateField('pulse_cooldown_hours', e.target.value)}
+          className="bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber w-48"
+        />
+        <p className="text-text-muted text-xs mt-1">
+          כמה שעות מינימום בין שליחת סקרי דופק לאותו משתמש
+        </p>
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          סף צבירה לדשבורד
+        </label>
+        <input
+          type="number"
+          min={1}
+          value={form.pulse_aggregate_threshold}
+          onChange={e => updateField('pulse_aggregate_threshold', e.target.value)}
+          className="bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber w-48"
+        />
+        <p className="text-text-muted text-xs mt-1">
+          מינימום תגובות להצגת סיכום בדשבורד
+        </p>
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          טקסט שאלת הסקר
+        </label>
+        <textarea
+          rows={3}
+          value={form.pulse_prompt_text}
+          onChange={e => updateField('pulse_prompt_text', e.target.value)}
+          placeholder="איך אתה מרגיש אחרי ההתראה?"
+          className="w-full bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber resize-y"
+        />
+      </div>
+    </GlassCard>
+  );
+}

--- a/dashboard-ui/src/pages/community/SkillsSection.tsx
+++ b/dashboard-ui/src/pages/community/SkillsSection.tsx
@@ -1,0 +1,60 @@
+import { GlassCard } from '../../components/ui/GlassCard';
+import { ToggleSwitch } from '../../components/ui/ToggleSwitch';
+
+interface CommunityForm {
+  pulse_enabled: string;
+  pulse_cooldown_hours: string;
+  pulse_aggregate_threshold: string;
+  pulse_prompt_text: string;
+  topic_id_stories: string;
+  stories_enabled: string;
+  stories_rate_limit_minutes: string;
+  stories_max_length: string;
+  skills_public_enabled: string;
+  skills_need_radius_zones: string;
+  neighbor_check_enabled_default: string;
+  neighbor_check_delay_minutes: string;
+  neighbor_check_text: string;
+}
+
+interface SkillsSectionProps {
+  form: CommunityForm;
+  updateField: (key: keyof CommunityForm, value: string) => void;
+}
+
+export function SkillsSection({ form, updateField }: SkillsSectionProps) {
+  return (
+    <GlassCard className="p-4 space-y-5">
+      <h2 className="font-semibold text-text-primary border-b border-border pb-3">
+        שיתוף מיומנויות (Skills)
+      </h2>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-text-secondary text-sm">שיתוף מיומנויות ציבורי</label>
+          <p className="text-text-muted text-xs">אפשר לחברי קהילה להציג מיומנויות לשכנים</p>
+        </div>
+        <ToggleSwitch
+          value={form.skills_public_enabled === 'true'}
+          onChange={v => updateField('skills_public_enabled', v ? 'true' : 'false')}
+        />
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          רדיוס אזורים לצורך עזרה (מספר אזורים)
+        </label>
+        <input
+          type="number"
+          min={1}
+          value={form.skills_need_radius_zones}
+          onChange={e => updateField('skills_need_radius_zones', e.target.value)}
+          className="bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber w-48"
+        />
+        <p className="text-text-muted text-xs mt-1">
+          כמה אזורים סמוכים לחפש בהם בעלי מיומנויות רלוונטיות
+        </p>
+      </div>
+    </GlassCard>
+  );
+}

--- a/dashboard-ui/src/pages/community/StoriesSection.tsx
+++ b/dashboard-ui/src/pages/community/StoriesSection.tsx
@@ -1,0 +1,94 @@
+import { GlassCard } from '../../components/ui/GlassCard';
+import { ToggleSwitch } from '../../components/ui/ToggleSwitch';
+
+interface CommunityForm {
+  pulse_enabled: string;
+  pulse_cooldown_hours: string;
+  pulse_aggregate_threshold: string;
+  pulse_prompt_text: string;
+  topic_id_stories: string;
+  stories_enabled: string;
+  stories_rate_limit_minutes: string;
+  stories_max_length: string;
+  skills_public_enabled: string;
+  skills_need_radius_zones: string;
+  neighbor_check_enabled_default: string;
+  neighbor_check_delay_minutes: string;
+  neighbor_check_text: string;
+}
+
+interface StoriesSectionProps {
+  form: CommunityForm;
+  updateField: (key: keyof CommunityForm, value: string) => void;
+}
+
+export function StoriesSection({ form, updateField }: StoriesSectionProps) {
+  return (
+    <GlassCard className="p-4 space-y-5">
+      <h2 className="font-semibold text-text-primary border-b border-border pb-3">
+        סיפורים מהמקלט (Stories)
+      </h2>
+
+      <div className="flex items-center justify-between">
+        <div>
+          <label className="text-text-secondary text-sm">סיפורים מהמקלט פעיל</label>
+          <p className="text-text-muted text-xs">אפשר למנויים לשתף סיפורים מהמקלט</p>
+        </div>
+        <ToggleSwitch
+          value={form.stories_enabled === 'true'}
+          onChange={v => updateField('stories_enabled', v ? 'true' : 'false')}
+        />
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          מזהה נושא לפרסום סיפורים
+        </label>
+        <input
+          type="number"
+          min={0}
+          value={form.topic_id_stories}
+          onChange={e => updateField('topic_id_stories', e.target.value)}
+          placeholder="מזהה Topic בטלגרם"
+          className="bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber w-48"
+          dir="ltr"
+        />
+        <p className="text-text-muted text-xs mt-1">
+          מזהה הנושא (Topic ID) בערוץ לפרסום סיפורים מאושרים. ערך 1 אינו תקין.
+        </p>
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          מרווח שליחה (דקות)
+        </label>
+        <input
+          type="number"
+          min={1}
+          value={form.stories_rate_limit_minutes}
+          onChange={e => updateField('stories_rate_limit_minutes', e.target.value)}
+          className="bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber w-48"
+        />
+        <p className="text-text-muted text-xs mt-1">
+          כמה דקות מינימום בין שליחת סיפורים מאותו משתמש
+        </p>
+      </div>
+
+      <div>
+        <label className="text-text-secondary text-sm block mb-1">
+          אורך מקסימלי לסיפור (תווים)
+        </label>
+        <input
+          type="number"
+          min={1}
+          value={form.stories_max_length}
+          onChange={e => updateField('stories_max_length', e.target.value)}
+          className="bg-base border border-border rounded-lg px-4 py-2.5 text-sm text-text-primary outline-none focus:border-amber w-48"
+        />
+        <p className="text-text-muted text-xs mt-1">
+          מספר תווים מקסימלי לסיפור שיישלח למנחה
+        </p>
+      </div>
+    </GlassCard>
+  );
+}

--- a/dashboard-ui/src/pages/stories/StoryCard.tsx
+++ b/dashboard-ui/src/pages/stories/StoryCard.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+
+export interface StoryCardProps {
+  id: number;
+  body: string;
+  status: 'pending' | 'approved' | 'rejected' | 'published';
+  createdAt: string;
+  onApprove?: (id: number) => void;
+  onReject?: (id: number) => void;
+  loading?: boolean;
+}
+
+export function StoryCard({
+  id,
+  body,
+  status,
+  createdAt,
+  onApprove,
+  onReject,
+  loading = false,
+}: StoryCardProps): React.ReactElement {
+  const date = new Date(createdAt).toLocaleString('he-IL', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  const statusLabel: Record<typeof status, string> = {
+    pending: 'ממתין',
+    approved: 'אושר',
+    rejected: 'נדחה',
+    published: 'פורסם',
+  };
+
+  const statusColor: Record<typeof status, string> = {
+    pending: 'text-yellow-400',
+    approved: 'text-green-400',
+    rejected: 'text-red-400',
+    published: 'text-blue-400',
+  };
+
+  return (
+    <div className="rounded-xl border border-white/10 bg-white/5 p-4 flex flex-col gap-3 text-right">
+      <div className="flex items-center justify-between gap-2">
+        <span className={`text-xs font-semibold ${statusColor[status]}`}>
+          {statusLabel[status]}
+        </span>
+        <span className="text-xs text-white/40">{date}</span>
+      </div>
+
+      <p className="text-sm text-white/90 whitespace-pre-wrap break-words leading-relaxed">
+        {body}
+      </p>
+
+      {status === 'pending' && (
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={() => onApprove?.(id)}
+            disabled={loading}
+            className="px-3 py-1.5 rounded-lg bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white text-xs font-medium transition-colors"
+          >
+            אשר ופרסם
+          </button>
+          <button
+            onClick={() => onReject?.(id)}
+            disabled={loading}
+            className="px-3 py-1.5 rounded-lg bg-red-700 hover:bg-red-600 disabled:opacity-50 text-white text-xs font-medium transition-colors"
+          >
+            דחה
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@haoref-boti/pikud-haoref-bot-server",
-  "version": "0.5.0",
+  "version": "0.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@haoref-boti/pikud-haoref-bot-server",
-      "version": "0.5.0",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@grammyjs/auto-retry": "^2.0.0",

--- a/src/__tests__/alertHandler.test.ts
+++ b/src/__tests__/alertHandler.test.ts
@@ -344,6 +344,58 @@ describe('handleNewAlert', () => {
     });
   });
 
+  describe('scheduleNeighborCheck dep', () => {
+    it('calls scheduleNeighborCheck with full cities on a fresh send', async () => {
+      const scheduleNeighborCheck = mock.fn();
+      const deps = makeDeps({ scheduleNeighborCheck });
+      await handleNewAlert(BASE_ALERT, deps);
+
+      const calls = (scheduleNeighborCheck as ReturnType<typeof mock.fn>).mock.calls;
+      assert.equal(calls.length, 1, 'scheduleNeighborCheck should be called once');
+      assert.deepEqual(calls[0].arguments[0].cities, BASE_ALERT.cities, 'should pass all cities on fresh send');
+    });
+
+    it('calls scheduleNeighborCheck with ONLY new cities on edit (dmCities filter)', async () => {
+      // Active message already has תל אביב — חיפה is the new city
+      const active = makeTracked({ alert: { type: 'missiles', cities: ['תל אביב'] } });
+      const scheduleNeighborCheck = mock.fn();
+      const deps = makeDeps({
+        getActiveMessage: mock.fn(() => active),
+        scheduleNeighborCheck,
+      });
+      const alert: Alert = { type: 'missiles', cities: ['תל אביב', 'חיפה'] };
+      await handleNewAlert(alert, deps);
+
+      const calls = (scheduleNeighborCheck as ReturnType<typeof mock.fn>).mock.calls;
+      assert.equal(calls.length, 1, 'should be called once for the new city');
+      assert.deepEqual(
+        calls[0].arguments[0].cities,
+        ['חיפה'],
+        'should only include cities not already in the active window'
+      );
+    });
+
+    it('does NOT call scheduleNeighborCheck when all alert cities are already active', async () => {
+      // Active message has all cities from the incoming alert — dmCities will be empty
+      const active = makeTracked({ alert: { type: 'missiles', cities: ['תל אביב', 'חיפה'] } });
+      const scheduleNeighborCheck = mock.fn();
+      const deps = makeDeps({
+        getActiveMessage: mock.fn(() => active),
+        scheduleNeighborCheck,
+      });
+      const alert: Alert = { type: 'missiles', cities: ['תל אביב'] };
+      await handleNewAlert(alert, deps);
+
+      const calls = (scheduleNeighborCheck as ReturnType<typeof mock.fn>).mock.calls;
+      assert.equal(calls.length, 0, 'must not be called when dmCities is empty');
+    });
+
+    it('is optional — omitting scheduleNeighborCheck does not throw', async () => {
+      const deps = makeDeps(); // default makeDeps has no scheduleNeighborCheck
+      await assert.doesNotReject(async () => handleNewAlert(BASE_ALERT, deps));
+    });
+  });
+
   describe('getDensityHint dep', () => {
     it('passes density from getDensityHint to sendAlert as 5th argument', async () => {
       const deps = makeDeps({

--- a/src/__tests__/alertHandler.test.ts
+++ b/src/__tests__/alertHandler.test.ts
@@ -352,7 +352,7 @@ describe('handleNewAlert', () => {
 
       const calls = (scheduleNeighborCheck as ReturnType<typeof mock.fn>).mock.calls;
       assert.equal(calls.length, 1, 'scheduleNeighborCheck should be called once');
-      assert.deepEqual(calls[0].arguments[0].cities, BASE_ALERT.cities, 'should pass all cities on fresh send');
+      assert.deepEqual((calls[0].arguments[0] as Alert).cities, BASE_ALERT.cities, 'should pass all cities on fresh send');
     });
 
     it('calls scheduleNeighborCheck with ONLY new cities on edit (dmCities filter)', async () => {
@@ -369,7 +369,7 @@ describe('handleNewAlert', () => {
       const calls = (scheduleNeighborCheck as ReturnType<typeof mock.fn>).mock.calls;
       assert.equal(calls.length, 1, 'should be called once for the new city');
       assert.deepEqual(
-        calls[0].arguments[0].cities,
+        (calls[0].arguments[0] as Alert).cities,
         ['חיפה'],
         'should only include cities not already in the active window'
       );

--- a/src/__tests__/alertWindowTracker.test.ts
+++ b/src/__tests__/alertWindowTracker.test.ts
@@ -5,8 +5,10 @@ import {
   getActiveMessage,
   trackMessage,
   clearAll,
+  clearAllCloseTimers,
   clearMemoryOnly,
   loadActiveMessages,
+  setWindowCloseCallback,
   TrackedMessage,
 } from '../alertWindowTracker.js';
 import { initDb, closeDb } from '../db/schema.js';
@@ -142,5 +144,90 @@ describe('alertWindowTracker — DB persistence', () => {
     // loadActiveMessages should evict the expired entry rather than restore it
     loadActiveMessages();
     assert.equal(getActiveMessage('earthQuake'), null, 'expired window must not be restored from DB');
+  });
+});
+
+describe('alertWindowTracker — window close callback', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    clearAll();
+    // Reset module-level callback so it doesn't leak between tests
+    setWindowCloseCallback(() => {});
+    process.env = { ...originalEnv, ALERT_UPDATE_WINDOW_SECONDS: '120' };
+  });
+
+  afterEach(() => {
+    setWindowCloseCallback(() => {});
+    process.env = originalEnv;
+  });
+
+  it('fires callback on lazy expiry detected by getActiveMessage', () => {
+    const calls: Array<{ alertType: string; tracked: TrackedMessage }> = [];
+    setWindowCloseCallback((alertType, tracked) => calls.push({ alertType, tracked }));
+
+    // Backdating sentAt forces the lazy expiry path in getActiveMessage
+    trackMessage('missiles', makeMsg({ sentAt: Date.now() - 200_000 }));
+    const result = getActiveMessage('missiles');
+
+    assert.equal(result, null);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].alertType, 'missiles');
+    assert.equal(calls[0].tracked.messageId, 1);
+  });
+
+  it('fires callback only once — entry is evicted after first getActiveMessage', () => {
+    let callCount = 0;
+    setWindowCloseCallback(() => { callCount++; });
+
+    trackMessage('missiles', makeMsg({ sentAt: Date.now() - 200_000 }));
+
+    getActiveMessage('missiles'); // evicts and fires callback
+    getActiveMessage('missiles'); // entry gone — no second fire
+
+    assert.equal(callCount, 1);
+  });
+
+  it('does not fire callback when message is still within the active window', () => {
+    let called = false;
+    setWindowCloseCallback(() => { called = true; });
+
+    trackMessage('missiles', makeMsg()); // sentAt = Date.now()
+    getActiveMessage('missiles');
+
+    assert.equal(called, false);
+  });
+
+  it('callback receives a shallow copy, not the original tracked reference', () => {
+    let received: TrackedMessage | null = null;
+    setWindowCloseCallback((_, tracked) => { received = tracked; });
+
+    const original = makeMsg({ sentAt: Date.now() - 200_000 });
+    trackMessage('missiles', original);
+    getActiveMessage('missiles');
+
+    assert.ok(received !== null, 'callback must have been called');
+    assert.notStrictEqual(received, original);
+    assert.equal((received as TrackedMessage).messageId, original.messageId);
+  });
+
+  it('clearAllCloseTimers cancels the scheduled timer; lazy expiry path remains independent', () => {
+    const firedTypes: string[] = [];
+    setWindowCloseCallback((alertType) => firedTypes.push(alertType));
+
+    // Track a fresh message — scheduleCloseTimer sets a real setTimeout for ~120s
+    trackMessage('missiles', makeMsg());
+    // Cancel all scheduled timers (simulates graceful shutdown)
+    clearAllCloseTimers();
+
+    // Lazy expiry still works independently: evict the fresh entry and add an expired one
+    clearMemoryOnly();
+    setWindowCloseCallback((alertType) => firedTypes.push(alertType));
+    trackMessage('earthQuake', makeMsg({ sentAt: Date.now() - 200_000, alert: { type: 'earthQuake', cities: [] } }));
+    getActiveMessage('earthQuake'); // lazy path fires for earthQuake only
+
+    // Only earthQuake fired — missiles timer was cancelled, never fired
+    assert.equal(firedTypes.length, 1);
+    assert.equal(firedTypes[0], 'earthQuake');
   });
 });

--- a/src/__tests__/botSetup.test.ts
+++ b/src/__tests__/botSetup.test.ts
@@ -36,7 +36,7 @@ describe('setupBotHandlers', () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
-    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status'];
+    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status', 'share'];
     assert.equal(bot._registeredCommands.length, expected.length, `should register exactly ${expected.length} commands`);
     for (const cmd of expected) {
       assert.ok(
@@ -111,16 +111,16 @@ describe('setupBotHandlers', () => {
     assert.equal(typeof bot._getCatchHandler(), 'function', 'catch handler should be a function');
   });
 
-  it('calls bot.api.setMyCommands with all 15 commands', async () => {
+  it('calls bot.api.setMyCommands with all 16 commands', async () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
     const cmds = bot._getSetMyCommandsArg() as Array<{ command: string; description: string }>;
     assert.ok(Array.isArray(cmds), 'setMyCommands should receive an array');
-    assert.equal(cmds.length, 15, 'setMyCommands should receive exactly 15 commands');
+    assert.equal(cmds.length, 16, 'setMyCommands should receive exactly 16 commands');
 
     const commandNames = cmds.map((c) => c.command);
-    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status']) {
+    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status', 'share']) {
       assert.ok(commandNames.includes(name), `setMyCommands should include /${name}`);
     }
     // Each command must have a non-empty Hebrew description

--- a/src/__tests__/botSetup.test.ts
+++ b/src/__tests__/botSetup.test.ts
@@ -36,7 +36,7 @@ describe('setupBotHandlers', () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
-    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status', 'share'];
+    const expected = ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status', 'share', 'need'];
     assert.equal(bot._registeredCommands.length, expected.length, `should register exactly ${expected.length} commands`);
     for (const cmd of expected) {
       assert.ok(
@@ -111,16 +111,16 @@ describe('setupBotHandlers', () => {
     assert.equal(typeof bot._getCatchHandler(), 'function', 'catch handler should be a function');
   });
 
-  it('calls bot.api.setMyCommands with all 16 commands', async () => {
+  it('calls bot.api.setMyCommands with all 17 commands', async () => {
     const bot = buildMockBot();
     await setupBotHandlers(bot as unknown as Bot);
 
     const cmds = bot._getSetMyCommandsArg() as Array<{ command: string; description: string }>;
     assert.ok(Array.isArray(cmds), 'setMyCommands should receive an array');
-    assert.equal(cmds.length, 16, 'setMyCommands should receive exactly 16 commands');
+    assert.equal(cmds.length, 17, 'setMyCommands should receive exactly 17 commands');
 
     const commandNames = cmds.map((c) => c.command);
-    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status', 'share']) {
+    for (const name of ['start', 'profile', 'add', 'zones', 'mycities', 'settings', 'stats', 'history', 'connect', 'contacts', 'group', 'privacy', 'today', 'legend', 'status', 'share', 'need']) {
       assert.ok(commandNames.includes(name), `setMyCommands should include /${name}`);
     }
     // Each command must have a non-empty Hebrew description

--- a/src/__tests__/communityPulseHandler.test.ts
+++ b/src/__tests__/communityPulseHandler.test.ts
@@ -1,0 +1,185 @@
+// src/__tests__/communityPulseHandler.test.ts
+// Run via: DB_PATH=:memory: npx tsx --test src/__tests__/communityPulseHandler.test.ts
+// (npm test already sets DB_PATH=:memory: for all __tests__/*.test.ts)
+import { describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Bot } from 'grammy';
+import { initDb, getDb } from '../db/schema.js';
+import { registerCommunityPulseHandler } from '../bot/communityPulseHandler.js';
+import { createPulse } from '../db/communityPulseRepository.js';
+
+const FINGERPRINT = 'aaaa1111bbbb2222cccc3333dddd4444eeee5555';
+const CHAT_ID = 777;
+
+/**
+ * Captures handlers registered by registerCommunityPulseHandler.
+ * The handler registers two callbackQuery patterns: pulse:ok|scared|helping and pulse:agg.
+ * We return them as [answerHandler, aggHandler] in registration order.
+ */
+function captureHandlers(bot: Bot): [(ctx: unknown) => Promise<void>, (ctx: unknown) => Promise<void>] {
+  const captured: Array<(ctx: unknown) => Promise<void>> = [];
+  const mockBot = {
+    callbackQuery: (_pattern: unknown, fn: (ctx: unknown) => Promise<void>) => {
+      captured.push(fn);
+    },
+  } as unknown as Bot;
+  registerCommunityPulseHandler(mockBot);
+  if (captured.length < 2) throw new Error('expected 2 handlers from registerCommunityPulseHandler');
+  return [captured[0]!, captured[1]!];
+}
+
+/** Spy context for a pulse:ok|scared|helping callback. */
+function makeAnswerCtx(callbackData: string, fromId = CHAT_ID) {
+  const editCalls: string[] = [];
+  return {
+    ctx: {
+      from: { id: fromId },
+      callbackQuery: { data: callbackData },
+      answerCallbackQuery: async () => {},
+      editMessageText: async (text: string) => { editCalls.push(text); return { message_id: 1 }; },
+    },
+    editCalls,
+  };
+}
+
+/** Spy context for a pulse:agg callback. */
+function makeAggCtx(callbackData: string) {
+  const editCalls: string[] = [];
+  return {
+    ctx: {
+      callbackQuery: { data: callbackData },
+      answerCallbackQuery: async () => {},
+      editMessageText: async (text: string) => { editCalls.push(text); return { message_id: 1 }; },
+    },
+    editCalls,
+  };
+}
+
+describe('communityPulseHandler — answer callbacks', () => {
+  let answerHandler: (ctx: unknown) => Promise<void>;
+  let aggHandler: (ctx: unknown) => Promise<void>;
+  let pulseId: number;
+
+  before(() => {
+    initDb();
+  });
+
+  beforeEach(() => {
+    // Clean up between tests
+    getDb().prepare('DELETE FROM community_pulse_responses').run();
+    getDb().prepare('DELETE FROM community_pulses').run();
+
+    // Create a fresh pulse for each test
+    const pulse = createPulse(getDb(), FINGERPRINT, 'missiles', ['תל אביב']);
+    pulseId = pulse.id;
+
+    // Capture fresh handlers each test (singleton bot registration is idempotent via pattern match)
+    const mockBot = {
+      callbackQuery: (_p: unknown, fn: (ctx: unknown) => Promise<void>) => fn,
+    } as unknown as Bot;
+    [answerHandler, aggHandler] = captureHandlers(mockBot);
+  });
+
+  it('first response — edits message with תודה', async () => {
+    const { ctx, editCalls } = makeAnswerCtx(`pulse:ok:${pulseId}`);
+    await answerHandler(ctx);
+
+    assert.equal(editCalls.length, 1, 'editMessageText should be called once');
+    assert.ok(editCalls[0]!.includes('תודה'), `expected תודה in response: "${editCalls[0]}"`);
+  });
+
+  it('duplicate response — edits message with already-responded message', async () => {
+    const data = `pulse:scared:${pulseId}`;
+
+    // First response
+    const { ctx: ctx1 } = makeAnswerCtx(data);
+    await answerHandler(ctx1);
+
+    // Second response (same user, same pulse)
+    const { ctx: ctx2, editCalls } = makeAnswerCtx(data);
+    await answerHandler(ctx2);
+
+    assert.equal(editCalls.length, 1);
+    assert.ok(
+      editCalls[0]!.includes('כבר ענית'),
+      `expected "כבר ענית" in duplicate response: "${editCalls[0]}"`
+    );
+  });
+
+  it('different users can each respond once', async () => {
+    const data1 = `pulse:ok:${pulseId}`;
+    const data2 = `pulse:helping:${pulseId}`;
+
+    const { ctx: ctx1, editCalls: calls1 } = makeAnswerCtx(data1, 101);
+    const { ctx: ctx2, editCalls: calls2 } = makeAnswerCtx(data2, 102);
+
+    await answerHandler(ctx1);
+    await answerHandler(ctx2);
+
+    // Both should see תודה (first response each)
+    assert.ok(calls1[0]!.includes('תודה'));
+    assert.ok(calls2[0]!.includes('תודה'));
+  });
+
+  it('missing ctx.from — returns without editing', async () => {
+    const editCalls: string[] = [];
+    const ctx = {
+      from: undefined, // no sender
+      callbackQuery: { data: `pulse:ok:${pulseId}` },
+      answerCallbackQuery: async () => {},
+      editMessageText: async (text: string) => { editCalls.push(text); return { message_id: 1 }; },
+    };
+    await answerHandler(ctx);
+    // Handler returns early when from is falsy — editMessageText not called
+    assert.equal(editCalls.length, 0, 'should not edit when from is missing');
+  });
+});
+
+describe('communityPulseHandler — aggregate view callbacks', () => {
+  let answerHandler: (ctx: unknown) => Promise<void>;
+  let aggHandler: (ctx: unknown) => Promise<void>;
+  let pulseId: number;
+
+  before(() => {
+    initDb();
+  });
+
+  beforeEach(() => {
+    getDb().prepare('DELETE FROM community_pulse_responses').run();
+    getDb().prepare('DELETE FROM community_pulses').run();
+
+    const pulse = createPulse(getDb(), FINGERPRINT + '2', 'missiles', ['חיפה']);
+    pulseId = pulse.id;
+
+    const mockBot = {} as unknown as Bot;
+    [answerHandler, aggHandler] = captureHandlers(mockBot);
+  });
+
+  it('pulse:agg — below threshold shows "מוקדם" message', async () => {
+    // No responses — threshold default is 5
+    const { ctx, editCalls } = makeAggCtx(`pulse:agg:${pulseId}`);
+    await aggHandler(ctx);
+
+    assert.equal(editCalls.length, 1);
+    assert.ok(editCalls[0]!.includes('מוקדם'), `expected מוקדם in: "${editCalls[0]}"`);
+  });
+
+  it('pulse:agg — at threshold shows aggregate counts', async () => {
+    // Seed pulse_aggregate_threshold = 2 so we can hit it easily
+    getDb().prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('pulse_aggregate_threshold', '2')`).run();
+
+    // Seed 2 responses from different users
+    getDb().prepare('INSERT INTO community_pulse_responses (pulse_id, chat_id, answer) VALUES (?, ?, ?)').run(pulseId, 801, 'ok');
+    getDb().prepare('INSERT INTO community_pulse_responses (pulse_id, chat_id, answer) VALUES (?, ?, ?)').run(pulseId, 802, 'scared');
+
+    const { ctx, editCalls } = makeAggCtx(`pulse:agg:${pulseId}`);
+    await aggHandler(ctx);
+
+    assert.equal(editCalls.length, 1);
+    assert.ok(editCalls[0]!.includes('תוצאות'), `expected תוצאות in: "${editCalls[0]}"`);
+    assert.ok(editCalls[0]!.includes('2'), 'should show total count');
+
+    // Cleanup settings
+    getDb().prepare(`DELETE FROM settings WHERE key = 'pulse_aggregate_threshold'`).run();
+  });
+});

--- a/src/__tests__/communityPulseRepository.test.ts
+++ b/src/__tests__/communityPulseRepository.test.ts
@@ -1,0 +1,127 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  createPulse,
+  getPulseByFingerprint,
+  insertResponse,
+  getAggregate,
+  getLastResponseTime,
+} from '../db/communityPulseRepository.js';
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  return db;
+}
+
+describe('communityPulseRepository', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = createTestDb();
+  });
+
+  test('createPulse inserts row and returns it', () => {
+    const fp = 'abc123';
+    const row = createPulse(db, fp, 'missiles', ['תל אביב']);
+    assert.equal(row.fingerprint, fp);
+    assert.equal(row.alertType, 'missiles');
+    assert.deepEqual(row.zones, ['תל אביב']);
+    assert.ok(typeof row.id === 'number' && row.id > 0);
+    assert.ok(typeof row.createdAt === 'string');
+  });
+
+  test('createPulse on duplicate fingerprint returns existing row (INSERT OR IGNORE)', () => {
+    const fp = 'dup_fp';
+    const first = createPulse(db, fp, 'missiles', ['תל אביב']);
+    const second = createPulse(db, fp, 'missiles', ['תל אביב']);
+    assert.equal(first.id, second.id, 'should return same row id on duplicate');
+    const count = (db.prepare('SELECT COUNT(*) as c FROM community_pulses WHERE fingerprint = ?').get(fp) as { c: number }).c;
+    assert.equal(count, 1, 'only one row should exist');
+  });
+
+  test('getPulseByFingerprint returns null for unknown fingerprint', () => {
+    const result = getPulseByFingerprint(db, 'nonexistent');
+    assert.equal(result, null);
+  });
+
+  test('getPulseByFingerprint returns row after creation', () => {
+    createPulse(db, 'fp_known', 'missiles', ['ירושלים']);
+    const result = getPulseByFingerprint(db, 'fp_known');
+    assert.ok(result !== null);
+    assert.equal(result.alertType, 'missiles');
+    assert.deepEqual(result.zones, ['ירושלים']);
+  });
+
+  test('insertResponse INSERT OR IGNORE — second call same (pulseId, chatId) is silent no-op', () => {
+    const pulse = createPulse(db, 'fp_resp', 'missiles', []);
+
+    // First insert a user row (community_pulse_responses has no FK to users, so raw insert works)
+    insertResponse(db, pulse.id, 1001, 'ok');
+    insertResponse(db, pulse.id, 1001, 'scared'); // same (pulseId, chatId) — must be ignored
+
+    const count = (db.prepare(
+      'SELECT COUNT(*) as c FROM community_pulse_responses WHERE pulse_id = ? AND chat_id = ?'
+    ).get(pulse.id, 1001) as { c: number }).c;
+    assert.equal(count, 1, 'duplicate response should be ignored');
+
+    // The stored answer should still be the first one
+    const row = db.prepare(
+      'SELECT answer FROM community_pulse_responses WHERE pulse_id = ? AND chat_id = ?'
+    ).get(pulse.id, 1001) as { answer: string };
+    assert.equal(row.answer, 'ok', 'first answer should be preserved');
+  });
+
+  test('getAggregate returns correct counts', () => {
+    const pulse = createPulse(db, 'fp_agg', 'missiles', []);
+    insertResponse(db, pulse.id, 1, 'ok');
+    insertResponse(db, pulse.id, 2, 'ok');
+    insertResponse(db, pulse.id, 3, 'scared');
+    insertResponse(db, pulse.id, 4, 'helping');
+    insertResponse(db, pulse.id, 5, 'helping');
+
+    const agg = getAggregate(db, pulse.id);
+    assert.equal(agg.total, 5);
+    assert.equal(agg.ok, 2);
+    assert.equal(agg.scared, 1);
+    assert.equal(agg.helping, 2);
+  });
+
+  test('getAggregate returns zeros when no responses', () => {
+    const pulse = createPulse(db, 'fp_empty', 'missiles', []);
+    const agg = getAggregate(db, pulse.id);
+    assert.equal(agg.total, 0);
+    assert.equal(agg.ok, 0);
+    assert.equal(agg.scared, 0);
+    assert.equal(agg.helping, 0);
+  });
+
+  test('getLastResponseTime returns null when no responses for chatId', () => {
+    const result = getLastResponseTime(db, 9999);
+    assert.equal(result, null);
+  });
+
+  test('getLastResponseTime returns ISO string when has one response', () => {
+    const pulse = createPulse(db, 'fp_lrt', 'missiles', []);
+    insertResponse(db, pulse.id, 2001, 'ok');
+
+    const result = getLastResponseTime(db, 2001);
+    assert.ok(result !== null, 'should return a string');
+    // ISO datetime format from SQLite: YYYY-MM-DD HH:MM:SS
+    assert.ok(result.length > 0);
+  });
+
+  test('getLastResponseTime returns most recent when multiple responses across pulses', () => {
+    const p1 = createPulse(db, 'fp_t1', 'missiles', []);
+    const p2 = createPulse(db, 'fp_t2', 'aircraft', []);
+    insertResponse(db, p1.id, 3001, 'ok');
+    insertResponse(db, p2.id, 3001, 'scared');
+
+    const result = getLastResponseTime(db, 3001);
+    assert.ok(result !== null);
+  });
+});

--- a/src/__tests__/communityPulseService.test.ts
+++ b/src/__tests__/communityPulseService.test.ts
@@ -1,0 +1,179 @@
+import { test, describe, before, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Bot } from 'grammy';
+import { initDb, getDb, closeDb } from '../db/schema.js';
+import { fireCommunityPulse } from '../services/communityPulseService.js';
+import type { TrackedMessage } from '../alertWindowTracker.js';
+
+// Use the singleton DB with in-memory path so getUsersForCities / configResolver work correctly.
+before(() => {
+  process.env['DB_PATH'] = ':memory:';
+  initDb();
+});
+
+function createTrackedMessage(cities: string[] = ['תל אביב']): TrackedMessage {
+  return {
+    messageId: 42,
+    chatId: '-100123456',
+    topicId: undefined,
+    alert: {
+      type: 'missiles',
+      cities,
+      instructions: 'היכנסו למרחב מוגן',
+      receivedAt: Date.now(),
+    },
+    sentAt: Date.now(),
+    hasPhoto: false,
+  };
+}
+
+function createMockBot(): Bot {
+  return {
+    api: {
+      sendMessage: mock.fn(async () => ({ message_id: 1 })),
+    },
+  } as unknown as Bot;
+}
+
+function setSetting(key: string, value: string): void {
+  getDb().prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)`).run(key, value);
+}
+
+function deleteSetting(key: string): void {
+  getDb().prepare(`DELETE FROM settings WHERE key = ?`).run(key);
+}
+
+function insertUserWithSub(chatId: number, city: string): void {
+  getDb().prepare(`INSERT OR IGNORE INTO users (chat_id) VALUES (?)`).run(chatId);
+  getDb().prepare(`INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)`).run(chatId, city);
+}
+
+describe('fireCommunityPulse', () => {
+  beforeEach(() => {
+    // Clean slate per test
+    getDb().prepare(`DELETE FROM community_pulse_responses`).run();
+    getDb().prepare(`DELETE FROM community_pulses`).run();
+    getDb().prepare(`DELETE FROM subscriptions`).run();
+    getDb().prepare(`DELETE FROM users`).run();
+    deleteSetting('pulse_enabled');
+    deleteSetting('pulse_cooldown_hours');
+    deleteSetting('pulse_aggregate_threshold');
+    deleteSetting('pulse_prompt_text');
+  });
+
+  test('returns early when pulse_enabled=false', async () => {
+    setSetting('pulse_enabled', 'false');
+    const bot = createMockBot();
+    insertUserWithSub(1001, 'תל אביב');
+
+    await fireCommunityPulse(getDb(), bot, 'missiles', createTrackedMessage());
+
+    const sendMock = bot.api.sendMessage as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(sendMock.mock.calls.length, 0, 'should not send any DMs when disabled');
+  });
+
+  test('calls createPulse exactly once for same fingerprint on multiple calls', async () => {
+    const bot = createMockBot();
+    insertUserWithSub(2001, 'תל אביב');
+    const tracked = createTrackedMessage(['תל אביב']);
+    const db = getDb();
+
+    const tasks1: Array<() => Promise<void>> = [];
+    const tasks2: Array<() => Promise<void>> = [];
+
+    await fireCommunityPulse(db, bot, 'missiles', tracked, { enqueue: (ts) => tasks1.push(...ts) });
+    await fireCommunityPulse(db, bot, 'missiles', tracked, { enqueue: (ts) => tasks2.push(...ts) });
+
+    const fp = db.prepare(`SELECT COUNT(*) as c FROM community_pulses WHERE alert_type = 'missiles'`).get() as { c: number };
+    assert.equal(fp.c, 1, 'only one pulse row should exist');
+  });
+
+  test('fires DM with correct callback data (pulse:ok, pulse:scared, pulse:helping)', async () => {
+    insertUserWithSub(3001, 'תל אביב');
+
+    const sentMessages: Array<{ chatId: number; text: string; opts: unknown }> = [];
+    const bot: Bot = {
+      api: {
+        sendMessage: mock.fn(async (chatId: number, text: string, opts: unknown) => {
+          sentMessages.push({ chatId, text, opts });
+          return { message_id: 1 };
+        }),
+      },
+    } as unknown as Bot;
+
+    const tasks: Array<() => Promise<void>> = [];
+    await fireCommunityPulse(getDb(), bot, 'missiles', createTrackedMessage(['תל אביב']), {
+      enqueue: (ts) => tasks.push(...ts),
+    });
+
+    await Promise.all(tasks.map((fn) => fn()));
+
+    assert.equal(sentMessages.length, 1, 'should send exactly one DM');
+    const opts = sentMessages[0].opts as { reply_markup: { inline_keyboard: Array<Array<{ callback_data: string }>> } };
+    const buttons = opts.reply_markup.inline_keyboard[0];
+    const cbData = buttons.map((b) => b.callback_data);
+
+    assert.ok(cbData.some((d) => d.startsWith('pulse:ok:')), 'should have ok callback');
+    assert.ok(cbData.some((d) => d.startsWith('pulse:scared:')), 'should have scared callback');
+    assert.ok(cbData.some((d) => d.startsWith('pulse:helping:')), 'should have helping callback');
+  });
+
+  test('skips user with is_dm_active=0', async () => {
+    const db = getDb();
+    db.prepare(`INSERT OR IGNORE INTO users (chat_id, is_dm_active) VALUES (?, 0)`).run(4001);
+    db.prepare(`INSERT OR IGNORE INTO subscriptions (chat_id, city_name) VALUES (?, ?)`).run(4001, 'תל אביב');
+
+    const bot = createMockBot();
+    const tasks: Array<() => Promise<void>> = [];
+    await fireCommunityPulse(db, bot, 'missiles', createTrackedMessage(['תל אביב']), {
+      enqueue: (ts) => tasks.push(...ts),
+    });
+
+    assert.equal(tasks.length, 0, 'should not enqueue tasks for inactive DM users');
+  });
+
+  test('skips user whose last response was within cooldown window', async () => {
+    insertUserWithSub(5001, 'תל אביב');
+    setSetting('pulse_cooldown_hours', '6');
+    const db = getDb();
+
+    const pulse = db.prepare(
+      `INSERT INTO community_pulses (fingerprint, alert_type, zones) VALUES ('old_fp', 'missiles', '[]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO community_pulse_responses (pulse_id, chat_id, answer) VALUES (?, ?, 'ok')`
+    ).run(pulse.lastInsertRowid, 5001);
+
+    const bot = createMockBot();
+    const tasks: Array<() => Promise<void>> = [];
+    const now = new Date();
+    await fireCommunityPulse(db, bot, 'missiles', createTrackedMessage(['תל אביב']), {
+      enqueue: (ts) => tasks.push(...ts),
+      now,
+    });
+
+    assert.equal(tasks.length, 0, 'should skip user within cooldown window');
+  });
+
+  test('sends DM when user last responded more than cooldown hours ago', async () => {
+    insertUserWithSub(6001, 'תל אביב');
+    setSetting('pulse_cooldown_hours', '1');
+    const db = getDb();
+
+    const pulse = db.prepare(
+      `INSERT INTO community_pulses (fingerprint, alert_type, zones) VALUES ('old_fp2', 'missiles', '[]')`
+    ).run();
+    db.prepare(
+      `INSERT INTO community_pulse_responses (pulse_id, chat_id, answer, created_at)
+       VALUES (?, ?, 'ok', datetime('now', '-2 hours'))`
+    ).run(pulse.lastInsertRowid, 6001);
+
+    const bot = createMockBot();
+    const tasks: Array<() => Promise<void>> = [];
+    await fireCommunityPulse(db, bot, 'missiles', createTrackedMessage(['תל אביב']), {
+      enqueue: (ts) => tasks.push(...ts),
+    });
+
+    assert.equal(tasks.length, 1, 'should enqueue DM when past cooldown');
+  });
+});

--- a/src/__tests__/dashboard/routes/settings.community.test.ts
+++ b/src/__tests__/dashboard/routes/settings.community.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import express from 'express';
+import request from 'supertest';
+import { initSchema } from '../../../db/schema.js';
+import { createSettingsRouter, settingsMutateLimiter } from '../../../dashboard/routes/settings.js';
+
+let db: Database.Database;
+let app: express.Express;
+
+before(() => {
+  db = new Database(':memory:');
+  initSchema(db);
+
+  app = express();
+  app.use(express.json());
+  app.use('/api/settings', createSettingsRouter(db));
+});
+
+beforeEach(() => {
+  db.prepare('DELETE FROM settings').run();
+  settingsMutateLimiter.clearStore();
+});
+
+after(() => db.close());
+
+// ─── Pulse section ────────────────────────────────────────────────────────────
+
+describe('PATCH /api/settings — pulse keys', () => {
+  it('accepts pulse_enabled=true', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_enabled: 'true' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+  });
+
+  it('accepts pulse_enabled=false', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_enabled: 'false' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects pulse_enabled=yes (not boolean)', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_enabled: 'yes' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('pulse_enabled'));
+  });
+
+  it('accepts pulse_cooldown_hours=24', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_cooldown_hours: '24' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+  });
+
+  it('accepts pulse_cooldown_hours=1 (boundary)', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_cooldown_hours: '1' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects pulse_cooldown_hours=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_cooldown_hours: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('pulse_cooldown_hours'));
+  });
+
+  it('rejects pulse_cooldown_hours=-1 (negative)', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_cooldown_hours: '-1' });
+    assert.equal(res.status, 400);
+  });
+
+  it('accepts pulse_aggregate_threshold=10', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_aggregate_threshold: '10' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects pulse_aggregate_threshold=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ pulse_aggregate_threshold: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('pulse_aggregate_threshold'));
+  });
+
+  it('accepts pulse_prompt_text (free text)', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ pulse_prompt_text: 'איך אתה מרגיש?' });
+    assert.equal(res.status, 200);
+  });
+});
+
+// ─── Stories section ──────────────────────────────────────────────────────────
+
+describe('PATCH /api/settings — stories keys', () => {
+  it('accepts topic_id_stories=0 (valid non-neg int)', async () => {
+    const res = await request(app).patch('/api/settings').send({ topic_id_stories: '0' });
+    assert.equal(res.status, 200);
+  });
+
+  it('accepts topic_id_stories=42', async () => {
+    const res = await request(app).patch('/api/settings').send({ topic_id_stories: '42' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects topic_id_stories=1 (reserved Telegram thread ID)', async () => {
+    const res = await request(app).patch('/api/settings').send({ topic_id_stories: '1' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('topic_id_stories'));
+  });
+
+  it('rejects topic_id_stories=-1 (negative)', async () => {
+    const res = await request(app).patch('/api/settings').send({ topic_id_stories: '-1' });
+    assert.equal(res.status, 400);
+  });
+
+  it('accepts stories_enabled=false', async () => {
+    const res = await request(app).patch('/api/settings').send({ stories_enabled: 'false' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects stories_enabled=1 (not boolean)', async () => {
+    const res = await request(app).patch('/api/settings').send({ stories_enabled: '1' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('stories_enabled'));
+  });
+
+  it('accepts stories_rate_limit_minutes=60', async () => {
+    const res = await request(app).patch('/api/settings').send({ stories_rate_limit_minutes: '60' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects stories_rate_limit_minutes=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ stories_rate_limit_minutes: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('stories_rate_limit_minutes'));
+  });
+
+  it('accepts stories_max_length=500', async () => {
+    const res = await request(app).patch('/api/settings').send({ stories_max_length: '500' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects stories_max_length=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ stories_max_length: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('stories_max_length'));
+  });
+});
+
+// ─── Skills section ───────────────────────────────────────────────────────────
+
+describe('PATCH /api/settings — skills keys', () => {
+  it('accepts skills_public_enabled=true', async () => {
+    const res = await request(app).patch('/api/settings').send({ skills_public_enabled: 'true' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects skills_public_enabled=on (not boolean)', async () => {
+    const res = await request(app).patch('/api/settings').send({ skills_public_enabled: 'on' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('skills_public_enabled'));
+  });
+
+  it('accepts skills_need_radius_zones=3', async () => {
+    const res = await request(app).patch('/api/settings').send({ skills_need_radius_zones: '3' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects skills_need_radius_zones=0 (must be ≥1)', async () => {
+    const res = await request(app).patch('/api/settings').send({ skills_need_radius_zones: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('skills_need_radius_zones'));
+  });
+});
+
+// ─── Neighbor check section ───────────────────────────────────────────────────
+
+describe('PATCH /api/settings — neighbor check keys', () => {
+  it('accepts neighbor_check_enabled_default=false', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ neighbor_check_enabled_default: 'false' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects neighbor_check_enabled_default=yes (not boolean)', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ neighbor_check_enabled_default: 'yes' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('neighbor_check_enabled_default'));
+  });
+
+  it('accepts neighbor_check_delay_minutes=10', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ neighbor_check_delay_minutes: '10' });
+    assert.equal(res.status, 200);
+  });
+
+  it('rejects neighbor_check_delay_minutes=0 (must be ≥1)', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ neighbor_check_delay_minutes: '0' });
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('neighbor_check_delay_minutes'));
+  });
+
+  it('accepts neighbor_check_text (free text)', async () => {
+    const res = await request(app)
+      .patch('/api/settings')
+      .send({ neighbor_check_text: 'האם אתה בסדר?' });
+    assert.equal(res.status, 200);
+  });
+});
+
+// ─── All 13 keys together ─────────────────────────────────────────────────────
+
+describe('PATCH /api/settings — all 13 community keys together', () => {
+  it('accepts all 13 community keys in a single PATCH', async () => {
+    const res = await request(app).patch('/api/settings').send({
+      pulse_enabled: 'true',
+      pulse_cooldown_hours: '24',
+      pulse_aggregate_threshold: '5',
+      pulse_prompt_text: 'שאלה בדיקה',
+      topic_id_stories: '42',
+      stories_enabled: 'true',
+      stories_rate_limit_minutes: '30',
+      stories_max_length: '300',
+      skills_public_enabled: 'false',
+      skills_need_radius_zones: '2',
+      neighbor_check_enabled_default: 'true',
+      neighbor_check_delay_minutes: '15',
+      neighbor_check_text: 'בדיקה',
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+  });
+
+  it('rejects when any one of the 13 keys is invalid (no partial write)', async () => {
+    const res = await request(app).patch('/api/settings').send({
+      pulse_enabled: 'true',
+      pulse_cooldown_hours: '0', // invalid — triggers 400
+    });
+    assert.equal(res.status, 400);
+    // pulse_enabled must NOT have been written
+    const row = db.prepare("SELECT value FROM settings WHERE key = 'pulse_enabled'").get();
+    assert.equal(row, undefined, 'pulse_enabled must not have been written before validation failed');
+  });
+});

--- a/src/__tests__/dashboard/routes/stories.test.ts
+++ b/src/__tests__/dashboard/routes/stories.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, before, after, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import request from 'supertest';
+import { initSchema } from '../../../db/schema.js';
+import { createStoriesRouter, storiesLimiter } from '../../../dashboard/routes/stories.js';
+import { createSessionStore } from '../../../dashboard/auth.js';
+import type { Bot } from 'grammy';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+let db: Database.Database;
+let appNoAuth: express.Express;   // router mounted directly (no auth — for most tests)
+let appWithAuth: express.Express; // router behind real auth middleware (for 401 test)
+
+const mockBot = {
+  api: { sendMessage: async () => ({ message_id: 42 }) },
+} as unknown as Bot;
+
+const AUTH_SECRET = 'test-secret-stories';
+const CHAT_ID = 77001;
+
+before(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  db.prepare('INSERT OR IGNORE INTO users (chat_id) VALUES (?)').run(CHAT_ID);
+  db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES ('topic_id_stories', '500', 0)").run();
+  process.env['TELEGRAM_CHAT_ID'] = '-100999999';
+
+  // App without auth — tests that verify business logic
+  appNoAuth = express();
+  appNoAuth.use(express.json());
+  appNoAuth.use('/api/stories', createStoriesRouter(db, mockBot));
+
+  // App with auth middleware — tests that verify 401 behavior
+  const { authMiddleware } = createSessionStore(db, AUTH_SECRET);
+  appWithAuth = express();
+  appWithAuth.use(cookieParser());
+  appWithAuth.use(express.json());
+  appWithAuth.use('/api/stories', authMiddleware, createStoriesRouter(db, mockBot));
+});
+
+after(() => db.close());
+
+beforeEach(() => {
+  storiesLimiter.clearStore();
+  db.prepare('DELETE FROM shelter_stories').run();
+  db.prepare("DELETE FROM settings WHERE key = 'topic_id_stories'").run();
+  db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES ('topic_id_stories', '500', 0)").run();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GET /api/stories', () => {
+  it('returns pending stories and counts', async () => {
+    db.prepare('INSERT INTO shelter_stories (chat_id, body) VALUES (?,?)').run(CHAT_ID, 'סיפור ראשון');
+    db.prepare('INSERT INTO shelter_stories (chat_id, body) VALUES (?,?)').run(CHAT_ID, 'סיפור שני');
+
+    const res = await request(appNoAuth).get('/api/stories?status=pending');
+    assert.equal(res.status, 200);
+    assert.ok(Array.isArray(res.body.stories), 'stories should be an array');
+    assert.equal(res.body.stories.length, 2);
+    assert.ok('counts' in res.body, 'response should include counts');
+  });
+});
+
+describe('POST /api/stories/:id/approve', () => {
+  it('returns 400 when topic_id_stories is unset (0)', async () => {
+    db.prepare("DELETE FROM settings WHERE key = 'topic_id_stories'").run();
+    db.prepare('INSERT INTO shelter_stories (chat_id, body) VALUES (?,?)').run(CHAT_ID, 'סיפור');
+    const row = db.prepare('SELECT id FROM shelter_stories ORDER BY id DESC LIMIT 1').get() as { id: number };
+
+    const res = await request(appNoAuth).post(`/api/stories/${row.id}/approve`).send({});
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('topic_id_stories'), `expected topic error, got: ${JSON.stringify(res.body)}`);
+  });
+
+  it('returns 400 when topic_id_stories is 1 (reserved)', async () => {
+    db.prepare("DELETE FROM settings WHERE key = 'topic_id_stories'").run();
+    db.prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES ('topic_id_stories', '1', 0)").run();
+    db.prepare('INSERT INTO shelter_stories (chat_id, body) VALUES (?,?)').run(CHAT_ID, 'סיפור');
+    const row = db.prepare('SELECT id FROM shelter_stories ORDER BY id DESC LIMIT 1').get() as { id: number };
+
+    const res = await request(appNoAuth).post(`/api/stories/${row.id}/approve`).send({});
+    assert.equal(res.status, 400);
+    assert.ok(res.body.error.includes('topic_id_stories'));
+  });
+
+  it('approves story successfully — calls sendMessage and stores messageId', async () => {
+    db.prepare('INSERT INTO shelter_stories (chat_id, body) VALUES (?,?)').run(CHAT_ID, 'חוויה אמיתית');
+    const row = db.prepare('SELECT id FROM shelter_stories ORDER BY id DESC LIMIT 1').get() as { id: number };
+
+    const res = await request(appNoAuth).post(`/api/stories/${row.id}/approve`).send({});
+    assert.equal(res.status, 200, `expected 200, got: ${JSON.stringify(res.body)}`);
+    assert.equal(res.body.ok, true);
+    assert.equal(typeof res.body.messageId, 'number');
+
+    const updated = db.prepare('SELECT * FROM shelter_stories WHERE id = ?').get(row.id) as { status: string; published_message_id: number };
+    assert.equal(updated.status, 'published');
+    assert.equal(updated.published_message_id, 42);
+  });
+
+  it('returns 409 when story is already processed', async () => {
+    db.prepare('INSERT INTO shelter_stories (chat_id, body, status) VALUES (?,?,?)').run(CHAT_ID, 'נדחה', 'rejected');
+    const row = db.prepare("SELECT id FROM shelter_stories WHERE status = 'rejected' ORDER BY id DESC LIMIT 1").get() as { id: number };
+
+    const res = await request(appNoAuth).post(`/api/stories/${row.id}/approve`).send({});
+    assert.equal(res.status, 409);
+  });
+});
+
+describe('POST /api/stories/:id/reject', () => {
+  it('rejects story successfully', async () => {
+    db.prepare('INSERT INTO shelter_stories (chat_id, body) VALUES (?,?)').run(CHAT_ID, 'לדחות');
+    const row = db.prepare('SELECT id FROM shelter_stories ORDER BY id DESC LIMIT 1').get() as { id: number };
+
+    const res = await request(appNoAuth).post(`/api/stories/${row.id}/reject`).send({});
+    assert.equal(res.status, 200);
+    assert.equal(res.body.ok, true);
+
+    const updated = db.prepare('SELECT status FROM shelter_stories WHERE id = ?').get(row.id) as { status: string };
+    assert.equal(updated.status, 'rejected');
+  });
+});
+
+describe('Rate limiter', () => {
+  it('storiesLimiter.clearStore() resets between tests', async () => {
+    // clearStore is called in beforeEach — subsequent requests should pass
+    const res = await request(appNoAuth).get('/api/stories');
+    assert.ok(res.status !== 429, 'should not be rate limited after clearStore');
+  });
+});
+
+describe('Auth guard', () => {
+  it('returns 401 without a valid session cookie', async () => {
+    const res = await request(appWithAuth).get('/api/stories');
+    assert.equal(res.status, 401);
+  });
+});

--- a/src/__tests__/groupHandler.delete.test.ts
+++ b/src/__tests__/groupHandler.delete.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for /group delete subcommand and gdel:conf / gdel:cancel callback logic.
+ *
+ * Strategy: exercise the repository layer (deleteGroup, insertAudit, getMembersOfGroup)
+ * directly with an :memory: DB, and test the pendingDeletes nonce map in isolation.
+ * Grammy handler integration (ctx.reply / wrapCallback) is covered separately by botSetup
+ * structural tests; here we focus on the data-layer invariants.
+ *
+ * Run with: npx tsx --test src/__tests__/groupHandler.delete.test.ts
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import { createGroup, deleteGroup, getMembersOfGroup, addMember } from '../db/groupRepository.js';
+import { insertAudit } from '../db/groupAuditRepository.js';
+import { pendingDeletes } from '../bot/groupHandler.js';
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  return db;
+}
+
+function insertUser(db: Database.Database, chatId: number): void {
+  db.prepare('INSERT OR IGNORE INTO users (chat_id) VALUES (?)').run(chatId);
+}
+
+describe('groupHandler.delete — repository layer', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = makeDb();
+    pendingDeletes.clear();
+  });
+
+  it('deleteGroup removes group and CASCADE-deletes group_members', () => {
+    insertUser(db, 100);
+    insertUser(db, 200);
+    const group = createGroup(db, { name: 'TestGroup', ownerId: 100, inviteCode: 'ABCDEF' });
+    addMember(db, group.id, 200);
+
+    const membersBefore = getMembersOfGroup(db, group.id);
+    assert.equal(membersBefore.length, 2, 'group should have 2 members before delete');
+
+    deleteGroup(db, group.id);
+
+    const membersAfter = getMembersOfGroup(db, group.id);
+    assert.equal(membersAfter.length, 0, 'all members should be removed via CASCADE');
+
+    const row = db.prepare('SELECT id FROM groups WHERE id = ?').get(group.id);
+    assert.equal(row, undefined, 'group row itself should be deleted');
+  });
+
+  it('insertAudit persists a deleted action and survives group deletion', () => {
+    insertUser(db, 100);
+    const group = createGroup(db, { name: 'AuditGroup', ownerId: 100, inviteCode: 'ZZZZZZ' });
+    const groupId = group.id;
+
+    // Insert audit BEFORE deleting (to simulate normal flow)
+    // But audit must survive the delete (no FK)
+    deleteGroup(db, groupId);
+    insertAudit(db, { groupId, action: 'deleted', actorId: 100, payload: null });
+
+    const row = db.prepare('SELECT * FROM group_audit WHERE group_id = ?').get(groupId) as {
+      group_id: number;
+      action: string;
+      actor_id: number;
+      payload: null;
+    } | undefined;
+
+    assert.ok(row, 'audit row should exist after group is deleted');
+    assert.equal(row.group_id, groupId);
+    assert.equal(row.action, 'deleted');
+    assert.equal(row.actor_id, 100);
+    assert.equal(row.payload, null);
+  });
+
+  it('members list captured before delete identifies other members to notify', () => {
+    insertUser(db, 100);
+    insertUser(db, 200);
+    insertUser(db, 300);
+    const group = createGroup(db, { name: 'MultiGroup', ownerId: 100, inviteCode: 'MULTI1' });
+    addMember(db, group.id, 200);
+    addMember(db, group.id, 300);
+
+    const chatId = 100; // owner
+    const members = getMembersOfGroup(db, group.id);
+    const otherMembers = members.filter((m) => m.userId !== chatId);
+
+    assert.equal(otherMembers.length, 2, 'should identify 2 other members to notify');
+    const ids = otherMembers.map((m) => m.userId).sort();
+    assert.deepEqual(ids, [200, 300]);
+  });
+
+  it('non-owner cannot find group in their owned-group list', () => {
+    insertUser(db, 100);
+    insertUser(db, 200);
+    const group = createGroup(db, { name: 'OwnedGroup', ownerId: 100, inviteCode: 'OWNR11' });
+    addMember(db, group.id, 200);
+
+    // Simulate what handleDelete does: find by name AND ownerId match
+    const groupsForOwner = db.prepare(
+      `SELECT g.* FROM groups g
+       INNER JOIN group_members gm ON gm.group_id = g.id
+       WHERE gm.user_id = ? ORDER BY g.created_at DESC`
+    ).all(100) as Array<{ id: number; name: string; owner_id: number }>;
+
+    const found = groupsForOwner.find((g) => g.name === 'OwnedGroup' && g.owner_id === 100);
+    assert.ok(found, 'owner should find their group');
+
+    const groupsForNonOwner = db.prepare(
+      `SELECT g.* FROM groups g
+       INNER JOIN group_members gm ON gm.group_id = g.id
+       WHERE gm.user_id = ? ORDER BY g.created_at DESC`
+    ).all(200) as Array<{ id: number; name: string; owner_id: number }>;
+
+    const notFound = groupsForNonOwner.find((g) => g.name === 'OwnedGroup' && g.owner_id === 200);
+    assert.equal(notFound, undefined, 'non-owner should not find group when filtering by ownerId');
+  });
+
+  it('pendingDeletes nonce: expired entry is detected via Date.now() > expiresAt', () => {
+    // Set an already-expired entry
+    pendingDeletes.set(100, { groupId: 1, nonce: 'abc12345', expiresAt: Date.now() - 1 });
+
+    const pending = pendingDeletes.get(100);
+    assert.ok(pending, 'entry should exist');
+    assert.ok(Date.now() > pending.expiresAt, 'entry should be expired');
+  });
+
+  it('pendingDeletes nonce: nonce mismatch is detected', () => {
+    pendingDeletes.set(100, { groupId: 1, nonce: 'correctnonce1', expiresAt: Date.now() + 60_000 });
+
+    const pending = pendingDeletes.get(100);
+    assert.ok(pending);
+    assert.notEqual(pending.nonce, 'wrongnonce12', 'different nonce should not match');
+  });
+
+  it('pendingDeletes: cancel removes the entry', () => {
+    pendingDeletes.set(100, { groupId: 1, nonce: 'aabbccdd', expiresAt: Date.now() + 60_000 });
+    assert.ok(pendingDeletes.has(100));
+
+    pendingDeletes.delete(100);
+    assert.equal(pendingDeletes.has(100), false, 'cancel should remove the entry');
+  });
+
+  it('group_audit table: check constraint rejects invalid action', () => {
+    // The group_audit table has CHECK (action IN ('deleted','transferred'))
+    // Inserting a bad action should throw
+    let threw = false;
+    try {
+      db.prepare(
+        `INSERT INTO group_audit (group_id, action, actor_id, payload, created_at)
+         VALUES (?, ?, ?, ?, datetime('now'))`
+      ).run(1, 'hacked', 100, null);
+    } catch {
+      threw = true;
+    }
+    assert.ok(threw, 'invalid action should throw a constraint error');
+  });
+});

--- a/src/__tests__/groupHandler.transfer.test.ts
+++ b/src/__tests__/groupHandler.transfer.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Tests for /group transfer subcommand logic.
+ *
+ * Strategy: exercise transferOwnership and insertAudit directly with an :memory: DB.
+ * Validates the TOCTOU guard, membership check, and audit payload.
+ *
+ * Run with: npx tsx --test src/__tests__/groupHandler.transfer.test.ts
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  createGroup,
+  addMember,
+  getMembersOfGroup,
+  findGroupById,
+  transferOwnership,
+} from '../db/groupRepository.js';
+import { insertAudit } from '../db/groupAuditRepository.js';
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  return db;
+}
+
+function insertUser(db: Database.Database, chatId: number): void {
+  db.prepare('INSERT OR IGNORE INTO users (chat_id) VALUES (?)').run(chatId);
+}
+
+describe('groupHandler.transfer — repository layer', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = makeDb();
+  });
+
+  it('transferOwnership: owner successfully transfers to a member', () => {
+    insertUser(db, 100);
+    insertUser(db, 200);
+    const group = createGroup(db, { name: 'FamilyGroup', ownerId: 100, inviteCode: 'FAMIL1' });
+    addMember(db, group.id, 200);
+
+    const result = transferOwnership(db, group.id, 100, 200);
+    assert.equal(result, true, 'transferOwnership should return true on success');
+
+    const updated = findGroupById(db, group.id);
+    assert.ok(updated, 'group should still exist after transfer');
+    assert.equal(updated.ownerId, 200, 'ownerId should be updated to new owner');
+  });
+
+  it('transferOwnership: returns false when fromOwnerId does not match current owner (TOCTOU guard)', () => {
+    insertUser(db, 100);
+    insertUser(db, 200);
+    const group = createGroup(db, { name: 'TOCTOUGroup', ownerId: 100, inviteCode: 'TOCTOU' });
+    addMember(db, group.id, 200);
+
+    // Simulate TOCTOU: pass wrong fromOwnerId
+    const result = transferOwnership(db, group.id, 999, 200);
+    assert.equal(result, false, 'should return false when fromOwnerId does not match');
+
+    // Ownership should be unchanged
+    const group2 = findGroupById(db, group.id);
+    assert.equal(group2?.ownerId, 100, 'owner should not have changed');
+  });
+
+  it('transferOwnership: returns false when target is not a member', () => {
+    insertUser(db, 100);
+    insertUser(db, 300);
+    const group = createGroup(db, { name: 'MemberlessGroup', ownerId: 100, inviteCode: 'NONMBR' });
+    // 300 is NOT a member
+
+    const result = transferOwnership(db, group.id, 100, 300);
+    assert.equal(result, false, 'should return false when target is not a member');
+
+    const group2 = findGroupById(db, group.id);
+    assert.equal(group2?.ownerId, 100, 'owner should not have changed');
+  });
+
+  it('insertAudit: transferred action stores actorId and payload correctly', () => {
+    insertUser(db, 100);
+    insertUser(db, 200);
+    const group = createGroup(db, { name: 'AuditTransfer', ownerId: 100, inviteCode: 'AUDT12' });
+    addMember(db, group.id, 200);
+
+    transferOwnership(db, group.id, 100, 200);
+    insertAudit(db, {
+      groupId: group.id,
+      action: 'transferred',
+      actorId: 100,
+      payload: JSON.stringify({ to: 200 }),
+    });
+
+    const row = db.prepare('SELECT * FROM group_audit WHERE group_id = ?').get(group.id) as {
+      group_id: number;
+      action: string;
+      actor_id: number;
+      payload: string;
+    } | undefined;
+
+    assert.ok(row, 'audit row should exist');
+    assert.equal(row.action, 'transferred');
+    assert.equal(row.actor_id, 100);
+
+    const payload = JSON.parse(row.payload) as { to: number };
+    assert.equal(payload.to, 200, 'payload.to should be the new owner chatId');
+  });
+
+  it('membership check: target not in members list means transfer is rejected at handler level', () => {
+    insertUser(db, 100);
+    insertUser(db, 400);
+    const group = createGroup(db, { name: 'NonMemberGroup', ownerId: 100, inviteCode: 'NMEMB1' });
+    // 400 is NOT added as a member
+
+    const members = getMembersOfGroup(db, group.id);
+    const targetIseMember = members.some((m) => m.userId === 400);
+    assert.equal(targetIseMember, false, 'target should not be a member');
+
+    // Handler would reject here — verify by calling transferOwnership which also verifies
+    const result = transferOwnership(db, group.id, 100, 400);
+    assert.equal(result, false, 'transferOwnership should reject non-member target');
+  });
+
+  it('transferOwnership: group not found returns false', () => {
+    insertUser(db, 100);
+    // No group created with id 9999
+    const result = transferOwnership(db, 9999, 100, 200);
+    assert.equal(result, false, 'should return false for non-existent group');
+  });
+
+  it('after transfer, old owner is still a member (not removed)', () => {
+    insertUser(db, 100);
+    insertUser(db, 200);
+    const group = createGroup(db, { name: 'StayGroup', ownerId: 100, inviteCode: 'STAY12' });
+    addMember(db, group.id, 200);
+
+    transferOwnership(db, group.id, 100, 200);
+
+    const members = getMembersOfGroup(db, group.id);
+    const oldOwnerStillMember = members.some((m) => m.userId === 100);
+    assert.equal(oldOwnerStillMember, true, 'old owner should still be a member after transfer');
+  });
+});

--- a/src/__tests__/neighborCheckHandler.test.ts
+++ b/src/__tests__/neighborCheckHandler.test.ts
@@ -1,0 +1,133 @@
+// src/__tests__/neighborCheckHandler.test.ts
+// Run with: npx tsx --test src/__tests__/neighborCheckHandler.test.ts
+// No DB_PATH needed — uses its own :memory: Database via setNeighborCheckHandlerDb.
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import type { Bot } from 'grammy';
+import { initSchema } from '../db/schema.js';
+import {
+  registerNeighborCheckHandler,
+  setNeighborCheckHandlerDb,
+} from '../bot/neighborCheckHandler.js';
+import { insertPrompt } from '../db/neighborCheckRepository.js';
+
+function createTestDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  return db;
+}
+
+/**
+ * Captures the single callbackQuery handler registered by registerNeighborCheckHandler.
+ * Grammy registers handlers via bot.callbackQuery(pattern, fn) — we mock the bot and
+ * capture `fn` so tests can invoke it directly with a fake context.
+ */
+function captureHandler(db: Database.Database): (ctx: unknown) => Promise<void> {
+  setNeighborCheckHandlerDb(db);
+  let captured: ((ctx: unknown) => Promise<void>) | null = null;
+  const mockBot = {
+    callbackQuery: (_pattern: unknown, fn: (ctx: unknown) => Promise<void>) => {
+      if (!captured) captured = fn;
+    },
+  } as unknown as Bot;
+  registerNeighborCheckHandler(mockBot);
+  if (!captured) throw new Error('handler not captured — check registerNeighborCheckHandler');
+  return captured;
+}
+
+/** Build a fake Grammy context for an nc:* callback_data string. */
+function makeCtx(callbackData: string) {
+  const match = callbackData.match(/^nc:(checked|unable|dismissed):(\d+):([a-f0-9]{8})$/);
+  return {
+    match,
+    answerCallbackQuery: async () => {},
+    editMessageText: async (_text: string) => ({ message_id: 1 }),
+    // Track the last text passed to editMessageText for assertions
+    _lastEditText: null as string | null,
+  };
+}
+
+/** Same as makeCtx but records editMessageText argument for assertion. */
+function makeSpyCtx(callbackData: string) {
+  const calls: string[] = [];
+  const match = callbackData.match(/^nc:(checked|unable|dismissed):(\d+):([a-f0-9]{8})$/);
+  return {
+    ctx: {
+      match,
+      answerCallbackQuery: async () => {},
+      editMessageText: async (text: string) => { calls.push(text); return { message_id: 1 }; },
+    },
+    editCalls: calls,
+  };
+}
+
+const FINGERPRINT = 'abcdef1234567890abcdef1234567890abcdef12';
+const FP_SHORT = FINGERPRINT.slice(0, 8); // 'abcdef12'
+const CHAT_ID = 555;
+
+describe('neighborCheckHandler — nc:* callbacks', () => {
+  let db: Database.Database;
+  let handler: (ctx: unknown) => Promise<void>;
+
+  beforeEach(() => {
+    db = createTestDb();
+    handler = captureHandler(db);
+    // neighbor_check_prompts.chat_id → users(chat_id) FK — seed user first
+    db.prepare('INSERT OR IGNORE INTO users (chat_id) VALUES (?)').run(CHAT_ID);
+    insertPrompt(db, CHAT_ID, FINGERPRINT, 10);
+  });
+
+  it('nc:checked — edits message with תודה and marks prompt as responded', async () => {
+    const { ctx, editCalls } = makeSpyCtx(`nc:checked:${CHAT_ID}:${FP_SHORT}`);
+    await handler(ctx);
+
+    assert.equal(editCalls.length, 1, 'editMessageText should be called once');
+    assert.ok(editCalls[0]!.includes('תודה'), `expected תודה in: "${editCalls[0]}"`);
+
+    const row = db
+      .prepare('SELECT responded FROM neighbor_check_prompts WHERE chat_id = ? AND fingerprint = ?')
+      .get(CHAT_ID, FINGERPRINT) as { responded: number };
+    assert.equal(row.responded, 1, 'prompt should be marked as responded');
+  });
+
+  it('nc:unable — edits message with תודה', async () => {
+    const { ctx, editCalls } = makeSpyCtx(`nc:unable:${CHAT_ID}:${FP_SHORT}`);
+    await handler(ctx);
+
+    assert.equal(editCalls.length, 1);
+    assert.ok(editCalls[0]!.includes('תודה'), `expected תודה in: "${editCalls[0]}"`);
+  });
+
+  it('nc:dismissed — edits message with הובן (not תודה)', async () => {
+    const { ctx, editCalls } = makeSpyCtx(`nc:dismissed:${CHAT_ID}:${FP_SHORT}`);
+    await handler(ctx);
+
+    assert.equal(editCalls.length, 1);
+    assert.ok(editCalls[0]!.includes('הובן'), `expected הובן in: "${editCalls[0]}"`);
+    assert.ok(!editCalls[0]!.includes('תודה'), 'dismissed should NOT contain תודה');
+  });
+
+  it('already responded — does NOT record a second event', async () => {
+    // Pre-mark as responded
+    db.prepare('UPDATE neighbor_check_prompts SET responded = 1 WHERE chat_id = ? AND fingerprint = ?')
+      .run(CHAT_ID, FINGERPRINT);
+
+    const { ctx } = makeSpyCtx(`nc:checked:${CHAT_ID}:${FP_SHORT}`);
+    await handler(ctx);
+
+    // markResponded + recordEvent are skipped when row.responded is already true
+    const events = db.prepare('SELECT COUNT(*) as cnt FROM neighbor_check_events').get() as { cnt: number };
+    assert.equal(events.cnt, 0, 'recordEvent must NOT be called when already responded');
+  });
+
+  it('unknown fp_short — edits message with expiry notice', async () => {
+    // Use a fingerprint prefix that has no matching row
+    const { ctx, editCalls } = makeSpyCtx(`nc:checked:${CHAT_ID}:00000000`);
+    await handler(ctx);
+
+    assert.equal(editCalls.length, 1, 'should still call editMessageText for expiry');
+    assert.ok(editCalls[0]!.includes('פג תוקף'), `expected expiry message, got: "${editCalls[0]}"`);
+  });
+});

--- a/src/__tests__/neighborCheckRepository.test.ts
+++ b/src/__tests__/neighborCheckRepository.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  insertPrompt,
+  updatePromptMessageId,
+  markResponded,
+  getPromptByPrefix,
+  recordEvent,
+  getAggregate,
+} from '../db/neighborCheckRepository.js';
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  // Seed a user row so FK constraints pass
+  db.prepare('INSERT OR IGNORE INTO users (chat_id) VALUES (?)').run(999);
+  return db;
+}
+
+describe('neighborCheckRepository', () => {
+  describe('insertPrompt', () => {
+    it('inserts a new prompt row', () => {
+      const db = makeDb();
+      insertPrompt(db, 999, 'abcdef1234567890abcdef1234567890abcdef12', undefined);
+      const row = db
+        .prepare('SELECT * FROM neighbor_check_prompts WHERE chat_id = 999')
+        .get() as { chat_id: number; fingerprint: string; responded: number; message_id: number | null } | undefined;
+      assert.ok(row, 'row should exist');
+      assert.equal(row!.chat_id, 999);
+      assert.equal(row!.responded, 0);
+      assert.equal(row!.message_id, null);
+    });
+
+    it('INSERT OR IGNORE — duplicate does not throw', () => {
+      const db = makeDb();
+      const fp = 'abcdef1234567890abcdef1234567890abcdef12';
+      insertPrompt(db, 999, fp, undefined);
+      assert.doesNotThrow(() => insertPrompt(db, 999, fp, undefined));
+    });
+
+    it('stores messageId when provided', () => {
+      const db = makeDb();
+      insertPrompt(db, 999, 'fp_with_msgid_xxxxxxxxxxxxxxxxxxxxxxxxxxx', 42);
+      const row = db
+        .prepare('SELECT message_id FROM neighbor_check_prompts WHERE chat_id = 999 AND fingerprint = ?')
+        .get('fp_with_msgid_xxxxxxxxxxxxxxxxxxxxxxxxxxx') as { message_id: number | null } | undefined;
+      assert.equal(row?.message_id, 42);
+    });
+  });
+
+  describe('updatePromptMessageId', () => {
+    it('sets message_id on an existing row', () => {
+      const db = makeDb();
+      const fp = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+      insertPrompt(db, 999, fp, undefined);
+      updatePromptMessageId(db, 999, fp, 77);
+      const row = db
+        .prepare('SELECT message_id FROM neighbor_check_prompts WHERE chat_id = 999 AND fingerprint = ?')
+        .get(fp) as { message_id: number | null } | undefined;
+      assert.equal(row?.message_id, 77);
+    });
+  });
+
+  describe('markResponded', () => {
+    it('sets responded = 1', () => {
+      const db = makeDb();
+      const fp = 'cccccccccccccccccccccccccccccccccccccccc';
+      insertPrompt(db, 999, fp);
+      markResponded(db, 999, fp);
+      const row = db
+        .prepare('SELECT responded FROM neighbor_check_prompts WHERE chat_id = 999 AND fingerprint = ?')
+        .get(fp) as { responded: number } | undefined;
+      assert.equal(row?.responded, 1);
+    });
+  });
+
+  describe('getPromptByPrefix', () => {
+    it('finds row by 8-char prefix', () => {
+      const db = makeDb();
+      const fp = 'deadbeef11111111111111111111111111111111';
+      insertPrompt(db, 999, fp);
+      const row = getPromptByPrefix(db, 999, 'deadbeef');
+      assert.ok(row, 'should find row');
+      assert.equal(row!.fingerprint, fp);
+      assert.equal(row!.responded, false);
+    });
+
+    it('returns null when no match', () => {
+      const db = makeDb();
+      const result = getPromptByPrefix(db, 999, 'xxxxxxxx');
+      assert.equal(result, null);
+    });
+  });
+
+  describe('recordEvent', () => {
+    it('inserts event without chat_id', () => {
+      const db = makeDb();
+      recordEvent(db, 'fp123', 'checked', null);
+      const row = db
+        .prepare('SELECT * FROM neighbor_check_events WHERE alert_fp = ?')
+        .get('fp123') as { alert_fp: string; response: string; city: string | null } | undefined;
+      assert.ok(row, 'row should exist');
+      assert.equal(row!.response, 'checked');
+      assert.equal(row!.city, null);
+
+      // Verify no chat_id column exists in the row
+      assert.ok(!('chat_id' in (row as object)), 'event row must not have chat_id');
+    });
+
+    it('accepts city value', () => {
+      const db = makeDb();
+      recordEvent(db, 'fp456', 'unable', 'תל אביב');
+      const row = db
+        .prepare('SELECT city FROM neighbor_check_events WHERE alert_fp = ?')
+        .get('fp456') as { city: string | null } | undefined;
+      assert.equal(row?.city, 'תל אביב');
+    });
+  });
+
+  describe('getAggregate', () => {
+    it('returns correct counts by response type', () => {
+      const db = makeDb();
+      recordEvent(db, 'fp_a', 'checked', null);
+      recordEvent(db, 'fp_b', 'checked', null);
+      recordEvent(db, 'fp_c', 'unable', null);
+      recordEvent(db, 'fp_d', 'dismissed', null);
+      recordEvent(db, 'fp_e', 'dismissed', null);
+      recordEvent(db, 'fp_f', 'dismissed', null);
+
+      const agg = getAggregate(db, '2000-01-01');
+      assert.equal(agg.checked, 2);
+      assert.equal(agg.unable, 1);
+      assert.equal(agg.dismissed, 3);
+      assert.equal(agg.total, 6);
+    });
+
+    it('returns zeros when no events in range', () => {
+      const db = makeDb();
+      recordEvent(db, 'fp_old', 'checked', null);
+      // Use a far-future cutoff to exclude all events
+      const agg = getAggregate(db, '2999-12-31');
+      assert.equal(agg.total, 0);
+    });
+  });
+});

--- a/src/__tests__/neighborCheckService.test.ts
+++ b/src/__tests__/neighborCheckService.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  scheduleNeighborCheck,
+  cancelAll,
+  getUsersInAlertCities,
+} from '../services/neighborCheckService.js';
+import type { Alert } from '../types.js';
+import type { Bot } from 'grammy';
+
+function makeDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  return db;
+}
+
+function makeMockBot(): Bot {
+  return {
+    api: {
+      sendMessage: mock.fn(async () => ({ message_id: 1 })),
+    },
+  } as unknown as Bot;
+}
+
+const REAL_ALERT: Alert = {
+  id: 'abcdef1234567890abcdef1234567890abcdef12',
+  type: 'missiles',
+  cities: ['תל אביב', 'רמת גן'],
+};
+
+const DRILL_ALERT: Alert = {
+  id: 'drill_fp_1234567890abcdef1234567890abcde',
+  type: 'missilesDrill',
+  cities: ['תל אביב'],
+};
+
+describe('neighborCheckService', () => {
+  describe('scheduleNeighborCheck — drill guard', () => {
+    it('does NOT schedule for drill alerts', () => {
+      const db = makeDb();
+      const bot = makeMockBot();
+      const scheduleFn = mock.fn((fn: () => void, _ms: number) => setTimeout(fn, 999999));
+
+      scheduleNeighborCheck(db, bot, DRILL_ALERT, { scheduleFn });
+
+      assert.equal(
+        (scheduleFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+        0,
+        'scheduleFn should NOT be called for drill alerts'
+      );
+    });
+
+    it('schedules for non-drill alerts', () => {
+      const db = makeDb();
+      const bot = makeMockBot();
+      const handles: NodeJS.Timeout[] = [];
+      const scheduleFn = mock.fn((fn: () => void, _ms: number): NodeJS.Timeout => {
+        const h = setTimeout(() => {}, 999999);
+        handles.push(h);
+        return h;
+      });
+
+      scheduleNeighborCheck(db, bot, REAL_ALERT, { scheduleFn });
+
+      assert.equal(
+        (scheduleFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+        1,
+        'scheduleFn should be called once for real alerts'
+      );
+
+      // Cleanup
+      for (const h of handles) clearTimeout(h);
+    });
+  });
+
+  describe('scheduleNeighborCheck — global kill-switch', () => {
+    it('does NOT schedule when neighbor_check_enabled_default = false in DB', () => {
+      const db = makeDb();
+      db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('neighbor_check_enabled_default', 'false')`).run();
+      const bot = makeMockBot();
+      const scheduleFn = mock.fn((fn: () => void, _ms: number) => setTimeout(fn, 999999));
+
+      scheduleNeighborCheck(db, bot, REAL_ALERT, { scheduleFn });
+
+      assert.equal(
+        (scheduleFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+        0,
+        'scheduleFn should NOT be called when kill-switch is off'
+      );
+    });
+  });
+
+  describe('scheduleNeighborCheck — delay', () => {
+    it('schedules with correct delay from DB config', () => {
+      const db = makeDb();
+      db.prepare(`INSERT OR REPLACE INTO settings (key, value) VALUES ('neighbor_check_delay_minutes', '3')`).run();
+      const bot = makeMockBot();
+
+      let capturedMs = 0;
+      const scheduleFn = mock.fn((fn: () => void, ms: number): NodeJS.Timeout => {
+        capturedMs = ms;
+        return setTimeout(() => {}, 999999);
+      });
+
+      scheduleNeighborCheck(db, bot, REAL_ALERT, { scheduleFn });
+
+      assert.equal(capturedMs, 3 * 60 * 1000, 'delay should be 3 minutes in ms');
+
+      // Cleanup handles via cancelAll
+      cancelAll();
+    });
+  });
+
+  describe('scheduleNeighborCheck — fans out DMs', () => {
+    it('calls sendFn for each matching user', () => {
+      const db = makeDb();
+      const bot = makeMockBot();
+
+      // Seed two users with matching home_city
+      db.prepare('INSERT INTO users (chat_id, home_city, is_dm_active, neighbor_check_enabled) VALUES (?, ?, ?, ?)').run(101, 'תל אביב', 1, 1);
+      db.prepare('INSERT INTO users (chat_id, home_city, is_dm_active, neighbor_check_enabled) VALUES (?, ?, ?, ?)').run(102, 'תל אביב', 1, 1);
+      // One user with neighbor_check disabled
+      db.prepare('INSERT INTO users (chat_id, home_city, is_dm_active, neighbor_check_enabled) VALUES (?, ?, ?, ?)').run(103, 'תל אביב', 1, 0);
+      // One user in a different city
+      db.prepare('INSERT INTO users (chat_id, home_city, is_dm_active, neighbor_check_enabled) VALUES (?, ?, ?, ?)').run(104, 'חיפה', 1, 1);
+
+      const sentToIds: number[] = [];
+      const sendFn = mock.fn(async (chatId: number, _text: string, _keyboard: object) => {
+        sentToIds.push(chatId);
+        return { message_id: 1 };
+      });
+
+      // Use getUsersInCitiesFn override to use the real DB query
+      let timerFired = false;
+      const scheduleFn = (fn: () => void, _ms: number): NodeJS.Timeout => {
+        // Execute immediately for testing
+        fn();
+        timerFired = true;
+        return setTimeout(() => {}, 0);
+      };
+
+      scheduleNeighborCheck(db, bot, REAL_ALERT, { scheduleFn, sendFn });
+
+      assert.ok(timerFired, 'timer callback should have fired');
+      assert.equal(sentToIds.length, 2, 'should send to 2 users with matching city and enabled');
+      assert.ok(sentToIds.includes(101), 'should include user 101');
+      assert.ok(sentToIds.includes(102), 'should include user 102');
+      assert.ok(!sentToIds.includes(103), 'should NOT include user 103 (disabled)');
+      assert.ok(!sentToIds.includes(104), 'should NOT include user 104 (different city)');
+    });
+
+    it('does not send when no users match', () => {
+      const db = makeDb();
+      const bot = makeMockBot();
+      const sendFn = mock.fn(async () => ({ message_id: 1 }));
+
+      let fired = false;
+      const scheduleFn = (fn: () => void, _ms: number): NodeJS.Timeout => {
+        fn();
+        fired = true;
+        return setTimeout(() => {}, 0);
+      };
+
+      scheduleNeighborCheck(db, bot, REAL_ALERT, { scheduleFn, sendFn });
+
+      assert.ok(fired, 'timer should fire');
+      assert.equal(
+        (sendFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length,
+        0,
+        'sendFn should not be called when no matching users'
+      );
+    });
+  });
+
+  describe('cancelAll', () => {
+    it('cancels all active handles', () => {
+      const db = makeDb();
+      const bot = makeMockBot();
+      const cancelledHandles: NodeJS.Timeout[] = [];
+
+      let scheduled = false;
+      const scheduleFn = (_fn: () => void, _ms: number): NodeJS.Timeout => {
+        const h = setTimeout(() => {}, 999999);
+        scheduled = true;
+        return h;
+      };
+      const cancelScheduleFn = mock.fn((h: NodeJS.Timeout) => {
+        cancelledHandles.push(h);
+        clearTimeout(h);
+      });
+
+      scheduleNeighborCheck(db, bot, REAL_ALERT, { scheduleFn, cancelScheduleFn });
+      assert.ok(scheduled, 'handle should be scheduled');
+
+      // cancelAll uses clearTimeout internally, not cancelScheduleFn
+      cancelAll();
+
+      // After cancelAll, scheduling a new one should work cleanly
+      const scheduleFn2 = (_fn: () => void, _ms: number): NodeJS.Timeout => {
+        return setTimeout(() => {}, 999999);
+      };
+      const alert2: Alert = { id: 'ffffffffffffffffffffffffffffffffffffffff', type: 'missiles', cities: [] };
+      scheduleNeighborCheck(db, bot, alert2, { scheduleFn: scheduleFn2 });
+      cancelAll(); // cleanup
+    });
+  });
+
+  describe('getUsersInAlertCities', () => {
+    it('returns empty array for empty cities', () => {
+      const db = makeDb();
+      const result = getUsersInAlertCities(db, []);
+      assert.equal(result.length, 0);
+    });
+
+    it('filters by neighbor_check_enabled and is_dm_active', () => {
+      const db = makeDb();
+      db.prepare('INSERT INTO users (chat_id, home_city, is_dm_active, neighbor_check_enabled) VALUES (?, ?, ?, ?)').run(201, 'ירושלים', 1, 1);
+      db.prepare('INSERT INTO users (chat_id, home_city, is_dm_active, neighbor_check_enabled) VALUES (?, ?, ?, ?)').run(202, 'ירושלים', 0, 1); // DM inactive
+      db.prepare('INSERT INTO users (chat_id, home_city, is_dm_active, neighbor_check_enabled) VALUES (?, ?, ?, ?)').run(203, 'ירושלים', 1, 0); // NC disabled
+
+      const result = getUsersInAlertCities(db, ['ירושלים']);
+      assert.equal(result.length, 1);
+      assert.equal(result[0]!.chat_id, 201);
+    });
+  });
+});

--- a/src/__tests__/safetyPromptService.test.ts
+++ b/src/__tests__/safetyPromptService.test.ts
@@ -29,6 +29,7 @@ function makeUser(overrides: Partial<User> = {}): User {
     social_contact_count_enabled: true,
     social_group_alerts_enabled: true,
     social_quick_ok_enabled: true,
+    neighbor_check_enabled: true,
     created_at: new Date().toISOString(),
     ...overrides,
   };

--- a/src/__tests__/shelterStoriesHandler.test.ts
+++ b/src/__tests__/shelterStoriesHandler.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, before, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Bot, Context } from 'grammy';
+
+process.env['DB_PATH'] = ':memory:';
+
+import { initDb, getDb } from '../db/schema.js';
+import {
+  registerShelterStoriesHandler,
+  clearPendingShare,
+  hasPendingShare,
+} from '../bot/shelterStoriesHandler.js';
+
+// ── Mock bot factory ──────────────────────────────────────────────────────────
+
+function createMockBot() {
+  const handlers = {
+    command: new Map<string, Function>(),
+    callbackQuery: new Map<string, Function | Function[]>(),
+    on: new Map<string, Function>(),
+  };
+  const bot = {
+    command: (name: string, fn: Function) => {
+      handlers.command.set(name, fn);
+    },
+    callbackQuery: (pattern: string | RegExp, fn: Function) => {
+      const key = String(pattern);
+      handlers.callbackQuery.set(key, fn);
+    },
+    on: (event: string, fn: Function) => {
+      handlers.on.set(event, fn);
+    },
+    api: {
+      sendMessage: mock.fn(async () => ({ message_id: 1 })),
+    },
+  } as unknown as Bot;
+  return { bot, handlers };
+}
+
+function createMockCtx(overrides: Record<string, unknown> = {}): Context {
+  return {
+    from: { id: 55001, first_name: 'Test' },
+    chat: { id: 55001, type: 'private' },
+    message: { text: '' },
+    reply: mock.fn(async () => ({ message_id: 1 })),
+    editMessageText: mock.fn(async () => ({ message_id: 1 })),
+    answerCallbackQuery: mock.fn(async () => {}),
+    callbackQuery: { data: '' },
+    match: null,
+    ...overrides,
+  } as unknown as Context;
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+const TEST_CHAT_ID = 55001;
+
+before(() => {
+  initDb();
+  getDb().prepare('INSERT OR IGNORE INTO users (chat_id) VALUES (?)').run(TEST_CHAT_ID);
+});
+
+beforeEach(() => {
+  clearPendingShare(TEST_CHAT_ID);
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('shelterStoriesHandler', () => {
+  it('registers the /share command', () => {
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+    assert.ok(handlers.command.has('share'), '/share must be registered');
+  });
+
+  it('/share when stories_enabled=false replies with disabled message', async () => {
+    getDb().prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES ('stories_enabled','false',0)").run();
+
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+
+    const ctx = createMockCtx();
+    const fn = handlers.command.get('share')!;
+    await fn(ctx);
+
+    const replyCalls = (ctx.reply as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(replyCalls.length, 1);
+    const replyText: string = replyCalls[0].arguments[0] as string;
+    assert.ok(replyText.includes('כבוי'), `expected 'כבוי' in reply, got: ${replyText}`);
+    assert.equal(hasPendingShare(TEST_CHAT_ID), false);
+
+    // cleanup
+    getDb().prepare("DELETE FROM settings WHERE key = 'stories_enabled'").run();
+  });
+
+  it('/share when rate limited replies with rate limit message', async () => {
+    // Set rate limit to 1 minute and insert a recent story
+    getDb().prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES ('stories_rate_limit_minutes','60',0)").run();
+    // Insert a story within the last hour to trigger rate limit
+    getDb().prepare("INSERT INTO shelter_stories (chat_id, body) VALUES (?,?)").run(TEST_CHAT_ID, 'prior story');
+
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+
+    const ctx = createMockCtx();
+    const fn = handlers.command.get('share')!;
+    await fn(ctx);
+
+    const replyCalls = (ctx.reply as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(replyCalls.length, 1);
+    const replyText: string = replyCalls[0].arguments[0] as string;
+    assert.ok(replyText.includes('יותר מדי'), `expected rate limit message, got: ${replyText}`);
+    assert.equal(hasPendingShare(TEST_CHAT_ID), false);
+
+    // cleanup
+    getDb().prepare("DELETE FROM settings WHERE key = 'stories_rate_limit_minutes'").run();
+    getDb().prepare("DELETE FROM shelter_stories WHERE chat_id = ? AND body = 'prior story'").run(TEST_CHAT_ID);
+  });
+
+  it('/share sets pendingShares entry when not rate limited', async () => {
+    getDb().prepare("DELETE FROM shelter_stories WHERE chat_id = ?").run(TEST_CHAT_ID);
+
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+
+    const ctx = createMockCtx();
+    const fn = handlers.command.get('share')!;
+    await fn(ctx);
+
+    assert.equal(hasPendingShare(TEST_CHAT_ID), true);
+
+    const replyCalls = (ctx.reply as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(replyCalls.length, 1);
+  });
+
+  it('text message with chatId in pendingShares creates story', async () => {
+    getDb().prepare("DELETE FROM shelter_stories WHERE chat_id = ?").run(TEST_CHAT_ID);
+
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+
+    // Manually set pending state
+    clearPendingShare(TEST_CHAT_ID);
+    // Trigger /share to set state
+    const commandFn = handlers.command.get('share')!;
+    await commandFn(createMockCtx());
+    assert.equal(hasPendingShare(TEST_CHAT_ID), true);
+
+    // Now send a text message
+    const textFn = handlers.on.get('message:text')!;
+    const nextFn = mock.fn(async () => {});
+    const ctx = createMockCtx({ message: { text: 'הייתי במקלט וזה היה מפחיד' } });
+    await textFn(ctx, nextFn);
+
+    // Story should be created, pendingShare cleared
+    assert.equal(hasPendingShare(TEST_CHAT_ID), false);
+    const storyCount = (getDb().prepare("SELECT COUNT(*) as cnt FROM shelter_stories WHERE chat_id = ?").get(TEST_CHAT_ID) as { cnt: number }).cnt;
+    assert.ok(storyCount >= 1);
+
+    const replyCalls = (ctx.reply as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(replyCalls.length, 1);
+    const replyText: string = replyCalls[0].arguments[0] as string;
+    assert.ok(replyText.includes('תודה'), `expected confirmation message, got: ${replyText}`);
+    assert.equal((nextFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length, 0);
+  });
+
+  it('text message with chatId NOT in pendingShares calls next()', async () => {
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+
+    assert.equal(hasPendingShare(TEST_CHAT_ID), false);
+
+    const textFn = handlers.on.get('message:text')!;
+    const nextFn = mock.fn(async () => {});
+    const ctx = createMockCtx({ message: { text: 'שאילתה כלשהי' } });
+    await textFn(ctx, nextFn);
+
+    assert.equal((nextFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length, 1);
+    const replyCalls = (ctx.reply as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(replyCalls.length, 0);
+  });
+
+  it('text over max length replies with error without creating story', async () => {
+    getDb().prepare("DELETE FROM shelter_stories WHERE chat_id = ?").run(TEST_CHAT_ID);
+    getDb().prepare("INSERT OR REPLACE INTO settings (key, value, encrypted) VALUES ('stories_max_length','200',0)").run();
+
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+
+    const commandFn = handlers.command.get('share')!;
+    await commandFn(createMockCtx());
+    assert.equal(hasPendingShare(TEST_CHAT_ID), true);
+
+    const longText = 'א'.repeat(201);
+    const textFn = handlers.on.get('message:text')!;
+    const nextFn = mock.fn(async () => {});
+    const ctx = createMockCtx({ message: { text: longText } });
+    await textFn(ctx, nextFn);
+
+    // pendingShare should remain (user can retry with shorter text)
+    assert.equal(hasPendingShare(TEST_CHAT_ID), true);
+
+    const replyCalls = (ctx.reply as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(replyCalls.length, 1);
+    const replyText: string = replyCalls[0].arguments[0] as string;
+    assert.ok(replyText.includes('ארוכה'), `expected length error, got: ${replyText}`);
+
+    const storyCount = (getDb().prepare("SELECT COUNT(*) as cnt FROM shelter_stories WHERE chat_id = ?").get(TEST_CHAT_ID) as { cnt: number }).cnt;
+    assert.equal(storyCount, 0);
+
+    getDb().prepare("DELETE FROM settings WHERE key = 'stories_max_length'").run();
+  });
+
+  it('story:cancel removes from pendingShares and answers callback', async () => {
+    const { bot, handlers } = createMockBot();
+    registerShelterStoriesHandler(bot);
+
+    // Manually set pending state
+    const commandFn = handlers.command.get('share')!;
+    await commandFn(createMockCtx());
+    assert.equal(hasPendingShare(TEST_CHAT_ID), true);
+
+    const cancelFn = handlers.callbackQuery.get('story:cancel')!;
+    const ctx = createMockCtx({
+      callbackQuery: { data: 'story:cancel' },
+    });
+    await (cancelFn as Function)(ctx);
+
+    assert.equal(hasPendingShare(TEST_CHAT_ID), false);
+    const answerCalls = (ctx.answerCallbackQuery as unknown as ReturnType<typeof mock.fn>).mock.calls;
+    assert.equal(answerCalls.length, 1);
+  });
+});

--- a/src/__tests__/shelterStoryRepository.test.ts
+++ b/src/__tests__/shelterStoryRepository.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  createStory,
+  getPendingStories,
+  getStoriesByStatus,
+  getStoryById,
+  lockForApproval,
+  approveStory,
+  rejectStory,
+  countStoriesByUserSince,
+  getCountsByStatus,
+} from '../db/shelterStoryRepository.js';
+
+let db: Database.Database;
+
+before(() => {
+  db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  // Insert a test user to satisfy the FK constraint
+  db.prepare('INSERT INTO users (chat_id) VALUES (?)').run(1001);
+  db.prepare('INSERT INTO users (chat_id) VALUES (?)').run(1002);
+});
+
+describe('shelterStoryRepository', () => {
+  it('createStory inserts with status=pending', () => {
+    const story = createStory(db, 1001, 'היה פה קצת עצבני אבל בסדר');
+    assert.equal(story.status, 'pending');
+    assert.equal(story.chatId, 1001);
+    assert.equal(story.body, 'היה פה קצת עצבני אבל בסדר');
+    assert.equal(story.publishedMessageId, null);
+    assert.ok(story.id > 0);
+  });
+
+  it('createStory rejects body > 200 chars (SQLite CHECK constraint)', () => {
+    const longBody = 'א'.repeat(201);
+    assert.throws(() => createStory(db, 1001, longBody));
+  });
+
+  it('lockForApproval returns true and sets status=approved for pending story', () => {
+    const story = createStory(db, 1001, 'חוויה מהמקלט');
+    const locked = lockForApproval(db, story.id);
+    assert.equal(locked, true);
+    const updated = getStoryById(db, story.id);
+    assert.ok(updated !== null);
+    assert.equal(updated!.status, 'approved');
+  });
+
+  it('lockForApproval returns false for already-processed story', () => {
+    const story = createStory(db, 1001, 'סיפור כפול');
+    lockForApproval(db, story.id); // first lock
+    const secondLock = lockForApproval(db, story.id); // second — already approved
+    assert.equal(secondLock, false);
+  });
+
+  it('lockForApproval returns false for non-existent story', () => {
+    const result = lockForApproval(db, 99999);
+    assert.equal(result, false);
+  });
+
+  it('approveStory sets status=published and publishedMessageId', () => {
+    const story = createStory(db, 1001, 'חוויה מהמקלט לאישור');
+    lockForApproval(db, story.id); // lock first (as the route does)
+    approveStory(db, story.id, 'admin', 9999);
+    const updated = getStoryById(db, story.id);
+    assert.ok(updated !== null);
+    assert.equal(updated!.status, 'published');
+    assert.equal(updated!.publishedMessageId, 9999);
+    assert.equal(updated!.reviewedBy, 'admin');
+    assert.ok(updated!.reviewedAt !== null);
+  });
+
+  it('rejectStory returns true and sets status=rejected for pending story', () => {
+    const story = createStory(db, 1002, 'סיפור שייך לדחייה');
+    const result = rejectStory(db, story.id, 'admin');
+    assert.equal(result, true);
+    const updated = getStoryById(db, story.id);
+    assert.ok(updated !== null);
+    assert.equal(updated!.status, 'rejected');
+    assert.equal(updated!.reviewedBy, 'admin');
+    assert.ok(updated!.reviewedAt !== null);
+  });
+
+  it('rejectStory returns false for already-processed story', () => {
+    const story = createStory(db, 1002, 'סיפור שנדחה כבר');
+    rejectStory(db, story.id, 'admin'); // first rejection
+    const secondReject = rejectStory(db, story.id, 'admin'); // already rejected
+    assert.equal(secondReject, false);
+  });
+
+  it('getStoryById returns null for non-existent id', () => {
+    const result = getStoryById(db, 99999);
+    assert.equal(result, null);
+  });
+
+  it('getStoriesByStatus returns camelCase rows for non-pending statuses', () => {
+    const testDb = new Database(':memory:');
+    testDb.pragma('foreign_keys = ON');
+    initSchema(testDb);
+    testDb.prepare('INSERT INTO users (chat_id) VALUES (?)').run(3001);
+
+    const s = createStory(testDb, 3001, 'סיפור לדחייה');
+    rejectStory(testDb, s.id, 'admin');
+
+    const rows = getStoriesByStatus(testDb, 'rejected', 10, 0);
+    assert.equal(rows.length, 1);
+    // verify camelCase fields (not snake_case)
+    assert.ok('chatId' in rows[0], 'should have chatId (camelCase)');
+    assert.ok('reviewedAt' in rows[0], 'should have reviewedAt (camelCase)');
+    assert.ok(!('chat_id' in rows[0]), 'should NOT have chat_id (snake_case)');
+    assert.equal(rows[0].status, 'rejected');
+
+    testDb.close();
+  });
+
+  it('countStoriesByUserSince returns correct count', () => {
+    // create 2 stories for user 1002
+    createStory(db, 1002, 'סיפור ראשון');
+    createStory(db, 1002, 'סיפור שני');
+
+    // since a minute ago — should count the two just created plus any others
+    const sinceIso = new Date(Date.now() - 60_000).toISOString().replace('T', ' ').slice(0, 19);
+    const count = countStoriesByUserSince(db, 1002, sinceIso);
+    assert.ok(count >= 2, `expected at least 2, got ${count}`);
+
+    // future cutoff — should return 0
+    const futureIso = new Date(Date.now() + 60_000).toISOString().replace('T', ' ').slice(0, 19);
+    const zeroCount = countStoriesByUserSince(db, 1002, futureIso);
+    assert.equal(zeroCount, 0);
+  });
+
+  it('getPendingStories pagination returns correct slice', () => {
+    // Clear existing stories first to have known state
+    db.prepare("DELETE FROM shelter_stories WHERE status = 'pending'").run();
+
+    // Insert 5 pending stories
+    for (let i = 0; i < 5; i++) {
+      createStory(db, 1001, `סיפור ${i}`);
+    }
+
+    const page1 = getPendingStories(db, 3, 0);
+    assert.equal(page1.length, 3);
+
+    const page2 = getPendingStories(db, 3, 3);
+    assert.equal(page2.length, 2);
+
+    const allIds = [...page1, ...page2].map((s) => s.id);
+    const unique = new Set(allIds);
+    assert.equal(unique.size, 5, 'all 5 stories should be distinct');
+  });
+
+  it('getCountsByStatus returns correct counts per status', () => {
+    // Use a fresh db to get deterministic counts
+    const testDb = new Database(':memory:');
+    testDb.pragma('foreign_keys = ON');
+    initSchema(testDb);
+    testDb.prepare('INSERT INTO users (chat_id) VALUES (?)').run(2001);
+
+    createStory(testDb, 2001, 'pending 1');
+    createStory(testDb, 2001, 'pending 2');
+    const s3 = createStory(testDb, 2001, 'to reject');
+    rejectStory(testDb, s3.id, 'admin');
+    const s4 = createStory(testDb, 2001, 'to approve');
+    approveStory(testDb, s4.id, 'admin', 111);
+
+    const counts = getCountsByStatus(testDb);
+    assert.equal(counts.pending, 2);
+    assert.equal(counts.rejected, 1);
+    assert.equal(counts.published, 1);
+    assert.equal(counts.approved, 0);
+
+    testDb.close();
+  });
+});

--- a/src/__tests__/shelterStoryRepository.test.ts
+++ b/src/__tests__/shelterStoryRepository.test.ts
@@ -8,7 +8,7 @@ import {
   getStoriesByStatus,
   getStoryById,
   lockForApproval,
-  approveStory,
+  publishStory,
   rejectStory,
   countStoriesByUserSince,
   getCountsByStatus,
@@ -35,9 +35,10 @@ describe('shelterStoryRepository', () => {
     assert.ok(story.id > 0);
   });
 
-  it('createStory rejects body > 200 chars (SQLite CHECK constraint)', () => {
-    const longBody = 'א'.repeat(201);
-    assert.throws(() => createStory(db, 1001, longBody));
+  it('createStory accepts body of any length (app layer enforces limit)', () => {
+    const longBody = 'א'.repeat(300);
+    const story = createStory(db, 1001, longBody);
+    assert.equal(story.body, longBody);
   });
 
   it('lockForApproval returns true and sets status=approved for pending story', () => {
@@ -61,16 +62,26 @@ describe('shelterStoryRepository', () => {
     assert.equal(result, false);
   });
 
-  it('approveStory sets status=published and publishedMessageId', () => {
+  it('publishStory transitions approved→published and returns true', () => {
     const story = createStory(db, 1001, 'חוויה מהמקלט לאישור');
     lockForApproval(db, story.id); // lock first (as the route does)
-    approveStory(db, story.id, 'admin', 9999);
+    const result = publishStory(db, story.id, 'admin', 9999);
+    assert.equal(result, true);
     const updated = getStoryById(db, story.id);
     assert.ok(updated !== null);
     assert.equal(updated!.status, 'published');
     assert.equal(updated!.publishedMessageId, 9999);
     assert.equal(updated!.reviewedBy, 'admin');
     assert.ok(updated!.reviewedAt !== null);
+  });
+
+  it('publishStory returns false for non-approved story', () => {
+    const story = createStory(db, 1001, 'סיפור בהמתנה');
+    // skip lockForApproval — story is still 'pending'
+    const result = publishStory(db, story.id, 'admin', 1234);
+    assert.equal(result, false);
+    const updated = getStoryById(db, story.id);
+    assert.equal(updated!.status, 'pending');
   });
 
   it('rejectStory returns true and sets status=rejected for pending story', () => {
@@ -164,7 +175,8 @@ describe('shelterStoryRepository', () => {
     const s3 = createStory(testDb, 2001, 'to reject');
     rejectStory(testDb, s3.id, 'admin');
     const s4 = createStory(testDb, 2001, 'to approve');
-    approveStory(testDb, s4.id, 'admin', 111);
+    lockForApproval(testDb, s4.id);
+    publishStory(testDb, s4.id, 'admin', 111);
 
     const counts = getCountsByStatus(testDb);
     assert.equal(counts.pending, 2);

--- a/src/__tests__/skillCatalogRepository.test.ts
+++ b/src/__tests__/skillCatalogRepository.test.ts
@@ -150,6 +150,8 @@ describe('skillCatalogRepository', () => {
     `;
     db.prepare(createUserSkills).run();
 
+    // Insert user first (FK constraint on user_skills.chat_id → users.chat_id)
+    db.prepare('INSERT OR IGNORE INTO users (chat_id) VALUES (?)').run(1001);
     // Insert one usage row for first_aid (seeded by initSchema)
     db.prepare('INSERT OR IGNORE INTO user_skills (chat_id, skill_key) VALUES (?, ?)').run(1001, 'first_aid');
 

--- a/src/__tests__/skillCatalogRepository.test.ts
+++ b/src/__tests__/skillCatalogRepository.test.ts
@@ -1,0 +1,200 @@
+import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  listActiveSkills,
+  listAllSkills,
+  getSkillByKey,
+  upsertSkill,
+  deactivateSkill,
+  activateSkill,
+  getUsageCount,
+} from '../db/skillCatalogRepository.js';
+
+describe('skillCatalogRepository', () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(':memory:');
+    initSchema(db);
+  });
+
+  // 1. listActiveSkills returns only is_active=1 rows, ordered by sort_order
+  test('listActiveSkills returns only active rows ordered by sort_order', () => {
+    // Seed rows with non-sequential sort_order to verify ordering
+    upsertSkill(db, { key: 'z_skill', labelHe: 'אחרון', description: null, isActive: true, sortOrder: 99 });
+    upsertSkill(db, { key: 'a_skill', labelHe: 'ראשון', description: null, isActive: true, sortOrder: 0 });
+    upsertSkill(db, { key: 'inactive_skill', labelHe: 'לא פעיל', description: null, isActive: false, sortOrder: 1 });
+
+    const rows = listActiveSkills(db);
+    // inactive_skill must be excluded
+    assert.ok(!rows.some((r) => r.key === 'inactive_skill'), 'inactive skill must be excluded');
+    // Verify ordering: a_skill (0) < z_skill (99)
+    const keys = rows.map((r) => r.key);
+    const idxA = keys.indexOf('a_skill');
+    const idxZ = keys.indexOf('z_skill');
+    assert.ok(idxA < idxZ, 'sort_order=0 must come before sort_order=99');
+  });
+
+  // 2. upsertSkill creates a new row
+  test('upsertSkill creates a new row', () => {
+    upsertSkill(db, { key: 'test_skill', labelHe: 'בדיקה', description: 'תיאור', isActive: true, sortOrder: 10 });
+    const row = getSkillByKey(db, 'test_skill');
+    assert.ok(row !== null, 'row should be found after insert');
+    assert.equal(row!.key, 'test_skill');
+    assert.equal(row!.labelHe, 'בדיקה');
+    assert.equal(row!.description, 'תיאור');
+    assert.equal(row!.isActive, true);
+    assert.equal(row!.sortOrder, 10);
+  });
+
+  // 3. upsertSkill updates existing row — created_at unchanged, updated_at changes
+  test('upsertSkill updates existing row without touching created_at', (_, done) => {
+    upsertSkill(db, { key: 'update_me', labelHe: 'לפני', description: null, isActive: true, sortOrder: 1 });
+    const before = getSkillByKey(db, 'update_me')!;
+    assert.ok(before, 'row must exist after first upsert');
+
+    // SQLite datetime() has 1-second resolution — wait 1100ms before second upsert
+    // so updated_at is guaranteed to differ
+    setTimeout(() => {
+      upsertSkill(db, { key: 'update_me', labelHe: 'אחרי', description: 'חדש', isActive: false, sortOrder: 2 });
+      const after = getSkillByKey(db, 'update_me')!;
+
+      assert.equal(after.labelHe, 'אחרי', 'labelHe must be updated');
+      assert.equal(after.description, 'חדש', 'description must be updated');
+      assert.equal(after.isActive, false, 'isActive must be updated');
+      assert.equal(after.sortOrder, 2, 'sortOrder must be updated');
+      assert.equal(after.createdAt, before.createdAt, 'createdAt must not change on update');
+      assert.notEqual(after.updatedAt, before.updatedAt, 'updatedAt must change on update');
+
+      done!();
+    }, 1100);
+  });
+
+  // 4. upsertSkill rejects invalid keys
+  test('upsertSkill throws on invalid key format', () => {
+    assert.throws(
+      () => upsertSkill(db, { key: 'UPPER_CASE', labelHe: 'bad', description: null, isActive: true, sortOrder: 0 }),
+      /Invalid skill key format/
+    );
+    assert.throws(
+      () => upsertSkill(db, { key: 'has space', labelHe: 'bad', description: null, isActive: true, sortOrder: 0 }),
+      /Invalid skill key format/
+    );
+    assert.throws(
+      () => upsertSkill(db, { key: '', labelHe: 'bad', description: null, isActive: true, sortOrder: 0 }),
+      /Invalid skill key format/
+    );
+    assert.throws(
+      () => upsertSkill(db, { key: 'a'.repeat(33), labelHe: 'bad', description: null, isActive: true, sortOrder: 0 }),
+      /Invalid skill key format/
+    );
+  });
+
+  // 5. deactivateSkill sets is_active=0; listActiveSkills excludes it
+  test('deactivateSkill excludes skill from listActiveSkills', () => {
+    upsertSkill(db, { key: 'to_deactivate', labelHe: 'כן', description: null, isActive: true, sortOrder: 1 });
+    deactivateSkill(db, 'to_deactivate');
+
+    const row = getSkillByKey(db, 'to_deactivate')!;
+    assert.equal(row.isActive, false, 'isActive must be false after deactivation');
+
+    const active = listActiveSkills(db);
+    assert.ok(!active.some((r) => r.key === 'to_deactivate'), 'deactivated skill must not appear in listActiveSkills');
+  });
+
+  // 6. activateSkill restores is_active=1
+  test('activateSkill restores is_active to true', () => {
+    upsertSkill(db, { key: 'restore_me', labelHe: 'לשחזר', description: null, isActive: false, sortOrder: 1 });
+    activateSkill(db, 'restore_me');
+
+    const row = getSkillByKey(db, 'restore_me')!;
+    assert.equal(row.isActive, true, 'isActive must be true after activation');
+
+    const active = listActiveSkills(db);
+    assert.ok(active.some((r) => r.key === 'restore_me'), 'activated skill must appear in listActiveSkills');
+  });
+
+  // 7. getSkillByKey returns null for unknown key
+  test('getSkillByKey returns null for missing key', () => {
+    const result = getSkillByKey(db, 'does_not_exist');
+    assert.equal(result, null);
+  });
+
+  // 8. getUsageCount returns 0 when user_skills table doesn't exist
+  test('getUsageCount returns 0 when user_skills table is absent', () => {
+    upsertSkill(db, { key: 'no_users', labelHe: 'לא בשימוש', description: null, isActive: true, sortOrder: 1 });
+    const count = getUsageCount(db, 'no_users');
+    assert.equal(count, 0);
+  });
+
+  // 9. listAllSkills includes usage_count=0 for skills with no user_skills rows
+  test('listAllSkills includes usage_count=0 for skills with no user_skills rows', () => {
+    upsertSkill(db, { key: 'unused_skill', labelHe: 'לא נמצא', description: null, isActive: true, sortOrder: 1 });
+    const rows = listAllSkills(db);
+    const found = rows.find((r) => r.key === 'unused_skill');
+    assert.ok(found, 'skill must appear in listAllSkills');
+    assert.equal(found!.usageCount, 0, 'usageCount must be 0 when user_skills is absent');
+  });
+
+  // 10. listAllSkills usage_count JOIN path — skill used by one user
+  test('listAllSkills returns usage_count=1 when user_skills has a matching row', () => {
+    // Create user_skills table (mirrors the real schema)
+    const createUserSkills = `
+      CREATE TABLE IF NOT EXISTS user_skills (
+        chat_id   INTEGER NOT NULL,
+        skill_key TEXT NOT NULL,
+        PRIMARY KEY (chat_id, skill_key)
+      );
+    `;
+    db.prepare(createUserSkills).run();
+
+    // Insert one usage row for first_aid (seeded by initSchema)
+    db.prepare('INSERT OR IGNORE INTO user_skills (chat_id, skill_key) VALUES (?, ?)').run(1001, 'first_aid');
+
+    const rows = listAllSkills(db);
+
+    const firstAid = rows.find((r) => r.key === 'first_aid');
+    assert.ok(firstAid, 'first_aid must appear in listAllSkills');
+    assert.equal(firstAid!.usageCount, 1, 'first_aid usageCount must be 1');
+
+    const shelterHost = rows.find((r) => r.key === 'shelter_host');
+    assert.ok(shelterHost, 'shelter_host must appear in listAllSkills');
+    assert.equal(shelterHost!.usageCount, 0, 'shelter_host usageCount must be 0 (no rows in user_skills)');
+  });
+
+  // Bonus: boolean columns are decoded as boolean, not number
+  test('boolean columns are decoded as TypeScript boolean, not number', () => {
+    upsertSkill(db, { key: 'bool_test', labelHe: 'בוליאני', description: null, isActive: true, sortOrder: 1 });
+    const row = getSkillByKey(db, 'bool_test')!;
+    assert.equal(typeof row.isActive, 'boolean', 'isActive must be boolean type');
+    assert.equal(row.isActive, true);
+  });
+
+  // Idempotency: running initSchema twice must not throw
+  test('migration is idempotent — re-running initSchema does not throw', () => {
+    initSchema(db);
+    initSchema(db);
+    assert.ok(true, 'no error thrown');
+  });
+
+  // Seed data is loaded by initSchema
+  test('initSchema seeds the default skills', () => {
+    const rows = listActiveSkills(db);
+    const keys = rows.map((r) => r.key);
+    assert.ok(keys.includes('first_aid'), 'first_aid must be seeded');
+    assert.ok(keys.includes('shelter_host'), 'shelter_host must be seeded');
+    assert.ok(keys.includes('psych_support'), 'psych_support must be seeded');
+    assert.ok(keys.includes('ride_share'), 'ride_share must be seeded');
+    assert.ok(keys.includes('water_food'), 'water_food must be seeded');
+  });
+
+  // Seeded skills have correct labels
+  test('seeded first_aid skill has correct Hebrew label', () => {
+    const row = getSkillByKey(db, 'first_aid');
+    assert.ok(row !== null);
+    assert.equal(row!.labelHe, 'עזרה ראשונה');
+    assert.equal(row!.isActive, true);
+  });
+});

--- a/src/__tests__/skillsHandler.test.ts
+++ b/src/__tests__/skillsHandler.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, before, beforeEach, mock } from 'node:test';
+import assert from 'node:assert/strict';
+import type { Bot, Context } from 'grammy';
+import { initDb, getDb } from '../db/schema.js';
+import { upsertSkill } from '../db/userSkillsRepository.js';
+import {
+  registerSkillsHandler,
+  clearPendingSkillNote,
+  hasPendingSkillNote,
+} from '../bot/skillsHandler.js';
+
+before(() => {
+  process.env['DB_PATH'] = ':memory:';
+  initDb();
+  // Seed a user
+  const db = getDb();
+  db.prepare(
+    `INSERT OR IGNORE INTO users (chat_id, display_name, home_city, onboarding_completed)
+     VALUES (?, ?, ?, 1)`
+  ).run(12345, 'TestUser', 'תל אביב');
+});
+
+type HandlerFn = (ctx: Context, next?: () => Promise<void>) => Promise<void>;
+
+function createMockBot() {
+  const commandHandlers = new Map<string, HandlerFn>();
+  const callbackHandlers = new Map<string | RegExp, HandlerFn>();
+  const textHandlers: HandlerFn[] = [];
+
+  const bot = {
+    command: (name: string, fn: HandlerFn) => {
+      commandHandlers.set(name, fn);
+    },
+    callbackQuery: (pat: string | RegExp, fn: HandlerFn) => {
+      callbackHandlers.set(pat, fn);
+    },
+    on: (event: string, fn: HandlerFn) => {
+      if (event === 'message:text') textHandlers.push(fn);
+    },
+    api: {
+      sendMessage: mock.fn(async () => ({ message_id: 1 })),
+    },
+  } as unknown as Bot;
+
+  return { bot, commandHandlers, callbackHandlers, textHandlers };
+}
+
+function createMockCtx(overrides: Record<string, unknown> = {}): Context {
+  return {
+    from: { id: 12345, first_name: 'Test' },
+    chat: { id: 12345, type: 'private' },
+    message: { text: '' },
+    match: null,
+    reply: mock.fn(async () => ({ message_id: 1 })),
+    editMessageText: mock.fn(async () => ({})),
+    answerCallbackQuery: mock.fn(async () => {}),
+    ...overrides,
+  } as unknown as Context;
+}
+
+function findCallbackHandler(
+  handlers: Map<string | RegExp, HandlerFn>,
+  data: string
+): HandlerFn | undefined {
+  for (const [pat, fn] of handlers) {
+    if (typeof pat === 'string' && pat === data) return fn;
+    if (pat instanceof RegExp && pat.test(data)) return fn;
+  }
+  return undefined;
+}
+
+describe('skillsHandler', () => {
+  let commandHandlers: Map<string, HandlerFn>;
+  let callbackHandlers: Map<string | RegExp, HandlerFn>;
+  let textHandlers: HandlerFn[];
+
+  beforeEach(() => {
+    const mocked = createMockBot();
+    commandHandlers = mocked.commandHandlers;
+    callbackHandlers = mocked.callbackHandlers;
+    textHandlers = mocked.textHandlers;
+    registerSkillsHandler(mocked.bot);
+    clearPendingSkillNote(12345);
+  });
+
+  it('registers the /need command', () => {
+    assert.ok(commandHandlers.has('need'), '/need command must be registered');
+  });
+
+  it('/need without arg shows catalog keyboard', async () => {
+    const fn = commandHandlers.get('need')!;
+    const ctx = createMockCtx({ match: '' });
+    await fn(ctx);
+    const replyMock = ctx.reply as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(replyMock.mock.calls.length, 1);
+    const text = replyMock.mock.calls[0].arguments[0] as string;
+    assert.ok(text.includes('עזרה בשעת חירום'), 'should show catalog prompt');
+  });
+
+  it('/need <key> shows results for known skill', async () => {
+    const fn = commandHandlers.get('need')!;
+    // Seed user with public skill
+    const db = getDb();
+    db.prepare(
+      `INSERT OR IGNORE INTO users (chat_id, display_name, onboarding_completed) VALUES (?, ?, 1)`
+    ).run(9001, 'Helper');
+    upsertSkill(db, 9001, 'first_aid', 'public', null);
+
+    const ctx = createMockCtx({ match: 'first_aid' });
+    await fn(ctx);
+    const replyMock = ctx.reply as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(replyMock.mock.calls.length, 1);
+  });
+
+  it('/need <key> replies with error for unknown skill', async () => {
+    const fn = commandHandlers.get('need')!;
+    const ctx = createMockCtx({ match: 'nonexistent_xyz' });
+    await fn(ctx);
+    const replyMock = ctx.reply as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(replyMock.mock.calls.length, 1);
+    const text = replyMock.mock.calls[0].arguments[0] as string;
+    assert.ok(text.includes('לא נמצא'), 'should indicate skill not found');
+  });
+
+  it('sk:list callback shows skills list', async () => {
+    const fn = findCallbackHandler(callbackHandlers, 'sk:list');
+    assert.ok(fn, 'sk:list must be registered');
+    const ctx = createMockCtx();
+    await fn!(ctx);
+    const answerMock = ctx.answerCallbackQuery as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(answerMock.mock.calls.length, 1, 'must answer callback query');
+    const editMock = ctx.editMessageText as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(editMock.mock.calls.length, 1, 'must edit message with skills list');
+  });
+
+  it('sk:pick callback shows catalog buttons', async () => {
+    const fn = findCallbackHandler(callbackHandlers, 'sk:pick');
+    assert.ok(fn, 'sk:pick must be registered');
+    const ctx = createMockCtx();
+    await fn!(ctx);
+    const answerMock = ctx.answerCallbackQuery as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(answerMock.mock.calls.length, 1);
+    const editMock = ctx.editMessageText as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(editMock.mock.calls.length, 1);
+    const text = editMock.mock.calls[0].arguments[0] as string;
+    assert.ok(text.includes('בחר כישור'), 'should show catalog prompt');
+  });
+
+  it('sk:add:<key> adds skill and shows visibility keyboard', async () => {
+    const fn = findCallbackHandler(callbackHandlers, 'sk:add:shelter_host');
+    assert.ok(fn, 'sk:add regex handler must be registered');
+    const ctx = createMockCtx({ match: ['sk:add:shelter_host', 'shelter_host'] });
+    await fn!(ctx);
+    const answerMock = ctx.answerCallbackQuery as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(answerMock.mock.calls.length, 1);
+    const editMock = ctx.editMessageText as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(editMock.mock.calls.length, 1);
+    const text = editMock.mock.calls[0].arguments[0] as string;
+    assert.ok(text.includes('נוסף'), 'should confirm skill was added');
+  });
+
+  it('sk:rm:<key> removes skill', async () => {
+    // First add the skill
+    const db = getDb();
+    upsertSkill(db, 12345, 'ride_share', 'contacts', null);
+
+    const fn = findCallbackHandler(callbackHandlers, 'sk:rm:ride_share');
+    assert.ok(fn, 'sk:rm regex handler must be registered');
+    const ctx = createMockCtx({ match: ['sk:rm:ride_share', 'ride_share'] });
+    await fn!(ctx);
+    const answerMock = ctx.answerCallbackQuery as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(answerMock.mock.calls.length, 1);
+    const editMock = ctx.editMessageText as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(editMock.mock.calls.length, 1);
+  });
+
+  it('sk:note:<key> sets pendingSkillNote and prompts for note', async () => {
+    const fn = findCallbackHandler(callbackHandlers, 'sk:note:first_aid');
+    assert.ok(fn, 'sk:note regex handler must be registered');
+    assert.equal(hasPendingSkillNote(12345), false);
+    const ctx = createMockCtx({ match: ['sk:note:first_aid', 'first_aid'] });
+    await fn!(ctx);
+    assert.equal(hasPendingSkillNote(12345), true, 'pendingSkillNote should be set');
+    const editMock = ctx.editMessageText as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(editMock.mock.calls.length, 1);
+    const text = editMock.mock.calls[0].arguments[0] as string;
+    assert.ok(text.includes('הוסף הערה'), 'should prompt for note');
+    clearPendingSkillNote(12345);
+  });
+
+  it('text handler calls next() when NOT in pendingSkillNote', async () => {
+    const handler = textHandlers[textHandlers.length - 1];
+    assert.ok(handler, 'text handler must be registered');
+    assert.equal(hasPendingSkillNote(12345), false);
+    const nextFn = mock.fn(async () => {});
+    const ctx = createMockCtx({ message: { text: 'hello' } });
+    await handler(ctx, nextFn as unknown as () => Promise<void>);
+    assert.equal((nextFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length, 1, 'next() must be called');
+  });
+
+  it('text handler saves note and clears state when IN pendingSkillNote', async () => {
+    // Set up pending state
+    const fn = findCallbackHandler(callbackHandlers, 'sk:note:water_food');
+    assert.ok(fn);
+    const noteCtx = createMockCtx({ match: ['sk:note:water_food', 'water_food'] });
+    await fn!(noteCtx);
+    assert.equal(hasPendingSkillNote(12345), true);
+
+    const handler = textHandlers[textHandlers.length - 1];
+    const nextFn = mock.fn(async () => {});
+    const ctx = createMockCtx({ message: { text: 'I have water supplies' } });
+    await handler(ctx, nextFn as unknown as () => Promise<void>);
+
+    assert.equal((nextFn as unknown as ReturnType<typeof mock.fn>).mock.calls.length, 0, 'next() must NOT be called when handling note');
+    assert.equal(hasPendingSkillNote(12345), false, 'pending state should be cleared after note saved');
+    const replyMock = ctx.reply as unknown as ReturnType<typeof mock.fn>;
+    assert.equal(replyMock.mock.calls.length, 1, 'should send confirmation reply');
+    const text = replyMock.mock.calls[0].arguments[0] as string;
+    assert.ok(text.includes('נשמרה'), 'should confirm note was saved');
+  });
+});

--- a/src/__tests__/userSkillsRepository.test.ts
+++ b/src/__tests__/userSkillsRepository.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+import Database from 'better-sqlite3';
+import { initSchema } from '../db/schema.js';
+import {
+  listSkillsForUser,
+  upsertSkill,
+  removeSkill,
+  findUsersWithSkill,
+} from '../db/userSkillsRepository.js';
+
+function createMemDb(): Database.Database {
+  const db = new Database(':memory:');
+  db.pragma('foreign_keys = ON');
+  initSchema(db);
+  return db;
+}
+
+function seedUser(db: Database.Database, chatId: number, displayName?: string, homeCity?: string): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO users (chat_id, display_name, home_city, onboarding_completed)
+     VALUES (?, ?, ?, 1)`
+  ).run(chatId, displayName ?? undefined, homeCity ?? undefined);
+}
+
+describe('userSkillsRepository', () => {
+  let db: Database.Database;
+
+  before(() => {
+    db = createMemDb();
+    // Seed users for tests
+    seedUser(db, 1001, 'Alice', 'תל אביב');
+    seedUser(db, 1002, 'Bob', 'ירושלים');
+    seedUser(db, 1003, 'Carol', undefined);
+  });
+
+  it('listSkillsForUser returns empty array initially', () => {
+    const skills = listSkillsForUser(db, 1001);
+    assert.deepEqual(skills, []);
+  });
+
+  it('upsertSkill inserts and returns row', () => {
+    const row = upsertSkill(db, 1001, 'first_aid', 'contacts', null);
+    assert.equal(row.chatId, 1001);
+    assert.equal(row.skillKey, 'first_aid');
+    assert.equal(row.visibility, 'contacts');
+    assert.equal(row.note, null);
+    assert.ok(typeof row.createdAt === 'string');
+  });
+
+  it('listSkillsForUser returns inserted skill', () => {
+    const skills = listSkillsForUser(db, 1001);
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].skillKey, 'first_aid');
+  });
+
+  it('upsertSkill updates existing row (visibility change)', () => {
+    const row = upsertSkill(db, 1001, 'first_aid', 'public', 'experienced medic');
+    assert.equal(row.visibility, 'public');
+    assert.equal(row.note, 'experienced medic');
+
+    const skills = listSkillsForUser(db, 1001);
+    assert.equal(skills.length, 1);
+    assert.equal(skills[0].visibility, 'public');
+    assert.equal(skills[0].note, 'experienced medic');
+  });
+
+  it('removeSkill returns true and removes row', () => {
+    upsertSkill(db, 1002, 'shelter_host', 'contacts', null);
+    const removed = removeSkill(db, 1002, 'shelter_host');
+    assert.equal(removed, true);
+    const skills = listSkillsForUser(db, 1002);
+    assert.equal(skills.length, 0);
+  });
+
+  it('removeSkill returns false for non-existent skill', () => {
+    const removed = removeSkill(db, 1002, 'nonexistent_skill');
+    assert.equal(removed, false);
+  });
+
+  it('findUsersWithSkill shows public skills to anyone', () => {
+    // 1001 already has first_aid = public (from previous test)
+    // viewer 1002, no contacts with 1001
+    const results = findUsersWithSkill(db, 'first_aid', 1002, [], 10, 0);
+    assert.equal(results.length, 1);
+    assert.equal(results[0].displayName, 'Alice');
+    assert.equal(results[0].homeCity, 'תל אביב');
+  });
+
+  it('findUsersWithSkill hides private skills', () => {
+    upsertSkill(db, 1003, 'first_aid', 'private', null);
+    const results = findUsersWithSkill(db, 'first_aid', 1002, [1003], 10, 0);
+    // Carol has private visibility — should NOT appear
+    const carols = results.filter((r) => r.displayName === 'Carol');
+    assert.equal(carols.length, 0);
+  });
+
+  it('findUsersWithSkill shows contacts-visibility only if in contactIds', () => {
+    upsertSkill(db, 1003, 'psych_support', 'contacts', null);
+    // 1002 is NOT in contactIds → should not see Carol
+    const resultsNoContact = findUsersWithSkill(db, 'psych_support', 1002, [], 10, 0);
+    assert.equal(resultsNoContact.length, 0);
+
+    // 1002 IS in contactIds → should see Carol
+    const resultsWithContact = findUsersWithSkill(db, 'psych_support', 1002, [1003], 10, 0);
+    assert.equal(resultsWithContact.length, 1);
+    assert.equal(resultsWithContact[0].displayName, 'Carol');
+  });
+
+  it('findUsersWithSkill filters orphan skills (inactive catalog entry)', () => {
+    // Deactivate first_aid in the catalog
+    db.prepare(`UPDATE skill_catalog SET is_active = 0 WHERE key = 'first_aid'`).run();
+    const results = findUsersWithSkill(db, 'first_aid', 1002, [1001], 10, 0);
+    // Should return 0 because catalog entry is inactive
+    assert.equal(results.length, 0);
+    // Restore for other tests
+    db.prepare(`UPDATE skill_catalog SET is_active = 1 WHERE key = 'first_aid'`).run();
+  });
+
+  it('findUsersWithSkill applies LIMIT/OFFSET pagination', () => {
+    // Seed extra users and give them psych_support (public) to test pagination
+    for (let i = 2000; i < 2010; i++) {
+      seedUser(db, i, `User_${i}`, undefined);
+      upsertSkill(db, i, 'psych_support', 'public', null);
+    }
+
+    const page0 = findUsersWithSkill(db, 'psych_support', 9999, [], 5, 0);
+    const page1 = findUsersWithSkill(db, 'psych_support', 9999, [], 5, 5);
+
+    assert.equal(page0.length, 5);
+    assert.equal(page1.length, 5);
+    // Pages must not overlap
+    const names0 = new Set(page0.map((r) => r.displayName));
+    const names1 = new Set(page1.map((r) => r.displayName));
+    for (const name of names1) {
+      assert.ok(!names0.has(name), `Name ${name} appeared in both pages`);
+    }
+  });
+});

--- a/src/alertHandler.ts
+++ b/src/alertHandler.ts
@@ -29,6 +29,7 @@ export interface AlertHandlerDeps {
   insertAlertHistory: (alert: Alert) => void;
   broadcastToWhatsApp?: (alert: Alert, imageBuffer?: Buffer | null) => Promise<void>;
   dispatchSafetyPrompts?: (alert: Alert) => Promise<void>;
+  scheduleNeighborCheck?: (alert: Alert) => void;
   getNextSerial?: () => number;
   getDensityHint?: () => 'חריג' | 'רגיל' | null;
 }
@@ -47,6 +48,7 @@ export async function handleNewAlert(alert: Alert, deps: AlertHandlerDeps): Prom
     insertAlertHistory,
     broadcastToWhatsApp,
     dispatchSafetyPrompts,
+    scheduleNeighborCheck,
     getNextSerial,
     getDensityHint,
   } = deps;
@@ -187,6 +189,7 @@ export async function handleNewAlert(alert: Alert, deps: AlertHandlerDeps): Prom
     notifySubscribers({ ...alert, cities: dmCities });
     dispatchSafetyPrompts?.({ ...alert, cities: dmCities })
       .catch((err) => log('error', 'AlertHandler', `[safetyPrompts] ${err}`));
+    scheduleNeighborCheck?.({ ...alert, cities: dmCities });
   }
 
   if (broadcastToWhatsApp) {

--- a/src/alertWindowTracker.ts
+++ b/src/alertWindowTracker.ts
@@ -52,7 +52,7 @@ function scheduleCloseTimer(alertType: string, msg: TrackedMessage): void {
       }
     }
     activeMessages.delete(alertType);
-    try { deleteWindow(alertType); } catch { /* ignore */ }
+    try { deleteWindow(alertType); } catch (err) { log('warn', 'AlertWindow', `deleteWindow on timer failed: ${err}`); }
   }, delay);
   closeTimers.set(alertType, timer);
 }

--- a/src/alertWindowTracker.ts
+++ b/src/alertWindowTracker.ts
@@ -13,6 +13,17 @@ export interface TrackedMessage {
 
 const activeMessages = new Map<string, TrackedMessage>();
 
+let windowCloseCallback: ((alertType: string, tracked: TrackedMessage) => void) | null = null;
+
+/** Pending close timers keyed by alertType. */
+const closeTimers = new Map<string, NodeJS.Timeout>();
+
+export function setWindowCloseCallback(
+  fn: (alertType: string, tracked: TrackedMessage) => void
+): void {
+  windowCloseCallback = fn;
+}
+
 function windowMs(): number {
   // Re-read on each call — caching at module load would capture the env before .env is loaded;
   // also allows test overrides of the env var without requiring a module reload. Default: 120s.
@@ -21,10 +32,45 @@ function windowMs(): number {
   return (isNaN(parsed) || parsed <= 0 ? 120 : parsed) * 1000;
 }
 
+/** Schedule (or reschedule) the close timer for a given alertType. */
+function scheduleCloseTimer(alertType: string, msg: TrackedMessage): void {
+  const existing = closeTimers.get(alertType);
+  if (existing) clearTimeout(existing);
+
+  const delay = windowMs() - (Date.now() - msg.sentAt);
+  if (delay <= 0) return; // already expired — caller handles eviction separately
+
+  const timer = setTimeout(() => {
+    closeTimers.delete(alertType);
+    const stillActive = activeMessages.get(alertType);
+    if (!stillActive) return; // already expired or deleted elsewhere
+    if (windowCloseCallback) {
+      try {
+        windowCloseCallback(alertType, { ...stillActive });
+      } catch (err) {
+        log('error', 'AlertWindow', `windowCloseCallback timer error: ${String(err)}`);
+      }
+    }
+    activeMessages.delete(alertType);
+    try { deleteWindow(alertType); } catch { /* ignore */ }
+  }, delay);
+  closeTimers.set(alertType, timer);
+}
+
 export function getActiveMessage(alertType: string): TrackedMessage | null {
   const tracked = activeMessages.get(alertType);
   if (!tracked) return null;
   if (Date.now() - tracked.sentAt > windowMs()) {
+    if (windowCloseCallback) {
+      try {
+        windowCloseCallback(alertType, { ...tracked });
+      } catch (err) {
+        log('error', 'AlertWindow', `windowCloseCallback error: ${String(err)}`);
+      }
+    }
+    // Cancel the timer since we're handling expiry inline here
+    const t = closeTimers.get(alertType);
+    if (t) { clearTimeout(t); closeTimers.delete(alertType); }
     try {
       deleteWindow(alertType);
     } catch (err) {
@@ -40,6 +86,7 @@ export function getActiveMessage(alertType: string): TrackedMessage | null {
 
 export function trackMessage(alertType: string, msg: TrackedMessage): void {
   activeMessages.set(alertType, msg);
+  scheduleCloseTimer(alertType, msg);
   try {
     upsertWindow(alertType, msg);
   } catch (err) {
@@ -48,6 +95,9 @@ export function trackMessage(alertType: string, msg: TrackedMessage): void {
 }
 
 export function clearAll(): void {
+  // Cancel all pending timers before clearing
+  for (const t of closeTimers.values()) clearTimeout(t);
+  closeTimers.clear();
   activeMessages.clear();
   try {
     clearAllWindows();
@@ -59,6 +109,8 @@ export function clearAll(): void {
 // Clears only the in-memory map. Use in tests to reset state between cases without touching
 // the DB. Use clearAll() in production reset flows (clears both memory and the DB).
 export function clearMemoryOnly(): void {
+  for (const t of closeTimers.values()) clearTimeout(t);
+  closeTimers.clear();
   activeMessages.clear();
 }
 
@@ -75,6 +127,7 @@ export function loadActiveMessages(): void {
   for (const { alertType, msg } of windows) {
     if (now - msg.sentAt <= windowMs()) {
       activeMessages.set(alertType, msg);
+      scheduleCloseTimer(alertType, msg);
       restored++;
     } else {
       try {
@@ -85,4 +138,10 @@ export function loadActiveMessages(): void {
     }
   }
   log('info', 'AlertWindow', `Loaded ${windows.length} window(s) from DB — ${restored} active, ${windows.length - restored} expired`);
+}
+
+/** Cancel all pending close timers. Call during graceful shutdown. */
+export function clearAllCloseTimers(): void {
+  for (const t of closeTimers.values()) clearTimeout(t);
+  closeTimers.clear();
 }

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -16,6 +16,7 @@ import { registerGroupHandler } from './groupHandler.js';
 import { registerCommunityPulseHandler } from './communityPulseHandler.js';
 import { registerShelterStoriesHandler } from './shelterStoriesHandler.js';
 import { registerSkillsHandler } from './skillsHandler.js';
+import { registerNeighborCheckHandler } from './neighborCheckHandler.js';
 import { log } from '../logger.js';
 
 export async function setupBotHandlers(bot: Bot): Promise<void> {
@@ -38,6 +39,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerLegendHandler(bot);
   registerShelterStoriesHandler(bot);
   registerSkillsHandler(bot);
+  registerNeighborCheckHandler(bot);
   registerCommunityPulseHandler(bot);
 
   bot.catch((err) => {

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -15,6 +15,7 @@ import { registerSafetyStatusHandler } from './safetyStatusHandler.js';
 import { registerGroupHandler } from './groupHandler.js';
 import { registerCommunityPulseHandler } from './communityPulseHandler.js';
 import { registerShelterStoriesHandler } from './shelterStoriesHandler.js';
+import { registerSkillsHandler } from './skillsHandler.js';
 import { log } from '../logger.js';
 
 export async function setupBotHandlers(bot: Bot): Promise<void> {
@@ -36,6 +37,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerTodayHandler(bot);
   registerLegendHandler(bot);
   registerShelterStoriesHandler(bot);
+  registerSkillsHandler(bot);
   registerCommunityPulseHandler(bot);
 
   bot.catch((err) => {
@@ -59,5 +61,6 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
     { command: 'legend',   description: 'מקרא אזורי ההתראה' },
     { command: 'status',   description: 'סטטוס ביטחוני שלך ואנשי קשר' },
     { command: 'share',    description: 'שתף חוויה מהמקלט' },
+    { command: 'need',     description: 'מצא עזרה לפי כישור' },
   ]);
 }

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -14,6 +14,7 @@ import { registerLegendHandler } from './legendHandler.js';
 import { registerSafetyStatusHandler } from './safetyStatusHandler.js';
 import { registerGroupHandler } from './groupHandler.js';
 import { registerCommunityPulseHandler } from './communityPulseHandler.js';
+import { registerShelterStoriesHandler } from './shelterStoriesHandler.js';
 import { log } from '../logger.js';
 
 export async function setupBotHandlers(bot: Bot): Promise<void> {
@@ -34,6 +35,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerPrivacyHandler(bot);
   registerTodayHandler(bot);
   registerLegendHandler(bot);
+  registerShelterStoriesHandler(bot);
   registerCommunityPulseHandler(bot);
 
   bot.catch((err) => {
@@ -56,5 +58,6 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
     { command: 'today',    description: 'סיכום יומי' },
     { command: 'legend',   description: 'מקרא אזורי ההתראה' },
     { command: 'status',   description: 'סטטוס ביטחוני שלך ואנשי קשר' },
+    { command: 'share',    description: 'שתף חוויה מהמקלט' },
   ]);
 }

--- a/src/bot/botSetup.ts
+++ b/src/bot/botSetup.ts
@@ -13,6 +13,7 @@ import { registerTodayHandler } from './todayHandler.js';
 import { registerLegendHandler } from './legendHandler.js';
 import { registerSafetyStatusHandler } from './safetyStatusHandler.js';
 import { registerGroupHandler } from './groupHandler.js';
+import { registerCommunityPulseHandler } from './communityPulseHandler.js';
 import { log } from '../logger.js';
 
 export async function setupBotHandlers(bot: Bot): Promise<void> {
@@ -33,6 +34,7 @@ export async function setupBotHandlers(bot: Bot): Promise<void> {
   registerPrivacyHandler(bot);
   registerTodayHandler(bot);
   registerLegendHandler(bot);
+  registerCommunityPulseHandler(bot);
 
   bot.catch((err) => {
     log('error', 'Bot', `Unhandled error: ${String(err)}`);

--- a/src/bot/communityPulseHandler.ts
+++ b/src/bot/communityPulseHandler.ts
@@ -46,7 +46,7 @@ export function registerCommunityPulseHandler(bot: Bot): void {
   bot.callbackQuery(/^pulse:(ok|scared|helping):\d+$/, async (ctx) => {
     const chatId = ctx.from?.id;
     if (!chatId) {
-      await ctx.answerCallbackQuery().catch(() => {});
+      await ctx.answerCallbackQuery().catch((e) => log('warn', 'CommunityPulse', `answerCallbackQuery: ${e}`));
       return;
     }
 
@@ -62,13 +62,15 @@ export function registerCommunityPulseHandler(bot: Bot): void {
       const { answer, pulseId } = parsed;
       const db = getDb();
 
-      insertResponse(db, pulseId, chatId, answer);
+      const inserted = insertResponse(db, pulseId, chatId, answer);
 
       const threshold = getNumber(db, 'pulse_aggregate_threshold', 5);
       const agg = getAggregate(db, pulseId);
 
       const label = ANSWER_LABELS[answer];
-      let text = `תודה על המענה ${label} ✅`;
+      let text = inserted
+        ? `תודה על המענה ${label} ✅`
+        : `כבר ענית על הסקר הזה — התשובה המקורית שלך נשמרה.`;
 
       if (agg.total >= threshold) {
         text += `\n\n${buildAggregateText(agg.total, agg.ok, agg.scared, agg.helping)}`;
@@ -86,7 +88,7 @@ export function registerCommunityPulseHandler(bot: Bot): void {
       log('error', 'CommunityPulse', `callback error: ${String(err)}`);
     } finally {
       if (!answered) {
-        await ctx.answerCallbackQuery().catch(() => {});
+        await ctx.answerCallbackQuery().catch((e) => log('warn', 'CommunityPulse', `answerCallbackQuery: ${e}`));
       }
     }
   });
@@ -118,7 +120,7 @@ export function registerCommunityPulseHandler(bot: Bot): void {
       log('error', 'CommunityPulse', `agg callback error: ${String(err)}`);
     } finally {
       if (!answered) {
-        await ctx.answerCallbackQuery().catch(() => {});
+        await ctx.answerCallbackQuery().catch((e) => log('warn', 'CommunityPulse', `answerCallbackQuery: ${e}`));
       }
     }
   });

--- a/src/bot/communityPulseHandler.ts
+++ b/src/bot/communityPulseHandler.ts
@@ -1,0 +1,125 @@
+import type { Bot } from 'grammy';
+import { getDb } from '../db/schema.js';
+import {
+  insertResponse,
+  getAggregate,
+  getPulseByFingerprint as _getPulseByFingerprint,
+} from '../db/communityPulseRepository.js';
+import type { PulseAnswer } from '../db/communityPulseRepository.js';
+import { getNumber } from '../config/configResolver.js';
+import { log } from '../logger.js';
+
+const ANSWER_LABELS: Record<PulseAnswer, string> = {
+  ok:      '✅ בסדר',
+  scared:  '😰 מפחד/ת',
+  helping: '🤝 עוזר/ת לאחרים',
+};
+
+function buildAggregateText(
+  total: number, ok: number, scared: number, helping: number
+): string {
+  return (
+    `📊 <b>תוצאות הסקר</b>\n\n` +
+    `✅ בסדר: <b>${ok}</b>\n` +
+    `😰 מפחד/ת: <b>${scared}</b>\n` +
+    `🤝 עוזר/ת: <b>${helping}</b>\n\n` +
+    `<i>סה"כ ${total} משיבים</i>`
+  );
+}
+
+function parseCallback(
+  data: string
+): { answer: PulseAnswer; pulseId: number } | null {
+  const m = data.match(/^pulse:(ok|scared|helping):(\d+)$/);
+  if (!m) return null;
+  return { answer: m[1] as PulseAnswer, pulseId: Number(m[2]) };
+}
+
+function parseAggCallback(data: string): number | null {
+  const m = data.match(/^pulse:agg:(\d+)$/);
+  if (!m) return null;
+  return Number(m[1]);
+}
+
+export function registerCommunityPulseHandler(bot: Bot): void {
+  // Response handler: pulse:ok|scared|helping:<pulseId>
+  bot.callbackQuery(/^pulse:(ok|scared|helping):\d+$/, async (ctx) => {
+    const chatId = ctx.from?.id;
+    if (!chatId) {
+      await ctx.answerCallbackQuery().catch(() => {});
+      return;
+    }
+
+    let answered = false;
+    try {
+      const parsed = parseCallback(ctx.callbackQuery.data);
+      if (!parsed) {
+        await ctx.answerCallbackQuery();
+        answered = true;
+        return;
+      }
+
+      const { answer, pulseId } = parsed;
+      const db = getDb();
+
+      insertResponse(db, pulseId, chatId, answer);
+
+      const threshold = getNumber(db, 'pulse_aggregate_threshold', 5);
+      const agg = getAggregate(db, pulseId);
+
+      const label = ANSWER_LABELS[answer];
+      let text = `תודה על המענה ${label} ✅`;
+
+      if (agg.total >= threshold) {
+        text += `\n\n${buildAggregateText(agg.total, agg.ok, agg.scared, agg.helping)}`;
+      }
+
+      await ctx.editMessageText(text, {
+        parse_mode: 'HTML',
+        reply_markup: {
+          inline_keyboard: [[
+            { text: '📊 ראה תוצאות', callback_data: `pulse:agg:${pulseId}` },
+          ]],
+        },
+      });
+    } catch (err) {
+      log('error', 'CommunityPulse', `callback error: ${String(err)}`);
+    } finally {
+      if (!answered) {
+        await ctx.answerCallbackQuery().catch(() => {});
+      }
+    }
+  });
+
+  // Aggregate view handler: pulse:agg:<pulseId>
+  bot.callbackQuery(/^pulse:agg:\d+$/, async (ctx) => {
+    let answered = false;
+    try {
+      const pulseId = parseAggCallback(ctx.callbackQuery.data);
+      if (pulseId === null) {
+        await ctx.answerCallbackQuery();
+        answered = true;
+        return;
+      }
+
+      const db = getDb();
+      const threshold = getNumber(db, 'pulse_aggregate_threshold', 5);
+      const agg = getAggregate(db, pulseId);
+
+      let text: string;
+      if (agg.total < threshold) {
+        text = `עדיין מוקדם — אין מספיק תגובות להצגה.`;
+      } else {
+        text = buildAggregateText(agg.total, agg.ok, agg.scared, agg.helping);
+      }
+
+      await ctx.editMessageText(text, { parse_mode: 'HTML' });
+    } catch (err) {
+      log('error', 'CommunityPulse', `agg callback error: ${String(err)}`);
+    } finally {
+      if (!answered) {
+        await ctx.answerCallbackQuery().catch(() => {});
+      }
+    }
+  });
+}

--- a/src/bot/groupHandler.ts
+++ b/src/bot/groupHandler.ts
@@ -2,7 +2,7 @@ import crypto from 'crypto';
 import type Database from 'better-sqlite3';
 import { Bot, InlineKeyboard } from 'grammy';
 import type { Context } from 'grammy';
-import { upsertUser, getUser } from '../db/userRepository.js';
+import { upsertUser, getUser, findUserByConnectionCode } from '../db/userRepository.js';
 import type { User } from '../db/userRepository.js';
 import {
   createGroup,
@@ -14,11 +14,14 @@ import {
   addMember,
   removeMember,
   deleteGroup,
+  transferOwnership,
   countGroupsOwnedBy,
   countMembersOfGroup,
   InviteCodeCollisionError,
   type Group,
 } from '../db/groupRepository.js';
+import { insertAudit } from '../db/groupAuditRepository.js';
+import { dmQueue } from '../services/dmQueue.js';
 import { getDb } from '../db/schema.js';
 import { log } from '../logger.js';
 import { escapeHtml, formatRelativeTime } from '../textUtils.js';
@@ -644,6 +647,115 @@ async function performLeave(
   });
 }
 
+// ─── Pending delete nonces (ephemeral, in-memory) ───────────────────────────
+
+interface PendingDelete {
+  groupId: number;
+  nonce: string;
+  expiresAt: number;
+}
+
+/** chatId → pending delete confirmation. Exported for test reset. */
+export const pendingDeletes = new Map<number, PendingDelete>();
+
+// ─── /group delete <name> ────────────────────────────────────────────────────
+
+async function handleDelete(ctx: Context, name: string): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+
+  const trimmed = name.trim();
+  if (trimmed.length === 0) {
+    await ctx.reply(
+      '❌ חסר שם קבוצה.\nשימוש: <code>/group delete &lt;שם&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  const db = getDb();
+  const groups = getGroupsForUser(db, chatId);
+  const group = groups.find((g) => g.name === trimmed && g.ownerId === chatId);
+  if (!group) {
+    await ctx.reply('❌ קבוצה לא נמצאה או שאינך הבעלים שלה.');
+    return;
+  }
+
+  const nonce = crypto.randomBytes(4).toString('hex');
+  pendingDeletes.set(chatId, { groupId: group.id, nonce, expiresAt: Date.now() + 60_000 });
+
+  const kb = new InlineKeyboard()
+    .text('✅ אשר מחיקה', cb(`gdel:conf:${group.id}:${nonce}`))
+    .text('❌ ביטול', cb(`gdel:cancel:${group.id}`));
+
+  await ctx.reply(
+    `⚠️ האם למחוק את הקבוצה "${escapeHtml(trimmed)}" ולהסיר את כל חברי הקבוצה? פעולה זו אינה הפיכה.`,
+    { parse_mode: 'HTML', reply_markup: kb }
+  );
+}
+
+// ─── /group transfer <name> <code> ──────────────────────────────────────────
+
+async function handleTransfer(ctx: Context, args: string[]): Promise<void> {
+  const chatId = ctx.chat?.id;
+  if (!chatId) return;
+
+  const name = args.slice(0, -1).join(' ').trim();
+  const code = args[args.length - 1]?.trim() ?? '';
+
+  if (!name || !code) {
+    await ctx.reply(
+      '❌ שימוש: <code>/group transfer &lt;שם&gt; &lt;קוד חיבור&gt;</code>',
+      { parse_mode: 'HTML' }
+    );
+    return;
+  }
+
+  const db = getDb();
+  const groups = getGroupsForUser(db, chatId);
+  const group = groups.find((g) => g.name === name && g.ownerId === chatId);
+  if (!group) {
+    await ctx.reply('❌ קבוצה לא נמצאה או שאינך הבעלים שלה.');
+    return;
+  }
+
+  const target = findUserByConnectionCode(code);
+  if (!target) {
+    await ctx.reply('❌ לא נמצא משתמש עם קוד החיבור הזה.');
+    return;
+  }
+
+  const members = getMembersOfGroup(db, group.id);
+  if (!members.some((m) => m.userId === target.chat_id)) {
+    await ctx.reply('❌ המשתמש אינו חבר בקבוצה זו.');
+    return;
+  }
+
+  const ok = transferOwnership(db, group.id, chatId, target.chat_id);
+  if (!ok) {
+    await ctx.reply('❌ העברת הבעלות נכשלה — נסה שוב.');
+    return;
+  }
+
+  insertAudit(db, {
+    groupId: group.id,
+    action: 'transferred',
+    actorId: chatId,
+    payload: JSON.stringify({ to: target.chat_id }),
+  });
+
+  log('info', 'Groups', `User ${chatId} transferred group ${group.id} (${group.name}) to ${target.chat_id}`);
+
+  // Notify new owner via DM queue
+  dmQueue.enqueueAll([
+    { chatId: String(target.chat_id), text: `אתה כעת מנהל הקבוצה "${name}".` },
+  ]);
+
+  await ctx.reply(`✅ הבעלות על הקבוצה "${escapeHtml(name)}" הועברה.`, {
+    parse_mode: 'HTML',
+  });
+}
+
 // ─── Main dispatch ───────────────────────────────────────────────────────────
 
 async function handleGroupCommand(ctx: Context): Promise<void> {
@@ -686,6 +798,12 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
     case 'status':
       await handleStatus(ctx, args[1]);
       return;
+    case 'delete':
+      await handleDelete(ctx, rest);
+      return;
+    case 'transfer':
+      await handleTransfer(ctx, args.slice(1));
+      return;
     default:
       await ctx.reply(
         '❌ פקודה לא מוכרת.\n\n' +
@@ -694,7 +812,9 @@ async function handleGroupCommand(ctx: Context): Promise<void> {
           '<code>/group create &lt;שם&gt;</code> — יצירת קבוצה\n' +
           '<code>/group join &lt;קוד&gt;</code> — הצטרפות עם קוד\n' +
           '<code>/group leave [id]</code> — עזיבת קבוצה\n' +
-          '<code>/group status [id]</code> — סטטוס קבוצתי',
+          '<code>/group status [id]</code> — סטטוס קבוצתי\n' +
+          '<code>/group delete &lt;שם&gt;</code> — מחיקת קבוצה\n' +
+          '<code>/group transfer &lt;שם&gt; &lt;קוד&gt;</code> — העברת בעלות',
         { parse_mode: 'HTML' }
       );
   }
@@ -837,6 +957,70 @@ export function registerGroupHandler(bot: Bot): void {
         return;
       }
       await renderGroupStatus(ctx, db, groupId);
+    }),
+  );
+
+  // gdel:conf:<groupId>:<nonce> — confirm group deletion
+  bot.callbackQuery(
+    /^gdel:conf:(\d+):([0-9a-f]{8})$/,
+    wrapCallback('gdel:conf', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (gdel:conf) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+
+      const groupId = parseInt(ctx.match?.[1] ?? '', 10);
+      const nonce = ctx.match?.[2];
+      if (isNaN(groupId) || !nonce) return;
+
+      const pending = pendingDeletes.get(chatId);
+      if (!pending || pending.groupId !== groupId || pending.nonce !== nonce) {
+        await ctx.reply('❌ הבקשה לא תקינה או פגה תוקף. הפעל /group delete שוב.');
+        return;
+      }
+      if (Date.now() > pending.expiresAt) {
+        pendingDeletes.delete(chatId);
+        await ctx.reply('❌ זמן האישור פג. הפעל /group delete שוב.');
+        return;
+      }
+      pendingDeletes.delete(chatId);
+
+      const db = getDb();
+      // TOCTOU guard: re-verify ownership before deletion
+      const group = findGroupById(db, groupId);
+      if (!group || group.ownerId !== chatId) {
+        await ctx.reply('❌ אין לך הרשאה למחוק קבוצה זו.');
+        return;
+      }
+
+      const groupName = group.name;
+      const members = getMembersOfGroup(db, groupId);
+      deleteGroup(db, groupId);
+      insertAudit(db, { groupId, action: 'deleted', actorId: chatId, payload: null });
+      log('info', 'Groups', `User ${chatId} deleted group ${groupId} (${groupName})`);
+
+      // Notify all OTHER members
+      const tasks = members
+        .filter((m) => m.userId !== chatId)
+        .map((m) => ({ chatId: String(m.userId), text: `הקבוצה "${groupName}" נמחקה על ידי המנהל.` }));
+      if (tasks.length > 0) dmQueue.enqueueAll(tasks);
+
+      await ctx.reply(`✅ הקבוצה "${escapeHtml(groupName)}" נמחקה.`, { parse_mode: 'HTML' });
+    }),
+  );
+
+  // gdel:cancel:<groupId> — cancel group deletion
+  bot.callbackQuery(
+    /^gdel:cancel:(\d+)$/,
+    wrapCallback('gdel:cancel', async (ctx) => {
+      await ctx
+        .answerCallbackQuery()
+        .catch((e) => log('warn', 'Groups', `answerCallbackQuery (gdel:cancel) failed: ${formatError(e)}`));
+      const chatId = ctx.chat?.id;
+      if (!chatId) return;
+      pendingDeletes.delete(chatId);
+      await ctx.reply('❌ המחיקה בוטלה.');
     }),
   );
 

--- a/src/bot/neighborCheckHandler.ts
+++ b/src/bot/neighborCheckHandler.ts
@@ -1,0 +1,62 @@
+import type { Bot } from 'grammy';
+import type Database from 'better-sqlite3';
+import { getPromptByPrefix, markResponded, recordEvent } from '../db/neighborCheckRepository.js';
+import { log } from '../logger.js';
+
+const CONFIRMATION_TEXT: Record<'checked' | 'unable' | 'dismissed', string> = {
+  checked:   '✅ תודה על הדיווח',
+  unable:    '✅ תודה על הדיווח',
+  dismissed: '🔇 הובן',
+};
+
+let _db: Database.Database | null = null;
+
+export function setNeighborCheckHandlerDb(db: Database.Database): void {
+  _db = db;
+}
+
+export function registerNeighborCheckHandler(bot: Bot): void {
+  // nc:checked:<chatId>:<fpShort>
+  // nc:unable:<chatId>:<fpShort>
+  // nc:dismissed:<chatId>:<fpShort>
+  bot.callbackQuery(/^nc:(checked|unable|dismissed):(\d+):([a-f0-9]{8})$/, async (ctx) => {
+    await ctx.answerCallbackQuery();
+
+    if (!_db) {
+      log('error', 'NeighborCheck', 'DB לא מאותחל — לא ניתן לטפל ב-nc callback');
+      return;
+    }
+
+    const match = ctx.match;
+    if (!match) return;
+
+    const responseStr = match[1] as 'checked' | 'unable' | 'dismissed';
+    const chatId = parseInt(match[2], 10);
+    const fpShort = match[3];
+
+    if (isNaN(chatId)) {
+      log('warn', 'NeighborCheck', `chatId לא תקין: ${match[2]}`);
+      return;
+    }
+
+    try {
+      const row = getPromptByPrefix(_db, chatId, fpShort);
+
+      if (!row) {
+        log('info', 'NeighborCheck', `לא נמצא prompt עבור chatId=${chatId} fp=${fpShort}`);
+        await ctx.editMessageText('⏱ הפרומפט פג תוקף.').catch(() => {});
+        return;
+      }
+
+      if (!row.responded) {
+        markResponded(_db, chatId, row.fingerprint);
+        recordEvent(_db, row.fingerprint, responseStr, null);
+      }
+
+      const confirmation = CONFIRMATION_TEXT[responseStr];
+      await ctx.editMessageText(confirmation, { parse_mode: 'HTML' }).catch(() => {});
+    } catch (err) {
+      log('error', 'NeighborCheck', `שגיאה בטיפול ב-nc callback: ${err}`);
+    }
+  });
+}

--- a/src/bot/neighborCheckHandler.ts
+++ b/src/bot/neighborCheckHandler.ts
@@ -44,7 +44,9 @@ export function registerNeighborCheckHandler(bot: Bot): void {
 
       if (!row) {
         log('info', 'NeighborCheck', `לא נמצא prompt עבור chatId=${chatId} fp=${fpShort}`);
-        await ctx.editMessageText('⏱ הפרומפט פג תוקף.').catch(() => {});
+        await ctx.editMessageText('⏱ הפרומפט פג תוקף.').catch((e) =>
+          log('warn', 'NeighborCheck', `editMessageText expired: ${e}`)
+        );
         return;
       }
 
@@ -54,7 +56,9 @@ export function registerNeighborCheckHandler(bot: Bot): void {
       }
 
       const confirmation = CONFIRMATION_TEXT[responseStr];
-      await ctx.editMessageText(confirmation, { parse_mode: 'HTML' }).catch(() => {});
+      await ctx.editMessageText(confirmation, { parse_mode: 'HTML' }).catch((e) =>
+        log('warn', 'NeighborCheck', `editMessageText confirmation: ${e}`)
+      );
     } catch (err) {
       log('error', 'NeighborCheck', `שגיאה בטיפול ב-nc callback: ${err}`);
     }

--- a/src/bot/neighborCheckHandler.ts
+++ b/src/bot/neighborCheckHandler.ts
@@ -1,9 +1,9 @@
 import type { Bot } from 'grammy';
 import type Database from 'better-sqlite3';
-import { getPromptByPrefix, markResponded, recordEvent } from '../db/neighborCheckRepository.js';
+import { getPromptByPrefix, markResponded, recordEvent, type NeighborCheckResponse } from '../db/neighborCheckRepository.js';
 import { log } from '../logger.js';
 
-const CONFIRMATION_TEXT: Record<'checked' | 'unable' | 'dismissed', string> = {
+const CONFIRMATION_TEXT: Record<NeighborCheckResponse, string> = {
   checked:   '✅ תודה על הדיווח',
   unable:    '✅ תודה על הדיווח',
   dismissed: '🔇 הובן',
@@ -30,7 +30,7 @@ export function registerNeighborCheckHandler(bot: Bot): void {
     const match = ctx.match;
     if (!match) return;
 
-    const responseStr = match[1] as 'checked' | 'unable' | 'dismissed';
+    const responseStr = match[1] as NeighborCheckResponse;
     const chatId = parseInt(match[2], 10);
     const fpShort = match[3];
 

--- a/src/bot/profileHandler.ts
+++ b/src/bot/profileHandler.ts
@@ -35,6 +35,8 @@ export function buildProfileSummary(
     .text('✏️ עריכת שם', 'pf:edit_name')
     .text('✏️ עריכת עיר', 'pf:edit_city')
     .row()
+    .text('🛠 כישורים', 'sk:list')
+    .row()
     .text('↩️ חזור', 'menu:main');
 
   return { text, keyboard };

--- a/src/bot/settingsHandler.ts
+++ b/src/bot/settingsHandler.ts
@@ -3,6 +3,7 @@ import type { Context } from 'grammy';
 import {
   getUser, setQuietHours, setMutedUntil, isMuted, upsertUser,
   setSocialPref, VALID_SOCIAL_FIELDS,
+  setNeighborCheckEnabled,
   type SocialPrefField,
 } from '../db/userRepository.js';
 import {
@@ -74,6 +75,11 @@ export function buildSocialSettingsMenu(chatId: number): { text: string; keyboar
     const status = enabled ? '✓' : '✗';
     keyboard.text(`${label}: ${status}`, `social:toggle:${field}`).row();
   }
+
+  // Neighbor check toggle (stored on users table, not social_* fields)
+  const ncEnabled = user?.neighbor_check_enabled ?? true;
+  const ncStatus = ncEnabled ? '✓' : '✗';
+  keyboard.text(`🏠 בדיקת שכנים אחרי אזעקה: ${ncStatus}`, 'nc:settings:toggle').row();
 
   keyboard.text('↩️ חזור', 'menu:settings');
 
@@ -353,6 +359,28 @@ export function registerSettingsHandler(bot: Bot, writeCooldownMs = 1500): void 
       await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Settings', `social:toggle נכשל: ${err}`);
+    }
+  });
+
+  // Neighbor check toggle (v0.5.3, #222)
+  bot.callbackQuery('nc:settings:toggle', async (ctx: Context) => {
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+    if (settingsWriteCooldown.isOnCooldown(chatId)) {
+      await ctx.answerCallbackQuery('⏳ נסה שוב בעוד רגע');
+      return;
+    }
+    await ctx.answerCallbackQuery();
+    settingsWriteCooldown.setCooldown(chatId);
+    try {
+      const { getDb } = await import('../db/schema.js');
+      const user = getUser(chatId);
+      const current = user?.neighbor_check_enabled ?? true;
+      setNeighborCheckEnabled(getDb(), chatId, !current);
+      const { text, keyboard } = buildSocialSettingsMenu(chatId);
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('error', 'Settings', `nc:settings:toggle נכשל: ${err}`);
     }
   });
 }

--- a/src/bot/shelterStoriesHandler.ts
+++ b/src/bot/shelterStoriesHandler.ts
@@ -1,0 +1,139 @@
+import { Bot, InlineKeyboard } from 'grammy';
+import type { Context } from 'grammy';
+import { getDb } from '../db/schema.js';
+import {
+  createStory,
+  countStoriesByUserSince,
+} from '../db/shelterStoryRepository.js';
+import { getBool, getNumber } from '../config/configResolver.js';
+import { log } from '../logger.js';
+
+/** Ephemeral per-user pending share state — acceptable to lose on restart. */
+interface PendingShareEntry {
+  startedAt: number;
+}
+
+const pendingShares = new Map<number, PendingShareEntry>();
+
+const PENDING_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+function pruneStalePendingShares(): void {
+  const now = Date.now();
+  for (const [chatId, entry] of pendingShares) {
+    if (now - entry.startedAt > PENDING_TTL_MS) {
+      pendingShares.delete(chatId);
+    }
+  }
+}
+
+export function registerShelterStoriesHandler(bot: Bot): void {
+  bot.command('share', async (ctx: Context) => {
+    if (ctx.chat?.type !== 'private') return;
+    const chatId = ctx.chat.id;
+
+    try {
+      const db = getDb();
+      const enabled = getBool(db, 'stories_enabled', true);
+      if (!enabled) {
+        await ctx.reply('הפיצ\'ר כבוי כרגע.');
+        return;
+      }
+
+      const rateLimitMinutes = getNumber(db, 'stories_rate_limit_minutes', 30);
+      const sinceIso = new Date(Date.now() - rateLimitMinutes * 60 * 1000)
+        .toISOString()
+        .replace('T', ' ')
+        .slice(0, 19);
+
+      const recentCount = countStoriesByUserSince(db, chatId, sinceIso);
+      if (recentCount > 0) {
+        await ctx.reply(
+          `יותר מדי הודעות — ניתן לשלוח הודעה אחת כל ${rateLimitMinutes} דקות. נסה שוב מאוחר יותר.`
+        );
+        return;
+      }
+
+      pendingShares.set(chatId, { startedAt: Date.now() });
+      log('info', 'ShelterStories', `User ${chatId} started /share`);
+
+      const keyboard = new InlineKeyboard().text('❌ ביטול', 'story:cancel');
+      await ctx.reply(
+        '📝 <b>שתף חוויה מהמקלט</b>\n\nשלח הודעה קצרה (עד 200 תווים) ונשלח אותה לסקירה.',
+        { parse_mode: 'HTML', reply_markup: keyboard }
+      );
+    } catch (err) {
+      log('error', 'ShelterStories', `/share failed for ${chatId}: ${String(err)}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch((e) =>
+        log('error', 'ShelterStories', `Failed to send error reply: ${e}`)
+      );
+    }
+  });
+
+  bot.callbackQuery('story:cancel', async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) =>
+      log('warn', 'ShelterStories', `answerCallbackQuery: ${e}`)
+    );
+    const chatId = ctx.chat?.id;
+    if (!chatId) return;
+
+    pendingShares.delete(chatId);
+    try {
+      await ctx.editMessageText('בוטל.');
+    } catch (err) {
+      log('warn', 'ShelterStories', `story:cancel edit failed: ${String(err)}`);
+    }
+  });
+
+  // Text handler for story submissions
+  bot.on('message:text', async (ctx: Context, next) => {
+    if (ctx.chat?.type !== 'private') { await next(); return; }
+    const chatId = ctx.chat.id;
+
+    pruneStalePendingShares();
+
+    if (!pendingShares.has(chatId)) { await next(); return; }
+
+    const text = ctx.message?.text ?? '';
+
+    // Let commands pass through and cancel the pending state
+    if (text.startsWith('/')) {
+      pendingShares.delete(chatId);
+      await next();
+      return;
+    }
+
+    try {
+      const db = getDb();
+      const maxLength = getNumber(db, 'stories_max_length', 200);
+
+      if (text.length > maxLength) {
+        await ctx.reply(
+          `❌ ההודעה ארוכה מדי (${text.length} תווים). הגבלה: ${maxLength} תווים. נסה שוב:`
+        );
+        // Stay in pending state so user can retry, but let downstream handlers see the message too
+        await next();
+        return;
+      }
+
+      createStory(db, chatId, text);
+      pendingShares.delete(chatId);
+      log('info', 'ShelterStories', `User ${chatId} submitted a story`);
+      await ctx.reply('תודה! הודעתך נשלחה לבדיקה ✅');
+    } catch (err) {
+      log('error', 'ShelterStories', `Story submission failed for ${chatId}: ${String(err)}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch((e) =>
+        log('error', 'ShelterStories', `Failed to send error reply: ${e}`)
+      );
+    }
+  });
+}
+
+/** Exposed for testing — clear a user's pending share state. */
+export function clearPendingShare(chatId: number): void {
+  pendingShares.delete(chatId);
+}
+
+/** Exposed for testing — check pending share state. */
+export function hasPendingShare(chatId: number): boolean {
+  return pendingShares.has(chatId);
+}

--- a/src/bot/shelterStoriesHandler.ts
+++ b/src/bot/shelterStoriesHandler.ts
@@ -56,9 +56,10 @@ export function registerShelterStoriesHandler(bot: Bot): void {
       pendingShares.set(chatId, { startedAt: Date.now() });
       log('info', 'ShelterStories', `User ${chatId} started /share`);
 
+      const maxLength = getNumber(db, 'stories_max_length', 200);
       const keyboard = new InlineKeyboard().text('❌ ביטול', 'story:cancel');
       await ctx.reply(
-        '📝 <b>שתף חוויה מהמקלט</b>\n\nשלח הודעה קצרה (עד 200 תווים) ונשלח אותה לסקירה.',
+        `📝 <b>שתף חוויה מהמקלט</b>\n\nשלח הודעה קצרה (עד ${maxLength} תווים) ונשלח אותה לסקירה.`,
         { parse_mode: 'HTML', reply_markup: keyboard }
       );
     } catch (err) {
@@ -120,6 +121,7 @@ export function registerShelterStoriesHandler(bot: Bot): void {
       log('info', 'ShelterStories', `User ${chatId} submitted a story`);
       await ctx.reply('תודה! הודעתך נשלחה לבדיקה ✅');
     } catch (err) {
+      pendingShares.delete(chatId);
       log('error', 'ShelterStories', `Story submission failed for ${chatId}: ${String(err)}`);
       await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch((e) =>
         log('error', 'ShelterStories', `Failed to send error reply: ${e}`)

--- a/src/bot/skillsHandler.ts
+++ b/src/bot/skillsHandler.ts
@@ -1,0 +1,361 @@
+import { Bot, InlineKeyboard } from 'grammy';
+import type { Context } from 'grammy';
+import { getDb } from '../db/schema.js';
+import {
+  listSkillsForUser,
+  upsertSkill,
+  removeSkill,
+  findUsersWithSkill,
+  type UserSkillRow,
+} from '../db/userSkillsRepository.js';
+import { listActiveSkills, getSkillByKey } from '../db/skillCatalogRepository.js';
+import { listContacts } from '../db/contactRepository.js';
+import { log } from '../logger.js';
+import { escapeHtml } from '../textUtils.js';
+
+const RESULTS_PER_PAGE = 5;
+const NOTE_PENDING_TTL_MS = 5 * 60_000;
+
+interface PendingNote {
+  skillKey: string;
+  expiresAt: number;
+}
+
+const pendingSkillNote = new Map<number, PendingNote>();
+
+function isPendingExpired(entry: PendingNote): boolean {
+  return Date.now() > entry.expiresAt;
+}
+
+/** Exposed for testing */
+export function clearPendingSkillNote(chatId: number): void {
+  pendingSkillNote.delete(chatId);
+}
+
+/** Exposed for testing */
+export function hasPendingSkillNote(chatId: number): boolean {
+  const entry = pendingSkillNote.get(chatId);
+  if (!entry) return false;
+  if (isPendingExpired(entry)) {
+    pendingSkillNote.delete(chatId);
+    return false;
+  }
+  return true;
+}
+
+const VIS_LABELS: Record<UserSkillRow['visibility'], string> = {
+  public:   '🌐 ציבורי',
+  contacts: '👥 אנשי קשר',
+  private:  '🔒 פרטי',
+};
+
+const VIS_CODES: Array<{ v: UserSkillRow['visibility']; code: number }> = [
+  { v: 'public',   code: 0 },
+  { v: 'contacts', code: 1 },
+  { v: 'private',  code: 2 },
+];
+
+function codeToVisibility(code: number): UserSkillRow['visibility'] {
+  return VIS_CODES.find((x) => x.code === code)?.v ?? 'contacts';
+}
+
+function getAcceptedContactIds(chatId: number): number[] {
+  const contacts = listContacts(chatId, 'accepted');
+  return contacts.map((c) =>
+    c.user_id === chatId ? c.contact_id : c.user_id
+  );
+}
+
+function buildSkillsListMessage(db: ReturnType<typeof getDb>, chatId: number): {
+  text: string;
+  keyboard: InlineKeyboard;
+} {
+  const skills = listSkillsForUser(db, chatId);
+  const keyboard = new InlineKeyboard();
+
+  if (skills.length === 0) {
+    const text = '🛠 <b>הכישורים שלי</b>\n\nעדיין לא הוספת כישורים.';
+    keyboard.text('➕ הוסף כישור', 'sk:pick').row();
+    keyboard.text('↩️ חזור', 'menu:main');
+    return { text, keyboard };
+  }
+
+  const lines = ['🛠 <b>הכישורים שלי</b>', ''];
+  for (const s of skills) {
+    const visLabel = VIS_LABELS[s.visibility];
+    const notePart = s.note ? ` — <i>${escapeHtml(s.note)}</i>` : '';
+    lines.push(`• ${escapeHtml(s.skillKey)}${notePart} (${visLabel})`);
+  }
+
+  const text = lines.join('\n');
+
+  for (const s of skills) {
+    keyboard.text(`✏️ ${s.skillKey}`, `sk:vis:${s.skillKey}:1`);
+    keyboard.text(`🗑 הסר`, `sk:rm:${s.skillKey}`).row();
+  }
+  keyboard.text('➕ הוסף עוד', 'sk:pick').row();
+  keyboard.text('↩️ חזור', 'menu:main');
+  return { text, keyboard };
+}
+
+function buildCatalogKeyboard(db: ReturnType<typeof getDb>, forNeed: boolean): InlineKeyboard {
+  const skills = listActiveSkills(db);
+  const keyboard = new InlineKeyboard();
+  for (const s of skills) {
+    const cbData = forNeed ? `need:${s.key}:0` : `sk:add:${s.key}`;
+    keyboard.text(s.labelHe, cbData).row();
+  }
+  if (!forNeed) keyboard.text('↩️ חזור', 'sk:list');
+  return keyboard;
+}
+
+function buildVisibilityKeyboard(skillKey: string): InlineKeyboard {
+  const keyboard = new InlineKeyboard();
+  for (const { v, code } of VIS_CODES) {
+    keyboard.text(VIS_LABELS[v], `sk:vis:${skillKey}:${code}`);
+  }
+  keyboard.row();
+  keyboard.text('📝 ערוך הערה', `sk:note:${skillKey}`);
+  keyboard.text('🗑 הסר', `sk:rm:${skillKey}`).row();
+  keyboard.text('↩️ חזור לרשימה', 'sk:list');
+  return keyboard;
+}
+
+function buildNeedResultsText(
+  db: ReturnType<typeof getDb>,
+  skillKey: string,
+  chatId: number,
+  page: number
+): { text: string; keyboard: InlineKeyboard } {
+  const skill = getSkillByKey(db, skillKey);
+  if (!skill || !skill.isActive) {
+    return {
+      text: '❌ כישור לא נמצא.',
+      keyboard: new InlineKeyboard(),
+    };
+  }
+
+  const contactIds = getAcceptedContactIds(chatId);
+  const results = findUsersWithSkill(db, skillKey, chatId, contactIds, RESULTS_PER_PAGE + 1, page * RESULTS_PER_PAGE);
+  const hasMore = results.length > RESULTS_PER_PAGE;
+  const pageResults = results.slice(0, RESULTS_PER_PAGE);
+
+  const lines = [`🔍 <b>מי יכול לעזור עם ${escapeHtml(skill.labelHe)}?</b>`, ''];
+  if (pageResults.length === 0) {
+    lines.push('לא נמצאו משתמשים.');
+  } else {
+    for (const r of pageResults) {
+      const citySuffix = r.homeCity ? ` — ${escapeHtml(r.homeCity)}` : '';
+      lines.push(`• ${escapeHtml(r.displayName)}${citySuffix}`);
+    }
+  }
+
+  const keyboard = new InlineKeyboard();
+  if (page > 0) keyboard.text('◀️ הקודם', `need:${skillKey}:${page - 1}`);
+  if (hasMore) keyboard.text('הבא ▶️', `need:${skillKey}:${page + 1}`);
+  if (page > 0 || hasMore) keyboard.row();
+
+  return { text: lines.join('\n'), keyboard };
+}
+
+export function registerSkillsHandler(bot: Bot): void {
+  // /need [skill] command
+  bot.command('need', async (ctx: Context) => {
+    if (ctx.chat?.type !== 'private') return;
+    const chatId = ctx.chat.id;
+    const db = getDb();
+    const matchVal = ctx.match;
+    const arg = (typeof matchVal === 'string' ? matchVal : '').trim();
+
+    try {
+      if (!arg) {
+        const keyboard = buildCatalogKeyboard(db, true);
+        await ctx.reply(
+          '🔍 <b>עזרה בשעת חירום</b>\n\nבחר את סוג הכישור שאתה מחפש:',
+          { parse_mode: 'HTML', reply_markup: keyboard }
+        );
+        return;
+      }
+
+      // Normalize arg to key format
+      const key = arg.toLowerCase().replace(/\s+/g, '_');
+      const skill = getSkillByKey(db, key);
+      if (!skill || !skill.isActive) {
+        await ctx.reply('❌ כישור לא נמצא. נסה /need ללא ארגומנט לצפייה ברשימה.');
+        return;
+      }
+
+      const { text, keyboard } = buildNeedResultsText(db, key, chatId, 0);
+      await ctx.reply(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('error', 'Skills', `/need failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch((e) =>
+        log('error', 'Skills', `Failed to send error reply: ${e}`)
+      );
+    }
+  });
+
+  // sk:list — show user's skills
+  bot.callbackQuery('sk:list', async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) => log('warn', 'Skills', `answerCbQ: ${e}`));
+    const chatId = ctx.chat?.id;
+    if (!chatId || ctx.chat?.type !== 'private') return;
+    try {
+      const db = getDb();
+      const { text, keyboard } = buildSkillsListMessage(db, chatId);
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('error', 'Skills', `sk:list failed for ${chatId}: ${err}`);
+    }
+  });
+
+  // sk:pick — show catalog for adding a skill
+  bot.callbackQuery('sk:pick', async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) => log('warn', 'Skills', `answerCbQ: ${e}`));
+    const chatId = ctx.chat?.id;
+    if (!chatId || ctx.chat?.type !== 'private') return;
+    try {
+      const db = getDb();
+      const keyboard = buildCatalogKeyboard(db, false);
+      await ctx.editMessageText(
+        '🛠 <b>בחר כישור להוספה:</b>',
+        { parse_mode: 'HTML', reply_markup: keyboard }
+      );
+    } catch (err) {
+      log('error', 'Skills', `sk:pick failed for ${chatId}: ${err}`);
+    }
+  });
+
+  // sk:add:<key> — add skill with default visibility=contacts
+  bot.callbackQuery(/^sk:add:([a-z0-9_]{1,32})$/, async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) => log('warn', 'Skills', `answerCbQ: ${e}`));
+    const chatId = ctx.chat?.id;
+    if (!chatId || ctx.chat?.type !== 'private') return;
+    const skillKey = ctx.match![1];
+    try {
+      const db = getDb();
+      upsertSkill(db, chatId, skillKey, 'contacts', null);
+      log('info', 'Skills', `User ${chatId} added skill ${skillKey}`);
+      const keyboard = buildVisibilityKeyboard(skillKey);
+      await ctx.editMessageText(
+        `✅ <b>${escapeHtml(skillKey)}</b> נוסף!\n\nבחר רמת נראות:`,
+        { parse_mode: 'HTML', reply_markup: keyboard }
+      );
+    } catch (err) {
+      log('error', 'Skills', `sk:add failed for ${chatId}: ${err}`);
+    }
+  });
+
+  // sk:vis:<key>:<v> — update visibility
+  bot.callbackQuery(/^sk:vis:([a-z0-9_]{1,32}):([012])$/, async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) => log('warn', 'Skills', `answerCbQ: ${e}`));
+    const chatId = ctx.chat?.id;
+    if (!chatId || ctx.chat?.type !== 'private') return;
+    const skillKey = ctx.match![1];
+    const visCode = Number(ctx.match![2]);
+    const visibility = codeToVisibility(visCode);
+    try {
+      const db = getDb();
+      const existing = listSkillsForUser(db, chatId).find((s) => s.skillKey === skillKey);
+      upsertSkill(db, chatId, skillKey, visibility, existing?.note ?? null);
+      log('info', 'Skills', `User ${chatId} set ${skillKey} visibility=${visibility}`);
+      const keyboard = buildVisibilityKeyboard(skillKey);
+      await ctx.editMessageText(
+        `🛠 <b>${escapeHtml(skillKey)}</b>\n\nנראות: ${VIS_LABELS[visibility]}\n\nבחר פעולה:`,
+        { parse_mode: 'HTML', reply_markup: keyboard }
+      );
+    } catch (err) {
+      log('error', 'Skills', `sk:vis failed for ${chatId}: ${err}`);
+    }
+  });
+
+  // sk:rm:<key> — remove skill
+  bot.callbackQuery(/^sk:rm:([a-z0-9_]{1,32})$/, async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) => log('warn', 'Skills', `answerCbQ: ${e}`));
+    const chatId = ctx.chat?.id;
+    if (!chatId || ctx.chat?.type !== 'private') return;
+    const skillKey = ctx.match![1];
+    try {
+      const db = getDb();
+      const removed = removeSkill(db, chatId, skillKey);
+      if (removed) {
+        log('info', 'Skills', `User ${chatId} removed skill ${skillKey}`);
+      }
+      const { text, keyboard } = buildSkillsListMessage(db, chatId);
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('error', 'Skills', `sk:rm failed for ${chatId}: ${err}`);
+    }
+  });
+
+  // sk:note:<key> — prompt user to type a note
+  bot.callbackQuery(/^sk:note:([a-z0-9_]{1,32})$/, async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) => log('warn', 'Skills', `answerCbQ: ${e}`));
+    const chatId = ctx.chat?.id;
+    if (!chatId || ctx.chat?.type !== 'private') return;
+    const skillKey = ctx.match![1];
+    try {
+      pendingSkillNote.set(chatId, { skillKey, expiresAt: Date.now() + NOTE_PENDING_TTL_MS });
+      await ctx.editMessageText(
+        `📝 <b>הוסף הערה לכישור "${escapeHtml(skillKey)}"</b>\n\nשלח הערה קצרה (עד 100 תווים):`,
+        {
+          parse_mode: 'HTML',
+          reply_markup: new InlineKeyboard().text('↩️ ביטול', `sk:vis:${skillKey}:1`),
+        }
+      );
+    } catch (err) {
+      log('error', 'Skills', `sk:note failed for ${chatId}: ${err}`);
+    }
+  });
+
+  // need:<key>:<page> — paginated results
+  bot.callbackQuery(/^need:([a-z0-9_]{1,32}):(\d+)$/, async (ctx: Context) => {
+    await ctx.answerCallbackQuery().catch((e) => log('warn', 'Skills', `answerCbQ: ${e}`));
+    const chatId = ctx.chat?.id;
+    if (!chatId || ctx.chat?.type !== 'private') return;
+    const skillKey = ctx.match![1];
+    const page = Number(ctx.match![2]);
+    try {
+      const db = getDb();
+      const { text, keyboard } = buildNeedResultsText(db, skillKey, chatId, page);
+      await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
+    } catch (err) {
+      log('error', 'Skills', `need callback failed for ${chatId}: ${err}`);
+    }
+  });
+
+  // Text handler — capture note input
+  bot.on('message:text', async (ctx: Context, next) => {
+    if (ctx.chat?.type !== 'private') { await next(); return; }
+    const chatId = ctx.chat.id;
+    if (!hasPendingSkillNote(chatId)) { await next(); return; }
+
+    const entry = pendingSkillNote.get(chatId)!;
+    const text = ctx.message?.text ?? '';
+
+    if (text.startsWith('/')) {
+      pendingSkillNote.delete(chatId);
+      await next();
+      return;
+    }
+
+    try {
+      const note = text.trim().slice(0, 100);
+      const db = getDb();
+      const existing = listSkillsForUser(db, chatId).find((s) => s.skillKey === entry.skillKey);
+      upsertSkill(db, chatId, entry.skillKey, existing?.visibility ?? 'contacts', note || null);
+      pendingSkillNote.delete(chatId);
+      log('info', 'Skills', `User ${chatId} set note for skill ${entry.skillKey}`);
+      const keyboard = buildVisibilityKeyboard(entry.skillKey);
+      await ctx.reply(
+        `✅ ההערה נשמרה עבור <b>${escapeHtml(entry.skillKey)}</b>.`,
+        { parse_mode: 'HTML', reply_markup: keyboard }
+      );
+    } catch (err) {
+      log('error', 'Skills', `Note text handler failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch((e) =>
+        log('error', 'Skills', `Failed to send error reply: ${e}`)
+      );
+    }
+  });
+}

--- a/src/bot/skillsHandler.ts
+++ b/src/bot/skillsHandler.ts
@@ -206,6 +206,7 @@ export function registerSkillsHandler(bot: Bot): void {
       await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Skills', `sk:list failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch(() => {});
     }
   });
 
@@ -223,6 +224,7 @@ export function registerSkillsHandler(bot: Bot): void {
       );
     } catch (err) {
       log('error', 'Skills', `sk:pick failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch(() => {});
     }
   });
 
@@ -243,6 +245,7 @@ export function registerSkillsHandler(bot: Bot): void {
       );
     } catch (err) {
       log('error', 'Skills', `sk:add failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch(() => {});
     }
   });
 
@@ -266,6 +269,7 @@ export function registerSkillsHandler(bot: Bot): void {
       );
     } catch (err) {
       log('error', 'Skills', `sk:vis failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch(() => {});
     }
   });
 
@@ -285,6 +289,7 @@ export function registerSkillsHandler(bot: Bot): void {
       await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Skills', `sk:rm failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch(() => {});
     }
   });
 
@@ -305,6 +310,7 @@ export function registerSkillsHandler(bot: Bot): void {
       );
     } catch (err) {
       log('error', 'Skills', `sk:note failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch(() => {});
     }
   });
 
@@ -321,6 +327,7 @@ export function registerSkillsHandler(bot: Bot): void {
       await ctx.editMessageText(text, { parse_mode: 'HTML', reply_markup: keyboard });
     } catch (err) {
       log('error', 'Skills', `need callback failed for ${chatId}: ${err}`);
+      await ctx.reply('אירעה שגיאה. נסה שוב מאוחר יותר.').catch(() => {});
     }
   });
 

--- a/src/config/configResolver.ts
+++ b/src/config/configResolver.ts
@@ -63,6 +63,11 @@ export const CONFIG_KEYS: ReadonlySet<string> = new Set([
   'social_default_group_alerts_enabled',
   'social_default_quick_ok_enabled',
   'social_banner_stale_prompt_minutes',
+  // v0.5.3 — community pulse survey (refs #219)
+  'pulse_enabled',
+  'pulse_cooldown_hours',
+  'pulse_aggregate_threshold',
+  'pulse_prompt_text',
 ]);
 
 /** Keys whose change requires a process restart to take effect. */

--- a/src/config/configResolver.ts
+++ b/src/config/configResolver.ts
@@ -76,6 +76,10 @@ export const CONFIG_KEYS: ReadonlySet<string> = new Set([
   // v0.5.3 — skills sharing (refs #221)
   'skills_public_enabled',
   'skills_need_radius_zones',
+  // v0.5.3 — neighbor check (refs #222)
+  'neighbor_check_enabled_default',
+  'neighbor_check_delay_minutes',
+  'neighbor_check_text',
 ]);
 
 /** Keys whose change requires a process restart to take effect. */

--- a/src/config/configResolver.ts
+++ b/src/config/configResolver.ts
@@ -68,6 +68,11 @@ export const CONFIG_KEYS: ReadonlySet<string> = new Set([
   'pulse_cooldown_hours',
   'pulse_aggregate_threshold',
   'pulse_prompt_text',
+  // v0.5.3 — shelter stories opt-in submissions (refs #220)
+  'topic_id_stories',
+  'stories_enabled',
+  'stories_rate_limit_minutes',
+  'stories_max_length',
 ]);
 
 /** Keys whose change requires a process restart to take effect. */
@@ -107,6 +112,7 @@ export const ENV_KEY_MAP: Readonly<Record<string, string>> = {
   telegram_chat_id:              'TELEGRAM_CHAT_ID',
   telegram_forward_group_id:     'TELEGRAM_FORWARD_GROUP_ID',
   telegram_listener_enabled:     'TELEGRAM_LISTENER_ENABLED',
+  topic_id_stories:              'TELEGRAM_TOPIC_ID_STORIES',
 };
 
 // ── Resolution ───────────────────────────────────────────────────────────────

--- a/src/config/configResolver.ts
+++ b/src/config/configResolver.ts
@@ -73,6 +73,9 @@ export const CONFIG_KEYS: ReadonlySet<string> = new Set([
   'stories_enabled',
   'stories_rate_limit_minutes',
   'stories_max_length',
+  // v0.5.3 — skills sharing (refs #221)
+  'skills_public_enabled',
+  'skills_need_radius_zones',
 ]);
 
 /** Keys whose change requires a process restart to take effect. */

--- a/src/dashboard/router.ts
+++ b/src/dashboard/router.ts
@@ -12,6 +12,7 @@ import { createListenersRouter } from './routes/whatsappListeners.js';
 import { createTelegramListenerRouter } from './routes/telegramListeners.js';
 import { createSecretsRouter } from './routes/secrets.js';
 import { createGroupsRouter } from './routes/groups.js';
+import { createStoriesRouter } from './routes/stories.js';
 import * as whatsappService from '../whatsapp/whatsappService.js';
 import { getEnabledGroupsForAlertType } from '../db/whatsappGroupRepository.js';
 
@@ -32,5 +33,6 @@ export function createApiRouter(db: Database.Database, bot: Bot): Router {
   router.use('/telegram', createTelegramListenerRouter(db, bot));
   router.use('/secrets', createSecretsRouter(db));
   router.use('/groups', createGroupsRouter(db));
+  router.use('/stories', createStoriesRouter(db, bot));
   return router;
 }

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -61,6 +61,9 @@ const ALLOWED_KEYS = new Set([
   'stories_enabled',
   'stories_rate_limit_minutes',
   'stories_max_length',
+  // v0.5.3 — skills sharing (refs #221)
+  'skills_public_enabled',
+  'skills_need_radius_zones',
 ]);
 
 // ─── Per-key value validators ─────────────────────────────────────────────
@@ -157,6 +160,9 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   stories_enabled:           validateBoolish,
   stories_rate_limit_minutes: validatePositiveInt,
   stories_max_length:        validatePositiveInt,
+  // v0.5.3 — skills sharing (refs #221)
+  skills_public_enabled:     validateBoolish,
+  skills_need_radius_zones:  validatePositiveInt,
 };
 
 export function createSettingsRouter(db: Database.Database): Router {

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -64,6 +64,10 @@ const ALLOWED_KEYS = new Set([
   // v0.5.3 — skills sharing (refs #221)
   'skills_public_enabled',
   'skills_need_radius_zones',
+  // v0.5.3 — neighbor check (refs #222)
+  'neighbor_check_enabled_default',
+  'neighbor_check_delay_minutes',
+  'neighbor_check_text',
 ]);
 
 // ─── Per-key value validators ─────────────────────────────────────────────
@@ -163,6 +167,10 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   // v0.5.3 — skills sharing (refs #221)
   skills_public_enabled:     validateBoolish,
   skills_need_radius_zones:  validatePositiveInt,
+  // v0.5.3 — neighbor check (refs #222)
+  // neighbor_check_text accepts any string — no validator needed
+  neighbor_check_enabled_default: validateBoolish,
+  neighbor_check_delay_minutes:   validatePositiveInt,
 };
 
 export function createSettingsRouter(db: Database.Database): Router {

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -56,6 +56,11 @@ const ALLOWED_KEYS = new Set([
   'pulse_cooldown_hours',
   'pulse_aggregate_threshold',
   'pulse_prompt_text',
+  // v0.5.3 — shelter stories opt-in submissions (refs #220)
+  'topic_id_stories',
+  'stories_enabled',
+  'stories_rate_limit_minutes',
+  'stories_max_length',
 ]);
 
 // ─── Per-key value validators ─────────────────────────────────────────────
@@ -141,6 +146,17 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   pulse_cooldown_hours:      validatePositiveInt,
   pulse_aggregate_threshold: validatePositiveInt,
   // pulse_prompt_text accepts any string — no validator needed
+  // v0.5.3 — shelter stories opt-in submissions (refs #220)
+  // topic_id_stories rejects 1 — reserved Telegram thread ID (same guard as approve route)
+  topic_id_stories:          (v) => {
+    const base = validateNonNegativeInt(v);
+    if (base) return base;
+    if (Number(v) === 1) return 'מזהה נושא 1 שמור על ידי טלגרם ואינו תקין';
+    return null;
+  },
+  stories_enabled:           validateBoolish,
+  stories_rate_limit_minutes: validatePositiveInt,
+  stories_max_length:        validatePositiveInt,
 };
 
 export function createSettingsRouter(db: Database.Database): Router {

--- a/src/dashboard/routes/settings.ts
+++ b/src/dashboard/routes/settings.ts
@@ -51,6 +51,11 @@ const ALLOWED_KEYS = new Set([
   'social_default_group_alerts_enabled',
   'social_default_quick_ok_enabled',
   'social_banner_stale_prompt_minutes',
+  // v0.5.3 — community pulse survey (refs #219)
+  'pulse_enabled',
+  'pulse_cooldown_hours',
+  'pulse_aggregate_threshold',
+  'pulse_prompt_text',
 ]);
 
 // ─── Per-key value validators ─────────────────────────────────────────────
@@ -131,6 +136,11 @@ const VALIDATORS: Record<string, (value: string) => string | null> = {
   social_default_group_alerts_enabled:  validateBoolish,
   social_default_quick_ok_enabled:      validateBoolish,
   social_banner_stale_prompt_minutes:   validateNonNegativeInt,
+  // v0.5.3 — community pulse survey (refs #219)
+  pulse_enabled:             validateBoolish,
+  pulse_cooldown_hours:      validatePositiveInt,
+  pulse_aggregate_threshold: validatePositiveInt,
+  // pulse_prompt_text accepts any string — no validator needed
 };
 
 export function createSettingsRouter(db: Database.Database): Router {

--- a/src/dashboard/routes/stories.ts
+++ b/src/dashboard/routes/stories.ts
@@ -1,0 +1,141 @@
+import { Router } from 'express';
+import type Database from 'better-sqlite3';
+import type { Bot } from 'grammy';
+import {
+  getPendingStories,
+  getStoriesByStatus,
+  getStoryById,
+  lockForApproval,
+  approveStory,
+  rejectStory,
+  getCountsByStatus,
+} from '../../db/shelterStoryRepository.js';
+import { getNumber } from '../../config/configResolver.js';
+import { createRateLimitMiddleware } from '../rateLimiter.js';
+import { log } from '../../logger.js';
+
+// Exported for test isolation — call storiesLimiter.clearStore() in beforeEach.
+export const storiesLimiter = createRateLimitMiddleware({
+  maxRequests: 30,
+  windowMs: 60_000,
+  message: 'יותר מדי בקשות — נסה שוב בעוד דקה',
+});
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function createStoriesRouter(db: Database.Database, bot: Bot): Router {
+  const router = Router();
+
+  router.get('/', storiesLimiter, (req, res) => {
+    try {
+      const status = (req.query['status'] as string | undefined) ?? 'pending';
+      const limit = Math.min(Number(req.query['limit'] ?? 20), 100);
+      const offset = Number(req.query['offset'] ?? 0);
+
+      if (!['pending', 'approved', 'rejected', 'published'].includes(status)) {
+        res.status(400).json({ error: `סטטוס לא חוקי: ${status}` });
+        return;
+      }
+
+      const stories = status === 'pending'
+        ? getPendingStories(db, limit, offset)
+        : getStoriesByStatus(
+            db,
+            status as 'approved' | 'rejected' | 'published',
+            limit,
+            offset
+          );
+
+      const counts = getCountsByStatus(db);
+      res.json({ stories, counts });
+    } catch (err) {
+      log('error', 'Stories', `GET /api/stories failed: ${String(err)}`);
+      res.status(500).json({ error: 'שגיאת שרת' });
+    }
+  });
+
+  router.post('/:id/approve', storiesLimiter, async (req, res) => {
+    try {
+      const id = Number(req.params['id']);
+      if (!Number.isInteger(id) || id <= 0) {
+        res.status(400).json({ error: 'מזהה לא תקין' });
+        return;
+      }
+
+      const topicId = getNumber(db, 'topic_id_stories', 0);
+      if (!topicId || topicId === 1) {
+        res.status(400).json({ error: 'topic_id_stories לא מוגדר' });
+        return;
+      }
+
+      const chatId = Number(process.env['TELEGRAM_CHAT_ID'] ?? '0');
+      if (!chatId) {
+        res.status(500).json({ error: 'TELEGRAM_CHAT_ID לא מוגדר' });
+        return;
+      }
+
+      // 404 check — must happen before lock attempt
+      const story = getStoryById(db, id);
+      if (!story) {
+        res.status(404).json({ error: 'הסיפור לא נמצא' });
+        return;
+      }
+
+      // Atomic lock: status pending→approved. Second concurrent call returns false → 409.
+      const locked = lockForApproval(db, id);
+      if (!locked) {
+        res.status(409).json({ error: `הסיפור כבר בסטטוס: ${story.status}` });
+        return;
+      }
+
+      const safeBody = escapeHtml(story.body);
+      const { message_id } = await bot.api.sendMessage(
+        chatId,
+        `🏠 <b>חוויה מהמקלט</b>\n\n${safeBody}`,
+        { parse_mode: 'HTML', message_thread_id: topicId }
+      );
+
+      approveStory(db, id, 'admin', message_id);
+      log('info', 'Stories', `Story ${id} approved and published (msg ${message_id})`);
+      res.json({ ok: true, messageId: message_id });
+    } catch (err) {
+      log('error', 'Stories', `POST /api/stories/:id/approve failed: ${String(err)}`);
+      if (!res.headersSent) res.status(500).json({ error: 'שגיאת שרת' });
+    }
+  });
+
+  router.post('/:id/reject', storiesLimiter, (req, res) => {
+    try {
+      const id = Number(req.params['id']);
+      if (!Number.isInteger(id) || id <= 0) {
+        res.status(400).json({ error: 'מזהה לא תקין' });
+        return;
+      }
+
+      const story = getStoryById(db, id);
+      if (!story) {
+        res.status(404).json({ error: 'הסיפור לא נמצא' });
+        return;
+      }
+
+      const rejected = rejectStory(db, id, 'admin');
+      if (!rejected) {
+        res.status(409).json({ error: `הסיפור כבר בסטטוס: ${story.status}` });
+        return;
+      }
+      log('info', 'Stories', `Story ${id} rejected`);
+      res.json({ ok: true });
+    } catch (err) {
+      log('error', 'Stories', `POST /api/stories/:id/reject failed: ${String(err)}`);
+      res.status(500).json({ error: 'שגיאת שרת' });
+    }
+  });
+
+  return router;
+}

--- a/src/dashboard/routes/stories.ts
+++ b/src/dashboard/routes/stories.ts
@@ -6,7 +6,7 @@ import {
   getStoriesByStatus,
   getStoryById,
   lockForApproval,
-  approveStory,
+  publishStory,
   rejectStory,
   getCountsByStatus,
 } from '../../db/shelterStoryRepository.js';
@@ -101,7 +101,7 @@ export function createStoriesRouter(db: Database.Database, bot: Bot): Router {
         { parse_mode: 'HTML', message_thread_id: topicId }
       );
 
-      approveStory(db, id, 'admin', message_id);
+      publishStory(db, id, 'admin', message_id);
       log('info', 'Stories', `Story ${id} approved and published (msg ${message_id})`);
       res.json({ ok: true, messageId: message_id });
     } catch (err) {

--- a/src/db/communityPulseRepository.ts
+++ b/src/db/communityPulseRepository.ts
@@ -1,0 +1,126 @@
+import type Database from 'better-sqlite3';
+
+export interface PulseRow {
+  id: number;
+  fingerprint: string;
+  alertType: string;
+  zones: string[];
+  createdAt: string;
+}
+
+export interface PulseAggregate {
+  total: number;
+  ok: number;
+  scared: number;
+  helping: number;
+}
+
+export type PulseAnswer = 'ok' | 'scared' | 'helping';
+
+interface PulseDbRow {
+  id: number;
+  fingerprint: string;
+  alert_type: string;
+  zones: string;
+  created_at: string;
+}
+
+function decodeRow(row: PulseDbRow): PulseRow {
+  return {
+    id: row.id,
+    fingerprint: row.fingerprint,
+    alertType: row.alert_type,
+    zones: JSON.parse(row.zones) as string[],
+    createdAt: row.created_at,
+  };
+}
+
+/**
+ * INSERT OR IGNORE — returns the existing row if fingerprint already exists.
+ */
+export function createPulse(
+  db: Database.Database,
+  fingerprint: string,
+  alertType: string,
+  zones: string[]
+): PulseRow {
+  db.prepare(
+    `INSERT OR IGNORE INTO community_pulses (fingerprint, alert_type, zones)
+     VALUES (?, ?, ?)`
+  ).run(fingerprint, alertType, JSON.stringify(zones));
+
+  const row = db
+    .prepare('SELECT * FROM community_pulses WHERE fingerprint = ?')
+    .get(fingerprint) as PulseDbRow;
+
+  return decodeRow(row);
+}
+
+export function getPulseByFingerprint(
+  db: Database.Database,
+  fingerprint: string
+): PulseRow | null {
+  const row = db
+    .prepare('SELECT * FROM community_pulses WHERE fingerprint = ?')
+    .get(fingerprint) as PulseDbRow | undefined;
+
+  return row ? decodeRow(row) : null;
+}
+
+/**
+ * INSERT OR IGNORE — dedup at (pulse_id, chat_id) PRIMARY KEY.
+ */
+export function insertResponse(
+  db: Database.Database,
+  pulseId: number,
+  chatId: number,
+  answer: PulseAnswer
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO community_pulse_responses (pulse_id, chat_id, answer)
+     VALUES (?, ?, ?)`
+  ).run(pulseId, chatId, answer);
+}
+
+export function getAggregate(
+  db: Database.Database,
+  pulseId: number
+): PulseAggregate {
+  const row = db
+    .prepare(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN answer = 'ok'      THEN 1 ELSE 0 END) AS ok,
+         SUM(CASE WHEN answer = 'scared'  THEN 1 ELSE 0 END) AS scared,
+         SUM(CASE WHEN answer = 'helping' THEN 1 ELSE 0 END) AS helping
+       FROM community_pulse_responses
+       WHERE pulse_id = ?`
+    )
+    .get(pulseId) as { total: number; ok: number; scared: number; helping: number };
+
+  return {
+    total: row.total ?? 0,
+    ok: row.ok ?? 0,
+    scared: row.scared ?? 0,
+    helping: row.helping ?? 0,
+  };
+}
+
+/**
+ * Returns ISO datetime string of last response by this chatId, or null.
+ */
+export function getLastResponseTime(
+  db: Database.Database,
+  chatId: number
+): string | null {
+  const row = db
+    .prepare(
+      `SELECT created_at FROM community_pulse_responses
+       WHERE chat_id = ?
+       ORDER BY created_at DESC
+       LIMIT 1`
+    )
+    .get(chatId) as { created_at: string } | undefined;
+
+  return row?.created_at ?? null;
+}

--- a/src/db/communityPulseRepository.ts
+++ b/src/db/communityPulseRepository.ts
@@ -30,7 +30,14 @@ function decodeRow(row: PulseDbRow): PulseRow {
     id: row.id,
     fingerprint: row.fingerprint,
     alertType: row.alert_type,
-    zones: JSON.parse(row.zones) as string[],
+    zones: (() => {
+      try {
+        const parsed = JSON.parse(row.zones);
+        return Array.isArray(parsed) ? parsed as string[] : [];
+      } catch {
+        return [];
+      }
+    })(),
     createdAt: row.created_at,
   };
 }

--- a/src/db/communityPulseRepository.ts
+++ b/src/db/communityPulseRepository.ts
@@ -69,17 +69,19 @@ export function getPulseByFingerprint(
 
 /**
  * INSERT OR IGNORE — dedup at (pulse_id, chat_id) PRIMARY KEY.
+ * Returns true if the row was inserted, false if the user already responded.
  */
 export function insertResponse(
   db: Database.Database,
   pulseId: number,
   chatId: number,
   answer: PulseAnswer
-): void {
-  db.prepare(
+): boolean {
+  const result = db.prepare(
     `INSERT OR IGNORE INTO community_pulse_responses (pulse_id, chat_id, answer)
      VALUES (?, ?, ?)`
   ).run(pulseId, chatId, answer);
+  return result.changes > 0;
 }
 
 export function getAggregate(

--- a/src/db/groupAuditRepository.ts
+++ b/src/db/groupAuditRepository.ts
@@ -1,0 +1,15 @@
+import type Database from 'better-sqlite3';
+
+export interface AuditRow {
+  groupId: number;
+  action: 'deleted' | 'transferred';
+  actorId: number;
+  payload: string | null;  // JSON
+}
+
+export function insertAudit(db: Database.Database, row: AuditRow): void {
+  db.prepare(
+    `INSERT INTO group_audit (group_id, action, actor_id, payload, created_at)
+     VALUES (?, ?, ?, ?, datetime('now'))`
+  ).run(row.groupId, row.action, row.actorId, row.payload ?? null);
+}

--- a/src/db/groupRepository.ts
+++ b/src/db/groupRepository.ts
@@ -164,6 +164,30 @@ export function deleteGroup(db: Database.Database, groupId: number): void {
   db.prepare('DELETE FROM groups WHERE id = ?').run(groupId);
 }
 
+/**
+ * Transfers group ownership from `fromOwnerId` to `toUserId`.
+ * Runs in a transaction: verifies ownership + membership, then swaps
+ * the `owner_id` on the groups row.
+ * Returns false if ownership verification fails (TOCTOU guard).
+ */
+export function transferOwnership(
+  db: Database.Database,
+  groupId: number,
+  fromOwnerId: number,
+  toUserId: number
+): boolean {
+  const transfer = db.transaction(() => {
+    const group = db.prepare('SELECT owner_id FROM groups WHERE id = ?').get(groupId) as { owner_id: number } | undefined;
+    if (!group || group.owner_id !== fromOwnerId) return false;
+    // Verify target is a member
+    const member = db.prepare('SELECT 1 FROM group_members WHERE group_id = ? AND user_id = ?').get(groupId, toUserId);
+    if (!member) return false;
+    db.prepare('UPDATE groups SET owner_id = ? WHERE id = ?').run(toUserId, groupId);
+    return true;
+  });
+  return transfer() as boolean;
+}
+
 // ─── Reads ───────────────────────────────────────────────────────────────────
 
 export function findGroupByInviteCode(

--- a/src/db/neighborCheckRepository.ts
+++ b/src/db/neighborCheckRepository.ts
@@ -13,6 +13,8 @@ interface RawEventRow {
   cnt: number;
 }
 
+export type NeighborCheckResponse = 'checked' | 'unable' | 'dismissed';
+
 export interface NeighborCheckPromptRow {
   chat_id: number;
   fingerprint: string;
@@ -99,7 +101,7 @@ export function getPromptByPrefix(
 export function recordEvent(
   db: Database.Database,
   alertFp: string,
-  response: 'checked' | 'unable' | 'dismissed',
+  response: NeighborCheckResponse,
   city: string | null
 ): void {
   db.prepare(

--- a/src/db/neighborCheckRepository.ts
+++ b/src/db/neighborCheckRepository.ts
@@ -1,0 +1,135 @@
+import type Database from 'better-sqlite3';
+
+interface RawPromptRow {
+  chat_id: number;
+  fingerprint: string;
+  sent_at: string;
+  responded: number;
+  message_id: number | null;
+}
+
+interface RawEventRow {
+  response: string;
+  cnt: number;
+}
+
+export interface NeighborCheckPromptRow {
+  chat_id: number;
+  fingerprint: string;
+  sent_at: string;
+  responded: boolean;
+  message_id: number | null;
+}
+
+export interface NeighborCheckAggregate {
+  checked: number;
+  unable: number;
+  dismissed: number;
+  total: number;
+}
+
+function decodePromptRow(raw: RawPromptRow): NeighborCheckPromptRow {
+  return {
+    chat_id: raw.chat_id,
+    fingerprint: raw.fingerprint,
+    sent_at: raw.sent_at,
+    responded: raw.responded === 1,
+    message_id: raw.message_id,
+  };
+}
+
+/**
+ * Insert OR IGNORE — duplicate (chat_id, fingerprint) pairs are silently skipped.
+ */
+export function insertPrompt(
+  db: Database.Database,
+  chatId: number,
+  fingerprint: string,
+  messageId?: number
+): void {
+  db.prepare(
+    `INSERT OR IGNORE INTO neighbor_check_prompts (chat_id, fingerprint, message_id)
+     VALUES (?, ?, ?)`
+  ).run(chatId, fingerprint, messageId ?? null);
+}
+
+export function updatePromptMessageId(
+  db: Database.Database,
+  chatId: number,
+  fingerprint: string,
+  messageId: number
+): void {
+  db.prepare(
+    'UPDATE neighbor_check_prompts SET message_id = ? WHERE chat_id = ? AND fingerprint = ?'
+  ).run(messageId, chatId, fingerprint);
+}
+
+export function markResponded(
+  db: Database.Database,
+  chatId: number,
+  fingerprint: string
+): void {
+  db.prepare(
+    'UPDATE neighbor_check_prompts SET responded = 1 WHERE chat_id = ? AND fingerprint = ?'
+  ).run(chatId, fingerprint);
+}
+
+/**
+ * Find a prompt row by chatId and a fingerprint prefix (fp_short = first 8 chars).
+ * Returns the first matching row or null.
+ */
+export function getPromptByPrefix(
+  db: Database.Database,
+  chatId: number,
+  fpShort: string
+): NeighborCheckPromptRow | null {
+  const raw = db
+    .prepare(
+      `SELECT * FROM neighbor_check_prompts
+       WHERE chat_id = ? AND fingerprint LIKE ? || '%'
+       LIMIT 1`
+    )
+    .get(chatId, fpShort) as RawPromptRow | undefined;
+  return raw ? decodePromptRow(raw) : null;
+}
+
+/**
+ * Insert an anonymous event (no chat_id — privacy guarantee).
+ */
+export function recordEvent(
+  db: Database.Database,
+  alertFp: string,
+  response: 'checked' | 'unable' | 'dismissed',
+  city: string | null
+): void {
+  db.prepare(
+    `INSERT INTO neighbor_check_events (alert_fp, response, city)
+     VALUES (?, ?, ?)`
+  ).run(alertFp, response, city);
+}
+
+/**
+ * Aggregate counts grouped by response for events since `since` (ISO datetime string).
+ */
+export function getAggregate(
+  db: Database.Database,
+  since: string
+): NeighborCheckAggregate {
+  const rows = db
+    .prepare(
+      `SELECT response, COUNT(*) as cnt
+       FROM neighbor_check_events
+       WHERE created_at >= ?
+       GROUP BY response`
+    )
+    .all(since) as RawEventRow[];
+
+  const result: NeighborCheckAggregate = { checked: 0, unable: 0, dismissed: 0, total: 0 };
+  for (const row of rows) {
+    if (row.response === 'checked') result.checked = row.cnt;
+    else if (row.response === 'unable') result.unable = row.cnt;
+    else if (row.response === 'dismissed') result.dismissed = row.cnt;
+  }
+  result.total = result.checked + result.unable + result.dismissed;
+  return result;
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -273,6 +273,18 @@ export function initSchema(database: Database.Database): void {
       updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_skill_catalog_active ON skill_catalog(is_active, sort_order);
+
+    -- v0.5.3 — user skills (refs #221)
+    CREATE TABLE IF NOT EXISTS user_skills (
+      chat_id    INTEGER NOT NULL REFERENCES users(chat_id) ON DELETE CASCADE,
+      skill_key  TEXT NOT NULL,
+      visibility TEXT NOT NULL DEFAULT 'contacts'
+                   CHECK (visibility IN ('public','contacts','private')),
+      note       TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (chat_id, skill_key)
+    );
+    CREATE INDEX IF NOT EXISTS idx_user_skills_skill ON user_skills(skill_key);
   `);
 
   database.exec(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -251,7 +251,7 @@ export function initSchema(database: Database.Database): void {
     CREATE TABLE IF NOT EXISTS shelter_stories (
       id                   INTEGER PRIMARY KEY AUTOINCREMENT,
       chat_id              INTEGER NOT NULL REFERENCES users(chat_id) ON DELETE CASCADE,
-      body                 TEXT NOT NULL CHECK (length(body) <= 200),
+      body                 TEXT NOT NULL,
       status               TEXT NOT NULL DEFAULT 'pending'
                              CHECK (status IN ('pending','approved','rejected','published')),
       published_message_id INTEGER,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -228,6 +228,25 @@ export function initSchema(database: Database.Database): void {
       FOREIGN KEY (chat_id) REFERENCES users(chat_id) ON DELETE CASCADE
     );
 
+    -- v0.5.3 — community pulse survey (refs #219)
+    CREATE TABLE IF NOT EXISTS community_pulses (
+      id          INTEGER PRIMARY KEY AUTOINCREMENT,
+      fingerprint TEXT NOT NULL UNIQUE,
+      alert_type  TEXT NOT NULL,
+      zones       TEXT NOT NULL,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_pulses_fp ON community_pulses(fingerprint);
+
+    CREATE TABLE IF NOT EXISTS community_pulse_responses (
+      pulse_id   INTEGER NOT NULL REFERENCES community_pulses(id) ON DELETE CASCADE,
+      chat_id    INTEGER NOT NULL,
+      answer     TEXT NOT NULL CHECK (answer IN ('ok','scared','helping')),
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (pulse_id, chat_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_pulse_responses_chat ON community_pulse_responses(chat_id, created_at);
+
     -- v0.5.3 — skills catalog (refs #228)
     CREATE TABLE IF NOT EXISTS skill_catalog (
       key         TEXT PRIMARY KEY,
@@ -328,6 +347,7 @@ export function initDb(): void {
     database.prepare(`DELETE FROM contacts WHERE status = 'pending' AND created_at < datetime('now', '-7 days')`).run();
     database.prepare(`DELETE FROM safety_status WHERE expires_at < datetime('now')`).run();
     database.prepare(`DELETE FROM safety_prompts WHERE sent_at < datetime('now', '-24 hours')`).run();
+    database.prepare(`DELETE FROM community_pulses WHERE created_at < datetime('now', '-7 days')`).run();
   })();
 
   // Integrity check — warn if users table is empty but alert history exists (possible data loss)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -305,6 +305,18 @@ export function initSchema(database: Database.Database): void {
       created_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
     CREATE INDEX IF NOT EXISTS idx_nc_events_created ON neighbor_check_events(created_at);
+
+    -- v0.5.3 — group escape hatch audit log (refs #231)
+    -- NOTE: no FK on group_id — intentional; audit row must survive group deletion cascade
+    CREATE TABLE IF NOT EXISTS group_audit (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      group_id   INTEGER NOT NULL,
+      action     TEXT NOT NULL CHECK (action IN ('deleted','transferred')),
+      actor_id   INTEGER NOT NULL,
+      payload    TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_group_audit_group ON group_audit(group_id);
   `);
 
   database.exec(

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -227,6 +227,18 @@ export function initSchema(database: Database.Database): void {
       UNIQUE (chat_id, fingerprint),
       FOREIGN KEY (chat_id) REFERENCES users(chat_id) ON DELETE CASCADE
     );
+
+    -- v0.5.3 — skills catalog (refs #228)
+    CREATE TABLE IF NOT EXISTS skill_catalog (
+      key         TEXT PRIMARY KEY,
+      label_he    TEXT NOT NULL,
+      description TEXT,
+      is_active   INTEGER NOT NULL DEFAULT 1,
+      sort_order  INTEGER NOT NULL DEFAULT 0,
+      created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at  TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_skill_catalog_active ON skill_catalog(is_active, sort_order);
   `);
 
   database.exec(
@@ -297,6 +309,13 @@ export function initSchema(database: Database.Database): void {
     INSERT OR IGNORE INTO message_templates (alert_type, emoji, title_he, instructions_prefix)
     VALUES ('all_clear', '✅', 'שקט חזר', 'נשמו. אתם בטוחים. 🕊')
   `).run();
+
+  // v0.5.3 — seed default skills (refs #228); INSERT OR IGNORE preserves admin edits
+  database.prepare(`INSERT OR IGNORE INTO skill_catalog (key, label_he, sort_order) VALUES ('first_aid', 'עזרה ראשונה', 1)`).run();
+  database.prepare(`INSERT OR IGNORE INTO skill_catalog (key, label_he, sort_order) VALUES ('shelter_host', 'אירוח במקלט', 2)`).run();
+  database.prepare(`INSERT OR IGNORE INTO skill_catalog (key, label_he, sort_order) VALUES ('psych_support', 'תמיכה נפשית', 3)`).run();
+  database.prepare(`INSERT OR IGNORE INTO skill_catalog (key, label_he, sort_order) VALUES ('ride_share', 'הסעה', 4)`).run();
+  database.prepare(`INSERT OR IGNORE INTO skill_catalog (key, label_he, sort_order) VALUES ('water_food', 'מזון ומים', 5)`).run();
 }
 
 export function initDb(): void {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -285,6 +285,26 @@ export function initSchema(database: Database.Database): void {
       PRIMARY KEY (chat_id, skill_key)
     );
     CREATE INDEX IF NOT EXISTS idx_user_skills_skill ON user_skills(skill_key);
+
+    -- v0.5.3 — neighbor check (refs #222)
+    CREATE TABLE IF NOT EXISTS neighbor_check_prompts (
+      chat_id     INTEGER NOT NULL REFERENCES users(chat_id) ON DELETE CASCADE,
+      fingerprint TEXT NOT NULL,
+      sent_at     TEXT NOT NULL DEFAULT (datetime('now')),
+      responded   INTEGER NOT NULL DEFAULT 0,
+      message_id  INTEGER,
+      PRIMARY KEY (chat_id, fingerprint)
+    );
+    CREATE INDEX IF NOT EXISTS idx_nc_prompts_msg ON neighbor_check_prompts(message_id);
+
+    CREATE TABLE IF NOT EXISTS neighbor_check_events (
+      id         INTEGER PRIMARY KEY AUTOINCREMENT,
+      alert_fp   TEXT NOT NULL,
+      response   TEXT NOT NULL CHECK (response IN ('checked','unable','dismissed')),
+      city       TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_nc_events_created ON neighbor_check_events(created_at);
   `);
 
   database.exec(
@@ -346,6 +366,9 @@ export function initSchema(database: Database.Database): void {
   addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN social_group_alerts_enabled INTEGER NOT NULL DEFAULT 1');
   addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN social_quick_ok_enabled INTEGER NOT NULL DEFAULT 1');
 
+  // v0.5.3 — neighbor check (refs #222)
+  addColumnIfMissing(database, 'ALTER TABLE users ADD COLUMN neighbor_check_enabled INTEGER NOT NULL DEFAULT 1');
+
   database.prepare('CREATE UNIQUE INDEX IF NOT EXISTS idx_users_connection_code ON users(connection_code) WHERE connection_code IS NOT NULL').run();
 
   // Seed the all-clear template so it appears in the dashboard Messages page on first run.
@@ -376,6 +399,8 @@ export function initDb(): void {
     database.prepare(`DELETE FROM safety_prompts WHERE sent_at < datetime('now', '-24 hours')`).run();
     database.prepare(`DELETE FROM community_pulses WHERE created_at < datetime('now', '-7 days')`).run();
     database.prepare(`DELETE FROM shelter_stories WHERE status IN ('rejected','published') AND created_at < datetime('now','-30 days')`).run();
+    database.prepare(`DELETE FROM neighbor_check_prompts WHERE sent_at < datetime('now','-1 day')`).run();
+    database.prepare(`DELETE FROM neighbor_check_events WHERE created_at < datetime('now','-30 days')`).run();
   })();
 
   // Integrity check — warn if users table is empty but alert history exists (possible data loss)

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -247,6 +247,21 @@ export function initSchema(database: Database.Database): void {
     );
     CREATE INDEX IF NOT EXISTS idx_pulse_responses_chat ON community_pulse_responses(chat_id, created_at);
 
+    -- v0.5.3 — shelter stories opt-in submissions (refs #220)
+    CREATE TABLE IF NOT EXISTS shelter_stories (
+      id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+      chat_id              INTEGER NOT NULL REFERENCES users(chat_id) ON DELETE CASCADE,
+      body                 TEXT NOT NULL CHECK (length(body) <= 200),
+      status               TEXT NOT NULL DEFAULT 'pending'
+                             CHECK (status IN ('pending','approved','rejected','published')),
+      published_message_id INTEGER,
+      created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+      reviewed_at          TEXT,
+      reviewed_by          TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_stories_status ON shelter_stories(status);
+    CREATE INDEX IF NOT EXISTS idx_stories_chat ON shelter_stories(chat_id, created_at);
+
     -- v0.5.3 — skills catalog (refs #228)
     CREATE TABLE IF NOT EXISTS skill_catalog (
       key         TEXT PRIMARY KEY,
@@ -348,6 +363,7 @@ export function initDb(): void {
     database.prepare(`DELETE FROM safety_status WHERE expires_at < datetime('now')`).run();
     database.prepare(`DELETE FROM safety_prompts WHERE sent_at < datetime('now', '-24 hours')`).run();
     database.prepare(`DELETE FROM community_pulses WHERE created_at < datetime('now', '-7 days')`).run();
+    database.prepare(`DELETE FROM shelter_stories WHERE status IN ('rejected','published') AND created_at < datetime('now','-30 days')`).run();
   })();
 
   // Integrity check — warn if users table is empty but alert history exists (possible data loss)

--- a/src/db/shelterStoryRepository.ts
+++ b/src/db/shelterStoryRepository.ts
@@ -98,17 +98,22 @@ export function getStoryById(
   return row ? decodeRow(row) : null;
 }
 
-export function approveStory(
+/**
+ * Phase 2 of approve flow: transitions approved → published after the Telegram message is sent.
+ * Returns false if the story is not in 'approved' status (e.g. was rejected concurrently).
+ */
+export function publishStory(
   db: Database.Database,
   id: number,
   reviewedBy: string,
   publishedMessageId: number
-): void {
-  db.prepare(
+): boolean {
+  const result = db.prepare(
     `UPDATE shelter_stories
      SET status = 'published', published_message_id = ?, reviewed_at = datetime('now'), reviewed_by = ?
-     WHERE id = ?`
+     WHERE id = ? AND status = 'approved'`
   ).run(publishedMessageId, reviewedBy, id);
+  return result.changes > 0;
 }
 
 /**

--- a/src/db/shelterStoryRepository.ts
+++ b/src/db/shelterStoryRepository.ts
@@ -1,0 +1,168 @@
+import type Database from 'better-sqlite3';
+
+export interface StoryRow {
+  id: number;
+  chatId: number;
+  body: string;
+  status: 'pending' | 'approved' | 'rejected' | 'published';
+  publishedMessageId: number | null;
+  createdAt: string;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+}
+
+interface RawStoryRow {
+  id: number;
+  chat_id: number;
+  body: string;
+  status: 'pending' | 'approved' | 'rejected' | 'published';
+  published_message_id: number | null;
+  created_at: string;
+  reviewed_at: string | null;
+  reviewed_by: string | null;
+}
+
+function decodeRow(row: RawStoryRow): StoryRow {
+  return {
+    id: row.id,
+    chatId: row.chat_id,
+    body: row.body,
+    status: row.status,
+    publishedMessageId: row.published_message_id,
+    createdAt: row.created_at,
+    reviewedAt: row.reviewed_at,
+    reviewedBy: row.reviewed_by,
+  };
+}
+
+export function createStory(
+  db: Database.Database,
+  chatId: number,
+  body: string
+): StoryRow {
+  const stmt = db.prepare(
+    `INSERT INTO shelter_stories (chat_id, body) VALUES (?, ?) RETURNING *`
+  );
+  const row = stmt.get(chatId, body) as RawStoryRow;
+  return decodeRow(row);
+}
+
+export function getPendingStories(
+  db: Database.Database,
+  limit: number,
+  offset: number
+): StoryRow[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM shelter_stories WHERE status = 'pending' ORDER BY created_at ASC LIMIT ? OFFSET ?`
+    )
+    .all(limit, offset) as RawStoryRow[];
+  return rows.map(decodeRow);
+}
+
+export function getStoriesByStatus(
+  db: Database.Database,
+  status: 'pending' | 'approved' | 'rejected' | 'published',
+  limit: number,
+  offset: number
+): StoryRow[] {
+  const rows = db
+    .prepare(
+      `SELECT * FROM shelter_stories WHERE status = ? ORDER BY created_at ASC LIMIT ? OFFSET ?`
+    )
+    .all(status, limit, offset) as RawStoryRow[];
+  return rows.map(decodeRow);
+}
+
+/**
+ * Atomically claim a pending story for approval.
+ * Returns true if the story was successfully locked (status changed pending→approved).
+ * Returns false if the story wasn't in pending state (already processed or doesn't exist).
+ */
+export function lockForApproval(db: Database.Database, id: number): boolean {
+  const result = db
+    .prepare(
+      `UPDATE shelter_stories SET status = 'approved' WHERE id = ? AND status = 'pending'`
+    )
+    .run(id);
+  return result.changes > 0;
+}
+
+export function getStoryById(
+  db: Database.Database,
+  id: number
+): StoryRow | null {
+  const row = db
+    .prepare(`SELECT * FROM shelter_stories WHERE id = ?`)
+    .get(id) as RawStoryRow | undefined;
+  return row ? decodeRow(row) : null;
+}
+
+export function approveStory(
+  db: Database.Database,
+  id: number,
+  reviewedBy: string,
+  publishedMessageId: number
+): void {
+  db.prepare(
+    `UPDATE shelter_stories
+     SET status = 'published', published_message_id = ?, reviewed_at = datetime('now'), reviewed_by = ?
+     WHERE id = ?`
+  ).run(publishedMessageId, reviewedBy, id);
+}
+
+/**
+ * Reject a pending story.
+ * Returns true if the story was successfully rejected, false if it wasn't in pending state.
+ */
+export function rejectStory(
+  db: Database.Database,
+  id: number,
+  reviewedBy: string
+): boolean {
+  const result = db
+    .prepare(
+      `UPDATE shelter_stories
+       SET status = 'rejected', reviewed_at = datetime('now'), reviewed_by = ?
+       WHERE id = ? AND status = 'pending'`
+    )
+    .run(reviewedBy, id);
+  return result.changes > 0;
+}
+
+export function countStoriesByUserSince(
+  db: Database.Database,
+  chatId: number,
+  sinceIso: string
+): number {
+  const row = db
+    .prepare(
+      `SELECT COUNT(*) as cnt FROM shelter_stories WHERE chat_id = ? AND created_at >= ?`
+    )
+    .get(chatId, sinceIso) as { cnt: number };
+  return row.cnt;
+}
+
+export function getCountsByStatus(
+  db: Database.Database
+): Record<'pending' | 'approved' | 'rejected' | 'published', number> {
+  const rows = db
+    .prepare(
+      `SELECT status, COUNT(*) as cnt FROM shelter_stories GROUP BY status`
+    )
+    .all() as Array<{ status: string; cnt: number }>;
+
+  const result: Record<'pending' | 'approved' | 'rejected' | 'published', number> = {
+    pending: 0,
+    approved: 0,
+    rejected: 0,
+    published: 0,
+  };
+
+  for (const row of rows) {
+    const s = row.status as keyof typeof result;
+    if (s in result) result[s] = row.cnt;
+  }
+
+  return result;
+}

--- a/src/db/skillCatalogRepository.ts
+++ b/src/db/skillCatalogRepository.ts
@@ -1,0 +1,155 @@
+import type Database from 'better-sqlite3';
+
+const SKILL_KEY_REGEX = /^[a-z0-9_]{1,32}$/;
+
+export interface SkillCatalogRow {
+  key: string;
+  labelHe: string;
+  description: string | null;
+  isActive: boolean;
+  sortOrder: number;
+  createdAt: string;
+  updatedAt: string;
+  usageCount?: number;
+}
+
+type RawRow = {
+  key: string;
+  label_he: string;
+  description: string | null;
+  is_active: number;
+  sort_order: number;
+  created_at: string;
+  updated_at: string;
+  usage_count?: number;
+};
+
+function decodeRow(raw: RawRow): SkillCatalogRow {
+  return {
+    key: raw.key,
+    labelHe: raw.label_he,
+    description: raw.description ?? null,
+    isActive: Boolean(raw.is_active),
+    sortOrder: raw.sort_order,
+    createdAt: raw.created_at,
+    updatedAt: raw.updated_at,
+    ...(raw.usage_count !== undefined ? { usageCount: raw.usage_count } : {}),
+  };
+}
+
+/**
+ * Returns all active skills ordered by sort_order ascending.
+ */
+export function listActiveSkills(db: Database.Database): SkillCatalogRow[] {
+  const rows = db
+    .prepare(
+      `SELECT key, label_he, description, is_active, sort_order, created_at, updated_at
+       FROM skill_catalog
+       WHERE is_active = 1
+       ORDER BY sort_order ASC`
+    )
+    .all() as RawRow[];
+  return rows.map(decodeRow);
+}
+
+/**
+ * Returns all skills with usage_count from user_skills (0 when user_skills does not yet exist).
+ */
+export function listAllSkills(db: Database.Database): SkillCatalogRow[] {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT s.key, s.label_he, s.description, s.is_active, s.sort_order, s.created_at, s.updated_at,
+                COUNT(us.skill_key) AS usage_count
+         FROM skill_catalog s
+         LEFT JOIN user_skills us ON us.skill_key = s.key
+         GROUP BY s.key
+         ORDER BY s.sort_order ASC`
+      )
+      .all() as RawRow[];
+    return rows.map(decodeRow);
+  } catch {
+    // user_skills table does not exist yet — fall back to 0 counts
+    const rows = db
+      .prepare(
+        `SELECT key, label_he, description, is_active, sort_order, created_at, updated_at
+         FROM skill_catalog
+         ORDER BY sort_order ASC`
+      )
+      .all() as RawRow[];
+    return rows.map((r) => decodeRow({ ...r, usage_count: 0 }));
+  }
+}
+
+/**
+ * Returns a single skill by primary key, or null if not found.
+ */
+export function getSkillByKey(db: Database.Database, key: string): SkillCatalogRow | null {
+  const raw = db
+    .prepare(
+      `SELECT key, label_he, description, is_active, sort_order, created_at, updated_at
+       FROM skill_catalog
+       WHERE key = ?`
+    )
+    .get(key) as RawRow | undefined;
+  return raw ? decodeRow(raw) : null;
+}
+
+/**
+ * Inserts or updates a skill row.
+ * Uses ON CONFLICT DO UPDATE to preserve created_at on updates.
+ * Throws Error('Invalid skill key format') if key does not match /^[a-z0-9_]{1,32}$/.
+ */
+export function upsertSkill(
+  db: Database.Database,
+  row: Pick<SkillCatalogRow, 'key' | 'labelHe' | 'description' | 'isActive' | 'sortOrder'>
+): void {
+  if (!SKILL_KEY_REGEX.test(row.key)) {
+    throw new Error('Invalid skill key format');
+  }
+  db.prepare(`
+    INSERT INTO skill_catalog (key, label_he, description, is_active, sort_order, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))
+    ON CONFLICT(key) DO UPDATE SET
+      label_he    = excluded.label_he,
+      description = excluded.description,
+      is_active   = excluded.is_active,
+      sort_order  = excluded.sort_order,
+      updated_at  = datetime('now')
+  `).run(
+    row.key,
+    row.labelHe,
+    row.description ?? null,
+    row.isActive ? 1 : 0,
+    row.sortOrder
+  );
+}
+
+/**
+ * Soft-deletes a skill by setting is_active = 0.
+ */
+export function deactivateSkill(db: Database.Database, key: string): void {
+  db.prepare(`UPDATE skill_catalog SET is_active = 0, updated_at = datetime('now') WHERE key = ?`).run(key);
+}
+
+/**
+ * Restores a deactivated skill by setting is_active = 1.
+ */
+export function activateSkill(db: Database.Database, key: string): void {
+  db.prepare(`UPDATE skill_catalog SET is_active = 1, updated_at = datetime('now') WHERE key = ?`).run(key);
+}
+
+/**
+ * Returns the number of users who have claimed a given skill.
+ * Returns 0 if user_skills table does not yet exist.
+ */
+export function getUsageCount(db: Database.Database, key: string): number {
+  try {
+    const row = db
+      .prepare(`SELECT COUNT(*) AS n FROM user_skills WHERE skill_key = ?`)
+      .get(key) as { n: number };
+    return row.n;
+  } catch {
+    return 0;
+  }
+}

--- a/src/db/skillCatalogRepository.ts
+++ b/src/db/skillCatalogRepository.ts
@@ -68,16 +68,20 @@ export function listAllSkills(db: Database.Database): SkillCatalogRow[] {
       )
       .all() as RawRow[];
     return rows.map(decodeRow);
-  } catch {
-    // user_skills table does not exist yet — fall back to 0 counts
-    const rows = db
-      .prepare(
-        `SELECT key, label_he, description, is_active, sort_order, created_at, updated_at
-         FROM skill_catalog
-         ORDER BY sort_order ASC`
-      )
-      .all() as RawRow[];
-    return rows.map((r) => decodeRow({ ...r, usage_count: 0 }));
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('no such table')) {
+      // Safety net: user_skills table missing (unlikely — both created in initSchema)
+      const rows = db
+        .prepare(
+          `SELECT key, label_he, description, is_active, sort_order, created_at, updated_at
+           FROM skill_catalog
+           ORDER BY sort_order ASC`
+        )
+        .all() as RawRow[];
+      return rows.map((r) => decodeRow({ ...r, usage_count: 0 }));
+    }
+    throw err;
   }
 }
 
@@ -149,7 +153,9 @@ export function getUsageCount(db: Database.Database, key: string): number {
       .prepare(`SELECT COUNT(*) AS n FROM user_skills WHERE skill_key = ?`)
       .get(key) as { n: number };
     return row.n;
-  } catch {
-    return 0;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('no such table')) return 0;
+    throw err;
   }
 }

--- a/src/db/userRepository.ts
+++ b/src/db/userRepository.ts
@@ -24,6 +24,7 @@ export interface User {
   social_contact_count_enabled: boolean;
   social_group_alerts_enabled: boolean;
   social_quick_ok_enabled: boolean;
+  neighbor_check_enabled: boolean;
   created_at: string;
 }
 
@@ -51,6 +52,7 @@ interface RawUserRow {
   social_contact_count_enabled: number;
   social_group_alerts_enabled: number;
   social_quick_ok_enabled: number;
+  neighbor_check_enabled: number;
   created_at: string;
 }
 
@@ -72,6 +74,7 @@ function mapRowToUser(raw: RawUserRow): User {
     social_contact_count_enabled: raw.social_contact_count_enabled === 1,
     social_group_alerts_enabled: raw.social_group_alerts_enabled === 1,
     social_quick_ok_enabled: raw.social_quick_ok_enabled === 1,
+    neighbor_check_enabled: raw.neighbor_check_enabled === 1,
   };
 }
 
@@ -239,6 +242,13 @@ export function findUserByConnectionCode(code: string): User | undefined {
     .get(code) as RawUserRow | undefined;
   if (!raw) return undefined;
   return mapRowToUser(raw);
+}
+
+// --- Neighbor check preference (v0.5.3, #222) ---
+
+export function setNeighborCheckEnabled(db: Database.Database, chatId: number, enabled: boolean): void {
+  upsertUser(chatId);
+  db.prepare('UPDATE users SET neighbor_check_enabled = ? WHERE chat_id = ?').run(enabled ? 1 : 0, chatId);
 }
 
 /**

--- a/src/db/userSkillsRepository.ts
+++ b/src/db/userSkillsRepository.ts
@@ -1,0 +1,134 @@
+import type Database from 'better-sqlite3';
+
+export interface UserSkillRow {
+  chatId: number;
+  skillKey: string;
+  visibility: 'public' | 'contacts' | 'private';
+  note: string | null;
+  createdAt: string;
+}
+
+interface RawUserSkill {
+  chat_id: number;
+  skill_key: string;
+  visibility: string;
+  note: string | null;
+  created_at: string;
+}
+
+function decodeRow(raw: RawUserSkill): UserSkillRow {
+  return {
+    chatId: raw.chat_id,
+    skillKey: raw.skill_key,
+    visibility: raw.visibility as UserSkillRow['visibility'],
+    note: raw.note ?? null,
+    createdAt: raw.created_at,
+  };
+}
+
+/** Returns all skills claimed by a user, ordered by created_at. */
+export function listSkillsForUser(
+  db: Database.Database,
+  chatId: number
+): UserSkillRow[] {
+  const rows = db
+    .prepare(
+      `SELECT chat_id, skill_key, visibility, note, created_at
+       FROM user_skills
+       WHERE chat_id = ?
+       ORDER BY created_at ASC`
+    )
+    .all(chatId) as RawUserSkill[];
+  return rows.map(decodeRow);
+}
+
+/**
+ * Inserts or replaces a user skill.
+ * INSERT OR REPLACE is intentional here — created_at loss on update is acceptable
+ * for user skill edits (PRIMARY KEY is (chat_id, skill_key)).
+ */
+export function upsertSkill(
+  db: Database.Database,
+  chatId: number,
+  skillKey: string,
+  visibility: UserSkillRow['visibility'],
+  note: string | null
+): UserSkillRow {
+  db.prepare(
+    `INSERT OR REPLACE INTO user_skills (chat_id, skill_key, visibility, note, created_at)
+     VALUES (?, ?, ?, ?, datetime('now'))`
+  ).run(chatId, skillKey, visibility, note ?? null);
+
+  const raw = db
+    .prepare(
+      `SELECT chat_id, skill_key, visibility, note, created_at
+       FROM user_skills
+       WHERE chat_id = ? AND skill_key = ?`
+    )
+    .get(chatId, skillKey) as RawUserSkill;
+  return decodeRow(raw);
+}
+
+/** Removes a skill from a user. Returns true if the row was deleted. */
+export function removeSkill(
+  db: Database.Database,
+  chatId: number,
+  skillKey: string
+): boolean {
+  const result = db
+    .prepare(`DELETE FROM user_skills WHERE chat_id = ? AND skill_key = ?`)
+    .run(chatId, skillKey);
+  return result.changes > 0;
+}
+
+export interface SkillMatchRow {
+  displayName: string;
+  homeCity: string | null;
+}
+
+/**
+ * Returns users who have the given skill, respecting visibility rules:
+ * - 'public': always shown
+ * - 'contacts': only shown if chat_id is in contactIds
+ * - 'private': never shown
+ *
+ * Joins skill_catalog to filter orphaned skills (is_active = 1).
+ * Never exposes chat_id in results.
+ */
+export function findUsersWithSkill(
+  db: Database.Database,
+  skillKey: string,
+  viewerChatId: number,
+  contactIds: number[],
+  limit: number,
+  offset: number
+): SkillMatchRow[] {
+  const contactPlaceholders =
+    contactIds.length > 0 ? contactIds.map(() => '?').join(', ') : 'NULL';
+
+  const sql = `
+    SELECT u.display_name AS display_name, u.home_city AS home_city
+    FROM user_skills us
+    JOIN users u ON u.chat_id = us.chat_id
+    JOIN skill_catalog sc ON sc.key = us.skill_key AND sc.is_active = 1
+    WHERE us.skill_key = ?
+      AND us.chat_id != ?
+      AND (
+        us.visibility = 'public'
+        OR (us.visibility = 'contacts' AND us.chat_id IN (${contactPlaceholders}))
+      )
+    ORDER BY us.created_at ASC
+    LIMIT ? OFFSET ?
+  `;
+
+  const params: unknown[] = [skillKey, viewerChatId, ...contactIds, limit, offset];
+  const rows = db.prepare(sql).all(...params) as Array<{
+    display_name: string | null;
+    home_city: string | null;
+  }>;
+
+  return rows.map((r) => ({
+    displayName: r.display_name ?? 'משתמש',
+    homeCity: r.home_city ?? null,
+  }));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { AlertPoller } from './alertPoller';
 import { generateMapImage } from './mapService';
 import { sendAlert, getBot, editAlert } from './telegramBot';
-import { getActiveMessage, trackMessage, loadActiveMessages } from './alertWindowTracker';
+import { getActiveMessage, trackMessage, loadActiveMessages, setWindowCloseCallback, clearAllCloseTimers } from './alertWindowTracker';
 import { getTopicId } from './topicRouter';
 import { Alert } from './types';
 import { initDb, closeDb } from './db/schema';
@@ -42,6 +42,7 @@ import { getDensityLabel } from './config/alertDensity.js';
 import { pruneExpiredContacts } from './db/contactRepository.js';
 import { pruneExpiredSafetyStatuses } from './db/safetyStatusRepository.js';
 import { pruneOldPrompts } from './db/safetyPromptRepository.js';
+import { fireCommunityPulse } from './services/communityPulseService.js';
 import { initCrypto } from './dashboard/crypto.js';
 import { getSetting, setSetting } from './dashboard/settingsRepository.js';
 import { resolveConfig, resolveRequiredConfigs, ConfigMissingError, SECRET_KEYS, envKeyFor } from './config/configResolver.js';
@@ -159,6 +160,14 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
 
   const bot = getBot(resolvedConfig['telegram_bot_token']);
   await setupBotHandlers(bot);
+
+  // Wire community pulse: fires when an alert window expires (lazy expiry in getActiveMessage).
+  // MUST NOT fire in loadActiveMessages() — stale startup pruning must not trigger pulses.
+  setWindowCloseCallback((alertType, tracked) => {
+    fireCommunityPulse(getDb(), bot, alertType, tracked).catch((err) =>
+      log('error', 'CommunityPulse', `fireCommunityPulse error: ${String(err)}`)
+    );
+  });
 
   const tgListenerEnabled = resolveConfig(getDb(), 'telegram_listener_enabled') === 'true'
     || process.env.TELEGRAM_LISTENER_ENABLED === 'true';
@@ -344,6 +353,7 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
     tgListenerEnabled,
     disconnectTelegramListener: () => disconnectTelegramListener(getDb()),
     closeDb,
+    clearAlertWindowTimers: clearAllCloseTimers,
   });
   process.once('SIGTERM', () => { void shutdown('SIGTERM'); });
   process.once('SIGINT',  () => { void shutdown('SIGINT');  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,8 @@ import { pruneExpiredContacts } from './db/contactRepository.js';
 import { pruneExpiredSafetyStatuses } from './db/safetyStatusRepository.js';
 import { pruneOldPrompts } from './db/safetyPromptRepository.js';
 import { fireCommunityPulse } from './services/communityPulseService.js';
+import { scheduleNeighborCheck, cancelAll as cancelNeighborCheckAll } from './services/neighborCheckService.js';
+import { setNeighborCheckHandlerDb } from './bot/neighborCheckHandler.js';
 import { initCrypto } from './dashboard/crypto.js';
 import { getSetting, setSetting } from './dashboard/settingsRepository.js';
 import { resolveConfig, resolveRequiredConfigs, ConfigMissingError, SECRET_KEYS, envKeyFor } from './config/configResolver.js';
@@ -125,6 +127,7 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
     loadRoutingCache(getDb());
     setMenuHandlerDb(getDb());
     setSafetyStatusHandlerDeps(getDb());
+    setNeighborCheckHandlerDb(getDb());
     alertsToday = countAlertsToday();
     initAlertSerial(alertsToday);
   } catch (err) {
@@ -309,6 +312,7 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
       insertAlertHistory,
       broadcastToWhatsApp,
       dispatchSafetyPrompts: (alert) => dispatchSafetyPrompts(getDb(), alert, bot),
+      scheduleNeighborCheck: (alert) => scheduleNeighborCheck(getDb(), bot, alert),
       getNextSerial: getNextAlertSerial,
       getDensityHint: () => getDensityLabel(countAlertsToday(), getDailyCountsForMonth()),
     });
@@ -354,6 +358,7 @@ function autoMigrateEnvSecrets(db: ReturnType<typeof getDb>): void {
     disconnectTelegramListener: () => disconnectTelegramListener(getDb()),
     closeDb,
     clearAlertWindowTimers: clearAllCloseTimers,
+    cancelNeighborCheckTimers: cancelNeighborCheckAll,
   });
   process.once('SIGTERM', () => { void shutdown('SIGTERM'); });
   process.once('SIGINT',  () => { void shutdown('SIGINT');  });

--- a/src/services/communityPulseService.ts
+++ b/src/services/communityPulseService.ts
@@ -1,0 +1,119 @@
+import type Database from 'better-sqlite3';
+import type { Bot } from 'grammy';
+import { getBool, getNumber, getString } from '../config/configResolver.js';
+import { computeAlertFingerprint } from '../alertHelpers.js';
+import { getCityData } from '../cityLookup.js';
+import { getUsersForCities } from '../db/subscriptionRepository.js';
+import { shouldSkipForQuietHours } from './dmDispatcher.js';
+import {
+  createPulse,
+  getLastResponseTime,
+} from '../db/communityPulseRepository.js';
+import type { TrackedMessage } from '../alertWindowTracker.js';
+import { log } from '../logger.js';
+
+export interface CommunityPulseDeps {
+  /** Override send fan-out for tests. Defaults to Promise.allSettled over direct bot calls. */
+  enqueue?: (tasks: Array<() => Promise<void>>) => void;
+  now?: Date;
+}
+
+function getZonesFromCities(cities: string[]): string[] {
+  const seen = new Set<string>();
+  for (const city of cities) {
+    const zone = getCityData(city)?.zone;
+    if (zone) seen.add(zone);
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Called from alertWindowTracker close callback when a window expires.
+ * Fans out a survey DM to all subscribers in the affected zones.
+ */
+export async function fireCommunityPulse(
+  db: Database.Database,
+  bot: Bot,
+  alertType: string,
+  trackedAlert: TrackedMessage,
+  deps?: CommunityPulseDeps
+): Promise<void> {
+  const cities = trackedAlert.alert.cities ?? [];
+  if (cities.length === 0) {
+    log('info', 'CommunityPulse', `no cities for alertType=${alertType} — skipping pulse`);
+    return;
+  }
+
+  const pulseEnabled = getBool(db, 'pulse_enabled', true);
+  if (!pulseEnabled) {
+    log('info', 'CommunityPulse', `pulse_enabled=false — skipping for ${alertType}`);
+    return;
+  }
+
+  const now = deps?.now ?? new Date();
+  const fingerprint = computeAlertFingerprint(alertType, cities);
+  const zones = getZonesFromCities(cities);
+
+  const pulse = createPulse(db, fingerprint, alertType, zones);
+
+  const cooldownHours = getNumber(db, 'pulse_cooldown_hours', 6);
+  const promptText = getString(db, 'pulse_prompt_text', 'איך אתה מרגיש אחרי האזעקה?');
+
+  const subscribers = getUsersForCities(cities);
+  log('info', 'CommunityPulse', `pulse id=${pulse.id} — ${subscribers.length} מנויים · ${alertType}`);
+
+  const tasks: Array<() => Promise<void>> = [];
+
+  for (const sub of subscribers) {
+    if (!sub) continue;
+
+    // Quiet-hours check
+    if (shouldSkipForQuietHours(alertType, sub.quiet_hours_enabled, now)) continue;
+
+    // Snooze check
+    if (sub.muted_until && new Date(sub.muted_until) > now) continue;
+
+    // Cooldown: skip if user responded to any pulse in last N hours
+    const lastResponse = getLastResponseTime(db, sub.chat_id);
+    if (lastResponse) {
+      const msDiff = now.getTime() - new Date(lastResponse).getTime();
+      const hoursDiff = msDiff / (1000 * 60 * 60);
+      if (hoursDiff < cooldownHours) continue;
+    }
+
+    const chatId = sub.chat_id;
+    const pulseId = pulse.id;
+
+    tasks.push(async () => {
+      const reply_markup = {
+        inline_keyboard: [[
+          { text: '✅ בסדר',          callback_data: `pulse:ok:${pulseId}`      },
+          { text: '😰 מפחד/ת',        callback_data: `pulse:scared:${pulseId}`  },
+          { text: '🤝 עוזר/ת לאחרים', callback_data: `pulse:helping:${pulseId}` },
+        ]],
+      };
+      try {
+        await bot.api.sendMessage(chatId, promptText, {
+          parse_mode: 'HTML',
+          reply_markup,
+        });
+      } catch (err) {
+        log('error', 'CommunityPulse', `כישלון בשליחה ל-${chatId}: ${String(err)}`);
+      }
+    });
+  }
+
+  if (tasks.length === 0) {
+    log('info', 'CommunityPulse', `pulse id=${pulse.id} — אין מנויים להשלחה`);
+    return;
+  }
+
+  log('info', 'CommunityPulse', `שולחים ${tasks.length} סקרים · pulse=${pulse.id}`);
+
+  const enqueue = deps?.enqueue;
+  if (enqueue) {
+    enqueue(tasks);
+  } else {
+    void Promise.allSettled(tasks.map((fn) => fn()));
+  }
+}

--- a/src/services/communityPulseService.ts
+++ b/src/services/communityPulseService.ts
@@ -114,6 +114,11 @@ export async function fireCommunityPulse(
   if (enqueue) {
     enqueue(tasks);
   } else {
-    void Promise.allSettled(tasks.map((fn) => fn()));
+    Promise.allSettled(tasks.map((fn) => fn())).then((results) => {
+      const failed = results.filter((r) => r.status === 'rejected').length;
+      if (failed > 0) {
+        log('error', 'CommunityPulse', `${failed}/${results.length} שליחות נכשלו · pulse=${pulse.id}`);
+      }
+    });
   }
 }

--- a/src/services/neighborCheckService.ts
+++ b/src/services/neighborCheckService.ts
@@ -1,0 +1,125 @@
+import type Database from 'better-sqlite3';
+import type { Bot } from 'grammy';
+import type { Alert } from '../types.js';
+import { isDrillAlert } from '../alertHelpers.js';
+import { getBool, getNumber, getString } from '../config/configResolver.js';
+import { insertPrompt, updatePromptMessageId } from '../db/neighborCheckRepository.js';
+import { log } from '../logger.js';
+
+const DEFAULT_DELAY_MINUTES = 7;
+const DEFAULT_TEXT = 'שלום, האם בדקת שכנים קשישים באזורך לאחר האזעקה?';
+
+export interface NeighborCheckDeps {
+  scheduleFn?: (fn: () => void, ms: number) => NodeJS.Timeout;
+  cancelScheduleFn?: (handle: NodeJS.Timeout) => void;
+  /** Injectable send function — returns message_id. Tests pass a mock. */
+  sendFn?: (
+    chatId: number,
+    text: string,
+    keyboard: object
+  ) => Promise<{ message_id: number }>;
+  /** Injectable function to fetch users in cities — for test isolation. */
+  getUsersInCitiesFn?: (cities: string[]) => Array<{ chat_id: number }>;
+}
+
+/** Map of fingerprint → timeout handle for cancellation on graceful shutdown. */
+const activeHandles = new Map<string, NodeJS.Timeout>();
+
+interface UserRow {
+  chat_id: number;
+}
+
+/**
+ * Returns users whose home_city is in the alert's cities, who have
+ * neighbor_check_enabled = 1 and is_dm_active = 1.
+ */
+export function getUsersInAlertCities(
+  db: Database.Database,
+  cities: string[]
+): UserRow[] {
+  if (cities.length === 0) return [];
+  const placeholders = cities.map(() => '?').join(',');
+  return db
+    .prepare(
+      `SELECT chat_id FROM users
+       WHERE home_city IN (${placeholders})
+         AND neighbor_check_enabled = 1
+         AND is_dm_active = 1`
+    )
+    .all(...cities) as UserRow[];
+}
+
+export function scheduleNeighborCheck(
+  db: Database.Database,
+  bot: Bot,
+  alert: Alert,
+  deps: NeighborCheckDeps = {}
+): void {
+  if (isDrillAlert(alert.type)) return;
+
+  const globalEnabled = getBool(db, 'neighbor_check_enabled_default', true);
+  if (!globalEnabled) return;
+
+  const delayMinutes = getNumber(db, 'neighbor_check_delay_minutes', DEFAULT_DELAY_MINUTES);
+  const delayMs = delayMinutes * 60 * 1000;
+  const text = getString(db, 'neighbor_check_text', DEFAULT_TEXT);
+
+  const fingerprint = alert.id ?? '';
+  if (!fingerprint) {
+    log('warn', 'NeighborCheck', 'alert.id ריק — מדלג על בדיקת שכנים');
+    return;
+  }
+
+  const schedule = deps.scheduleFn ?? setTimeout;
+
+  const handle = schedule(() => {
+    activeHandles.delete(fingerprint);
+
+    const users = deps.getUsersInCitiesFn
+      ? deps.getUsersInCitiesFn(alert.cities)
+      : getUsersInAlertCities(db, alert.cities);
+
+    if (users.length === 0) return;
+
+    const fpShort = fingerprint.slice(0, 8);
+    const msgText = '🏠 <b>בדיקת שכנים</b>\n\n' + text;
+
+    const sendFn = deps.sendFn ?? ((chatId: number, msgTxt: string, keyboard: object) =>
+      bot.api.sendMessage(chatId, msgTxt, {
+        parse_mode: 'HTML' as const,
+        reply_markup: keyboard as any,
+      })
+    );
+
+    for (const user of users) {
+      const chatId = user.chat_id;
+      const keyboard = {
+        inline_keyboard: [[
+          { text: '✅ בדקתי', callback_data: `nc:checked:${chatId}:${fpShort}` },
+          { text: '😔 לא יכולתי', callback_data: `nc:unable:${chatId}:${fpShort}` },
+          { text: '🔇 דלג', callback_data: `nc:dismissed:${chatId}:${fpShort}` },
+        ]],
+      };
+
+      // Insert prompt row synchronously before fire-and-forget send (INSERT OR IGNORE — idempotent).
+      // Row must exist before the message arrives so the callback handler can look it up.
+      insertPrompt(db, chatId, fingerprint, undefined);
+
+      sendFn(chatId, msgText, keyboard)
+        .then((msg) => updatePromptMessageId(db, chatId, fingerprint, msg.message_id))
+        .catch((err) => log('warn', 'NeighborCheck', `שגיאה בשליחה ל-${chatId}: ${err}`));
+    }
+
+    log('info', 'NeighborCheck', `בדיקת שכנים לאחר ${delayMinutes} דק׳ — ${users.length} משתמשים (fp=${fpShort})`);
+  }, delayMs);
+
+  activeHandles.set(fingerprint, handle);
+}
+
+export function cancelAll(): void {
+  for (const [fp, handle] of activeHandles.entries()) {
+    clearTimeout(handle);
+    log('info', 'NeighborCheck', `ביטול טיימר שכנים עבור ${fp}`);
+  }
+  activeHandles.clear();
+}

--- a/src/services/neighborCheckService.ts
+++ b/src/services/neighborCheckService.ts
@@ -75,42 +75,46 @@ export function scheduleNeighborCheck(
   const handle = schedule(() => {
     activeHandles.delete(fingerprint);
 
-    const users = deps.getUsersInCitiesFn
-      ? deps.getUsersInCitiesFn(alert.cities)
-      : getUsersInAlertCities(db, alert.cities);
+    try {
+      const users = deps.getUsersInCitiesFn
+        ? deps.getUsersInCitiesFn(alert.cities)
+        : getUsersInAlertCities(db, alert.cities);
 
-    if (users.length === 0) return;
+      if (users.length === 0) return;
 
-    const fpShort = fingerprint.slice(0, 8);
-    const msgText = '🏠 <b>בדיקת שכנים</b>\n\n' + text;
+      const fpShort = fingerprint.slice(0, 8);
+      const msgText = '🏠 <b>בדיקת שכנים</b>\n\n' + text;
 
-    const sendFn = deps.sendFn ?? ((chatId: number, msgTxt: string, keyboard: object) =>
-      bot.api.sendMessage(chatId, msgTxt, {
-        parse_mode: 'HTML' as const,
-        reply_markup: keyboard as any,
-      })
-    );
+      const sendFn = deps.sendFn ?? ((chatId: number, msgTxt: string, keyboard: object) =>
+        bot.api.sendMessage(chatId, msgTxt, {
+          parse_mode: 'HTML' as const,
+          reply_markup: keyboard as any,
+        })
+      );
 
-    for (const user of users) {
-      const chatId = user.chat_id;
-      const keyboard = {
-        inline_keyboard: [[
-          { text: '✅ בדקתי', callback_data: `nc:checked:${chatId}:${fpShort}` },
-          { text: '😔 לא יכולתי', callback_data: `nc:unable:${chatId}:${fpShort}` },
-          { text: '🔇 דלג', callback_data: `nc:dismissed:${chatId}:${fpShort}` },
-        ]],
-      };
+      for (const user of users) {
+        const chatId = user.chat_id;
+        const keyboard = {
+          inline_keyboard: [[
+            { text: '✅ בדקתי', callback_data: `nc:checked:${chatId}:${fpShort}` },
+            { text: '😔 לא יכולתי', callback_data: `nc:unable:${chatId}:${fpShort}` },
+            { text: '🔇 דלג', callback_data: `nc:dismissed:${chatId}:${fpShort}` },
+          ]],
+        };
 
-      // Insert prompt row synchronously before fire-and-forget send (INSERT OR IGNORE — idempotent).
-      // Row must exist before the message arrives so the callback handler can look it up.
-      insertPrompt(db, chatId, fingerprint, undefined);
+        // Insert prompt row synchronously before fire-and-forget send (INSERT OR IGNORE — idempotent).
+        // Row must exist before the message arrives so the callback handler can look it up.
+        insertPrompt(db, chatId, fingerprint, undefined);
 
-      sendFn(chatId, msgText, keyboard)
-        .then((msg) => updatePromptMessageId(db, chatId, fingerprint, msg.message_id))
-        .catch((err) => log('warn', 'NeighborCheck', `שגיאה בשליחה ל-${chatId}: ${err}`));
+        sendFn(chatId, msgText, keyboard)
+          .then((msg) => updatePromptMessageId(db, chatId, fingerprint, msg.message_id))
+          .catch((err) => log('warn', 'NeighborCheck', `שגיאה בשליחה ל-${chatId}: ${err}`));
+      }
+
+      log('info', 'NeighborCheck', `בדיקת שכנים לאחר ${delayMinutes} דק׳ — ${users.length} משתמשים (fp=${fpShort})`);
+    } catch (err) {
+      log('error', 'NeighborCheck', `שגיאה בטיימר שכנים (fp=${fingerprint}): ${err}`);
     }
-
-    log('info', 'NeighborCheck', `בדיקת שכנים לאחר ${delayMinutes} דק׳ — ${users.length} משתמשים (fp=${fpShort})`);
   }, delayMs);
 
   activeHandles.set(fingerprint, handle);

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -30,6 +30,8 @@ export interface ShutdownHandles {
   tgListenerEnabled: boolean;
   disconnectTelegramListener: () => Promise<void>;
   closeDb: () => void;
+  /** Optional — cancel pending alertWindowTracker close timers on shutdown. */
+  clearAlertWindowTimers?: () => void;
 }
 
 export interface ShutdownOptions {
@@ -84,6 +86,7 @@ export function createShutdown(
     // ── Step 1: stop background timers
     clearInterval(handles.contactCleanupInterval);
     clearInterval(handles.safetyPruneInterval);
+    handles.clearAlertWindowTimers?.();
 
     // ── Step 2: cancel pending all-clear timers (so they don't fire mid-shutdown)
     handles.allClearTracker.clearAll();

--- a/src/shutdown.ts
+++ b/src/shutdown.ts
@@ -32,6 +32,8 @@ export interface ShutdownHandles {
   closeDb: () => void;
   /** Optional — cancel pending alertWindowTracker close timers on shutdown. */
   clearAlertWindowTimers?: () => void;
+  /** Optional — cancel pending neighbor check timers on shutdown. */
+  cancelNeighborCheckTimers?: () => void;
 }
 
 export interface ShutdownOptions {
@@ -87,6 +89,7 @@ export function createShutdown(
     clearInterval(handles.contactCleanupInterval);
     clearInterval(handles.safetyPruneInterval);
     handles.clearAlertWindowTimers?.();
+    handles.cancelNeighborCheckTimers?.();
 
     // ── Step 2: cancel pending all-clear timers (so they don't fire mid-shutdown)
     handles.allClearTracker.clearAll();


### PR DESCRIPTION
## Summary

Implements all 7 issues in the [v0.5.3 milestone](https://github.com/yonatan2021/pikud-haoref-bot/milestone/11):

- **#228** — `skill_catalog` table + repository (foundation for skills)
- **#219** — Community Pulse: anonymous post-alert survey (ok/scared/helping) sent via DM after alert window closes
- **#220** — Shelter Stories: opt-in 200-char shelter submissions → dashboard moderation queue → published to Telegram topic
- **#221** — Skills Sharing: user skill declarations + `/need [skill]` matching with visibility controls (public/contacts/private)
- **#222** — Neighbor Check: proactive 7-min post-alert DM to check on elderly neighbors, with callback tracking
- **#227** — Community Config Dashboard: hot-config UI page for all 13 new settings across 4 subsections
- **#231** — Group Escape Hatch: `/group delete <name>` (nonce-confirmed) + `/group transfer <name> <code>` with audit trail

## What changed

### Schema (inline in `initSchema()`)
- 7 new tables: `community_pulses`, `community_pulse_responses`, `shelter_stories`, `skill_catalog`, `user_skills`, `neighbor_check_prompts`, `neighbor_check_events`, `group_audit`
- 1 new column: `users.neighbor_check_enabled`

### Bot commands
- `/share` — submit shelter story
- `/need [skill]` — find helpers by skill
- `setMyCommands` updated: 15 → 17

### Dashboard
- New **קהילה** page with 4 config subsections
- Stories moderation route (`GET/POST /api/stories`)
- Skills catalog management (`GET/POST/PATCH/DELETE /api/skills-catalog`)

### Config keys added (all 3 locations: configResolver + ALLOWED_KEYS + VALIDATORS)
`pulse_enabled`, `pulse_cooldown_hours`, `pulse_aggregate_threshold`, `pulse_prompt_text`, `topic_id_stories`, `stories_enabled`, `stories_rate_limit_minutes`, `stories_max_length`, `skills_public_enabled`, `skills_need_radius_zones`, `neighbor_check_enabled_default`, `neighbor_check_delay_minutes`, `neighbor_check_text`

## Test plan

- [ ] `npm test` — 1397 tests, 0 failures
- [ ] `npx tsc --noEmit` — clean
- [ ] `DB_PATH=:memory: npx tsx --test 'src/__tests__/dashboard/**/*.test.ts'` — all pass
- [ ] Send test alert → verify pulse DM arrives ~2 min later
- [ ] `/share` → submit story → approve in dashboard → verify published to topic
- [ ] `/need first_aid` → verify results respect visibility
- [ ] Verify neighbor check DM arrives after configured delay

Closes #219, #220, #221, #222, #227, #228, #231