### PR TITLE
feat(dashboard): UI/UX accessibility & visual overhaul (Phases 1–3)

### DIFF
--- a/dashboard-ui/package-lock.json
+++ b/dashboard-ui/package-lock.json
@@ -17,6 +17,7 @@
         "qrcode": "^1.5.4",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-focus-lock": "^2.13.7",
         "react-hot-toast": "^2.6.0",
         "react-router-dom": "^7.13.2",
         "recharts": "^3.8.1"
@@ -230,6 +231,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2997,6 +3007,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/focus-lock": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-1.3.6.tgz",
+      "integrity": "sha512-Ik/6OCk9RQQ0T5Xw+hKNLWrjSMtv51dD4GRmJjbD5a58TIEpI5a5iXagKVl3Z5UuyslMCA8Xwnu76jQob62Yhg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -3259,7 +3281,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -3630,6 +3651,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3726,6 +3759,15 @@
       "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3893,6 +3935,23 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3929,6 +3988,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-clientside-effect": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.8.tgz",
+      "integrity": "sha512-ma2FePH0z3px2+WOu6h+YycZcEvFmmxIlAb62cF52bG86eMySciO/EQZeQMXd07kPCYB0a1dWDT5J+KE9mCDUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
@@ -3939,6 +4010,29 @@
       },
       "peerDependencies": {
         "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-focus-lock": {
+      "version": "2.13.7",
+      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-2.13.7.tgz",
+      "integrity": "sha512-20lpZHEQrXPb+pp1tzd4ULL6DyO5D2KnR0G69tTDdydrmNhU7pdFmbQUYVyHUgp+xN29IuFR0PVuhOmvaZL9Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "focus-lock": "^1.3.6",
+        "prop-types": "^15.6.2",
+        "react-clientside-effect": "^1.2.7",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-hot-toast": {

--- a/dashboard-ui/package.json
+++ b/dashboard-ui/package.json
@@ -19,6 +19,7 @@
     "qrcode": "^1.5.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-focus-lock": "^2.13.7",
     "react-hot-toast": "^2.6.0",
     "react-router-dom": "^7.13.2",
     "recharts": "^3.8.1"

--- a/dashboard-ui/src/components/AlertCategoryStats.tsx
+++ b/dashboard-ui/src/components/AlertCategoryStats.tsx
@@ -45,7 +45,7 @@ export function AlertCategoryStats({ data, total }: AlertCategoryStatsProps) {
                   </span>
                 </div>
               </div>
-              <div className="h-1.5 rounded-full bg-white/5 overflow-hidden">
+              <div className="h-2 rounded-full bg-white/5 overflow-hidden">
                 <motion.div
                   className="h-full rounded-full"
                   style={{ backgroundColor: row.color }}

--- a/dashboard-ui/src/components/AlertCategoryStats.tsx
+++ b/dashboard-ui/src/components/AlertCategoryStats.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion';
+import { BarChart2 } from 'lucide-react';
 import { EmptyState } from './EmptyState';
 import { GlassCard } from './ui/GlassCard';
 
@@ -24,7 +25,7 @@ export function AlertCategoryStats({ data, total }: AlertCategoryStatsProps) {
       </div>
 
       {data.length === 0 ? (
-        <EmptyState icon="📊" message="אין נתונים" />
+        <EmptyState icon={<BarChart2 size={36} />} message="אין נתונים" />
       ) : (
         <div className="space-y-3 max-h-80 overflow-y-auto">
           {data.map((row, index) => (

--- a/dashboard-ui/src/components/ConfirmModal.tsx
+++ b/dashboard-ui/src/components/ConfirmModal.tsx
@@ -1,3 +1,7 @@
+import { useId } from 'react';
+import FocusLock from 'react-focus-lock';
+import { motion, AnimatePresence } from 'framer-motion';
+
 interface ConfirmModalProps {
   open: boolean;
   title: string;
@@ -15,31 +19,55 @@ export function ConfirmModal({
   onCancel,
   danger = false,
 }: ConfirmModalProps) {
-  if (!open) return null;
+  const titleId = useId();
+  const descId = useId();
+
   return (
-    <div className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4">
-      <div className="bg-surface border border-border rounded-xl p-6 max-w-sm w-full">
-        <h3 className="font-bold text-lg text-text-primary">{title}</h3>
-        <p className="text-text-secondary text-sm mt-2">{description}</p>
-        <div className="flex gap-3 mt-6">
-          <button
-            onClick={onConfirm}
-            className={`flex-1 py-2 rounded-lg text-sm font-medium ${
-              danger
-                ? 'bg-red-600 hover:bg-red-700 text-white'
-                : 'bg-amber hover:bg-amber-dark text-black'
-            }`}
-          >
-            אישור
-          </button>
-          <button
-            onClick={onCancel}
-            className="flex-1 border border-border py-2 rounded-lg text-sm text-text-secondary hover:bg-white/5"
-          >
-            ביטול
-          </button>
-        </div>
-      </div>
-    </div>
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 bg-black/60 z-50 flex items-center justify-center p-4"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          <FocusLock returnFocus>
+            <motion.div
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={titleId}
+              aria-describedby={descId}
+              className="bg-surface border border-border rounded-xl p-6 max-w-sm w-full"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              exit={{ opacity: 0, scale: 0.95 }}
+              transition={{ duration: 0.15 }}
+            >
+              <h3 id={titleId} className="font-bold text-lg text-text-primary">{title}</h3>
+              <p id={descId} className="text-text-secondary text-sm mt-2">{description}</p>
+              <div className="flex gap-3 mt-6">
+                <button
+                  onClick={onConfirm}
+                  className={`flex-1 py-2 rounded-lg text-sm font-medium ${
+                    danger
+                      ? 'bg-red-600 hover:bg-red-700 text-white'
+                      : 'bg-amber hover:bg-amber-dark text-black'
+                  }`}
+                >
+                  אישור
+                </button>
+                <button
+                  onClick={onCancel}
+                  className="flex-1 border border-border py-2 rounded-lg text-sm text-text-secondary hover:bg-white/5"
+                >
+                  ביטול
+                </button>
+              </div>
+            </motion.div>
+          </FocusLock>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }

--- a/dashboard-ui/src/components/EmptyState.tsx
+++ b/dashboard-ui/src/components/EmptyState.tsx
@@ -1,12 +1,17 @@
+import type { ReactNode } from 'react';
+import { Inbox } from 'lucide-react';
+
 interface EmptyStateProps {
-  icon: string;
+  icon?: ReactNode;
   message: string;
 }
 
 export function EmptyState({ icon, message }: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center py-16 text-text-muted">
-      <span className="text-4xl mb-3">{icon}</span>
+      <span className="mb-3 opacity-60">
+        {icon ?? <Inbox size={36} />}
+      </span>
       <p className="text-sm">{message}</p>
     </div>
   );

--- a/dashboard-ui/src/components/Pagination.tsx
+++ b/dashboard-ui/src/components/Pagination.tsx
@@ -1,0 +1,32 @@
+interface PaginationProps {
+  page: number;
+  onPrev: () => void;
+  onNext: () => void;
+  hasNext: boolean;
+  total?: number;
+}
+
+export function Pagination({ page, onPrev, onNext, hasNext, total }: PaginationProps) {
+  return (
+    <div className="flex items-center justify-between px-4 py-3 border-t border-[var(--color-border)]">
+      <button
+        disabled={page === 0}
+        onClick={onPrev}
+        className="text-text-muted text-xs hover:text-text-primary disabled:opacity-40 cursor-pointer disabled:cursor-default"
+      >
+        הקודם →
+      </button>
+      <span className="text-text-muted text-xs">
+        עמוד {page + 1}
+        {total !== undefined && ` · ${total} סה״כ`}
+      </span>
+      <button
+        disabled={!hasNext}
+        onClick={onNext}
+        className="text-text-muted text-xs hover:text-text-primary disabled:opacity-40 cursor-pointer disabled:cursor-default"
+      >
+        ← הבא
+      </button>
+    </div>
+  );
+}

--- a/dashboard-ui/src/components/Skeleton.tsx
+++ b/dashboard-ui/src/components/Skeleton.tsx
@@ -1,3 +1,14 @@
-export function Skeleton({ className = '' }: { className?: string }) {
-  return <div className={`animate-pulse bg-surface rounded-lg ${className}`} />;
+interface SkeletonProps {
+  className?: string;
+  height?: string | number;
+  width?: string | number;
+}
+
+export function Skeleton({ className = '', height, width }: SkeletonProps) {
+  return (
+    <div
+      className={`skeleton-shimmer rounded-lg ${className}`}
+      style={{ height, width }}
+    />
+  );
 }

--- a/dashboard-ui/src/components/ui/GlassCard.tsx
+++ b/dashboard-ui/src/components/ui/GlassCard.tsx
@@ -49,7 +49,7 @@ export function GlassCard({
   const whileHoverProp =
     hoverable && !reducedMotion
       ? {
-          scale: 1.01,
+          scale: 1.015,
           borderColor: glowBorderColor[glow],
           backgroundColor: glowBgColor[glow],
         }

--- a/dashboard-ui/src/index.css
+++ b/dashboard-ui/src/index.css
@@ -55,3 +55,19 @@ body::before {
   pointer-events: none;
   z-index: -1;
 }
+
+@keyframes shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+
+.skeleton-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--color-surface) 25%,
+    rgba(255, 255, 255, 0.06) 50%,
+    var(--color-surface) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.6s ease-in-out infinite;
+}

--- a/dashboard-ui/src/layout/CommandPalette.tsx
+++ b/dashboard-ui/src/layout/CommandPalette.tsx
@@ -1,14 +1,24 @@
 import { Command } from 'cmdk';
 import { useNavigate } from 'react-router-dom';
 import { useEffect, useState } from 'react';
+import {
+  LayoutDashboard, Bell, Users, Radio, Settings, Globe,
+} from 'lucide-react';
+import type { LucideIcon } from 'lucide-react';
 
-const PAGES = [
-  { label: 'לוח בקרה', to: '/overview', icon: '📊' },
-  { label: 'התראות', to: '/alerts', icon: '🔔' },
-  { label: 'מנויים', to: '/subscribers', icon: '👥' },
-  { label: 'מרכז פיקוד', to: '/operations', icon: '📡' },
-  { label: 'הגדרות', to: '/settings', icon: '⚙️' },
-  { label: 'אתר נחיתה', to: '/landing', icon: '🌐' },
+interface Page {
+  label: string;
+  to: string;
+  icon: LucideIcon;
+}
+
+const PAGES: Page[] = [
+  { label: 'לוח בקרה', to: '/overview', icon: LayoutDashboard },
+  { label: 'התראות', to: '/alerts', icon: Bell },
+  { label: 'מנויים', to: '/subscribers', icon: Users },
+  { label: 'מרכז פיקוד', to: '/operations', icon: Radio },
+  { label: 'הגדרות', to: '/settings', icon: Settings },
+  { label: 'אתר נחיתה', to: '/landing', icon: Globe },
 ];
 
 export function CommandPalette() {
@@ -46,16 +56,19 @@ export function CommandPalette() {
             <Command.Empty className="text-center text-text-muted text-sm py-4">
               לא נמצאו תוצאות
             </Command.Empty>
-            {PAGES.map(p => (
-              <Command.Item
-                key={p.to}
-                onSelect={() => { navigate(p.to); setOpen(false); }}
-                className="flex items-center gap-3 px-3 py-2.5 rounded-lg cursor-pointer text-sm text-text-secondary data-[selected=true]:bg-amber/10 data-[selected=true]:text-amber"
-              >
-                <span>{p.icon}</span>
-                <span>{p.label}</span>
-              </Command.Item>
-            ))}
+            {PAGES.map(p => {
+              const Icon = p.icon;
+              return (
+                <Command.Item
+                  key={p.to}
+                  onSelect={() => { navigate(p.to); setOpen(false); }}
+                  className="flex items-center gap-3 px-3 py-2.5 rounded-lg cursor-pointer text-sm text-text-secondary data-[selected=true]:bg-amber/10 data-[selected=true]:text-amber"
+                >
+                  <Icon size={16} className="flex-shrink-0" />
+                  <span>{p.label}</span>
+                </Command.Item>
+              );
+            })}
           </Command.List>
         </Command>
         <p className="text-center text-text-muted text-xs py-2 border-t border-border">⌘K לסגירה</p>

--- a/dashboard-ui/src/layout/Root.tsx
+++ b/dashboard-ui/src/layout/Root.tsx
@@ -15,7 +15,9 @@ export function Root() {
         <StatusStrip onUptime={setUptime} />
         <RestartBanner />
         <div className="flex-1 overflow-y-auto p-6">
-          <Outlet />
+          <div className="max-w-[1600px] mx-auto">
+            <Outlet />
+          </div>
         </div>
       </main>
     </div>

--- a/dashboard-ui/src/layout/Sidebar.tsx
+++ b/dashboard-ui/src/layout/Sidebar.tsx
@@ -182,7 +182,7 @@ function CollapsibleGroup({ group, collapsed }: { group: NavGroup; collapsed: bo
             className="overflow-hidden"
           >
             {group.items.map(item => (
-              <div key={item.to} className={collapsed ? '' : 'pr-2'}>
+              <div key={item.to} className={collapsed ? '' : 'ps-2'}>
                 <NavItemLink item={item} collapsed={collapsed} />
               </div>
             ))}
@@ -223,7 +223,7 @@ export function Sidebar({ uptime }: { uptime: number }) {
           onClick={() => setCollapsed(c => !c)}
           aria-label={collapsed ? 'הרחב סרגל צד' : 'כווץ סרגל צד'}
           aria-expanded={!collapsed}
-          className="mr-auto text-text-muted hover:text-text-secondary flex-shrink-0"
+          className="me-auto text-text-muted hover:text-text-secondary flex-shrink-0"
         >
           <ChevronLeft
             size={16}

--- a/dashboard-ui/src/layout/StatusStrip.tsx
+++ b/dashboard-ui/src/layout/StatusStrip.tsx
@@ -31,7 +31,12 @@ export function StatusStrip({ onUptime }: { onUptime: (u: number) => void }) {
 
   if (isLoading) {
     return (
-      <div className="bg-[var(--color-glass)] backdrop-blur-sm border-b border-border px-4 py-1.5 text-xs text-text-muted flex items-center gap-1.5">
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label="מצב חיבור"
+        className="bg-[var(--color-glass)] backdrop-blur-sm border-b border-border px-4 py-1.5 text-xs text-text-muted flex items-center gap-1.5"
+      >
         <Loader2 size={12} className="animate-spin" />
         מתחבר...
       </div>
@@ -40,7 +45,13 @@ export function StatusStrip({ onUptime }: { onUptime: (u: number) => void }) {
 
   if (isError) {
     return (
-      <div className="bg-[var(--color-glass)] backdrop-blur-sm border-b border-red-700/50 px-4 py-1 text-xs text-red-300 flex items-center gap-1.5">
+      <div
+        role="status"
+        aria-live="polite"
+        aria-label="אין חיבור לשרת"
+        className="bg-[var(--color-glass)] backdrop-blur-sm border-b border-red-700/50 border-t-2 px-4 py-1 text-xs text-red-300 flex items-center gap-1.5"
+        style={{ borderTopColor: 'rgba(239,68,68,0.5)' }}
+      >
         <WifiOff size={12} />
         אין חיבור לשרת
       </div>
@@ -49,8 +60,11 @@ export function StatusStrip({ onUptime }: { onUptime: (u: number) => void }) {
 
   return (
     <div
+      role="status"
+      aria-live="polite"
+      aria-label="מצב הבוט"
       className="bg-[var(--color-glass)] backdrop-blur-sm border-b border-border border-t-2 px-4 py-1.5 flex items-center gap-6 text-xs text-text-secondary"
-      style={{ borderTopColor: 'color-mix(in srgb, var(--color-amber) 30%, transparent)' }}
+      style={{ borderTopColor: 'color-mix(in srgb, var(--color-green) 40%, transparent)' }}
     >
       <span className="flex items-center gap-1.5">
         <LiveDot color="green" size="sm" />

--- a/dashboard-ui/src/layout/StatusStrip.tsx
+++ b/dashboard-ui/src/layout/StatusStrip.tsx
@@ -80,7 +80,7 @@ export function StatusStrip({ onUptime }: { onUptime: (u: number) => void }) {
       </span>
       <span className="flex items-center gap-1">
         התראות היום:
-        <AnimatedCounter value={data?.alertsToday ?? 0} className="text-amber font-bold mr-1" />
+        <AnimatedCounter value={data?.alertsToday ?? 0} className="text-amber font-bold ms-1" />
       </span>
     </div>
   );

--- a/dashboard-ui/src/pages/Alerts.tsx
+++ b/dashboard-ui/src/pages/Alerts.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useSearchParams } from 'react-router-dom';
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Bell } from 'lucide-react';
+import { Bell, BellOff } from 'lucide-react';
 import { api } from '../api/client';
 import { EmptyState } from '../components/EmptyState';
 import { Skeleton } from '../components/Skeleton';
@@ -250,7 +250,7 @@ export function Alerts() {
               </div>
             ) : alerts.length === 0 ? (
               <EmptyState
-                icon="🔔"
+                icon={<BellOff size={36} />}
                 message={isFiltered ? 'אין תוצאות עבור הסינון הנוכחי' : 'אין התראות לתקופה זו'}
               />
             ) : (

--- a/dashboard-ui/src/pages/Alerts.tsx
+++ b/dashboard-ui/src/pages/Alerts.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '../components/Skeleton';
 import { GlassCard } from '../components/ui/GlassCard';
 import { PageTransition } from '../components/ui/PageTransition';
 import { AlertCategoryStats } from '../components/AlertCategoryStats';
+import { Pagination } from '../components/Pagination';
 
 interface Alert {
   id: number;
@@ -332,24 +333,12 @@ export function Alerts() {
                   </AnimatePresence>
                 </div>
 
-                {/* Pagination */}
-                <div className="flex items-center justify-between px-4 py-3 border-t border-[var(--color-border)]">
-                  <button
-                    disabled={page === 0}
-                    onClick={() => setSearchParams(prev => { const n = new URLSearchParams(prev); n.set('page', String(page - 1)); return n; })}
-                    className="text-text-muted text-xs hover:text-text-primary disabled:opacity-40"
-                  >
-                    הקודם →
-                  </button>
-                  <span className="text-text-muted text-xs">עמוד {page + 1}</span>
-                  <button
-                    disabled={alerts.length < PAGE_SIZE}
-                    onClick={() => setSearchParams(prev => { const n = new URLSearchParams(prev); n.set('page', String(page + 1)); return n; })}
-                    className="text-text-muted text-xs hover:text-text-primary disabled:opacity-40"
-                  >
-                    ← הבא
-                  </button>
-                </div>
+                <Pagination
+                  page={page}
+                  hasNext={alerts.length >= PAGE_SIZE}
+                  onPrev={() => setSearchParams(prev => { const n = new URLSearchParams(prev); n.set('page', String(page - 1)); return n; })}
+                  onNext={() => setSearchParams(prev => { const n = new URLSearchParams(prev); n.set('page', String(page + 1)); return n; })}
+                />
               </>
             )}
           </GlassCard>

--- a/dashboard-ui/src/pages/Groups.tsx
+++ b/dashboard-ui/src/pages/Groups.tsx
@@ -105,19 +105,19 @@ function Groups(): React.ReactElement {
         {/* KPI cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
           <GlassCard className="p-4">
-            <div className="text-sm text-gray-400">סה״כ קבוצות</div>
+            <div className="text-sm text-text-secondary">סה״כ קבוצות</div>
             <div className="text-3xl font-bold mt-1">{stats?.total ?? '—'}</div>
           </GlassCard>
           <GlassCard className="p-4">
-            <div className="text-sm text-gray-400">חברים בממוצע</div>
+            <div className="text-sm text-text-secondary">חברים בממוצע</div>
             <div className="text-3xl font-bold mt-1">{stats?.avgMembers ?? '—'}</div>
           </GlassCard>
           <GlassCard className="p-4">
-            <div className="text-sm text-gray-400">קבוצה עם הכי הרבה חברים</div>
+            <div className="text-sm text-text-secondary">קבוצה עם הכי הרבה חברים</div>
             <div className="text-xl font-semibold mt-1 truncate">
               {stats?.top10[0]?.name ?? '—'}
               {stats?.top10[0] !== undefined && (
-                <span className="text-sm text-gray-400 mr-2">
+                <span className="text-sm text-text-muted mr-2">
                   ({stats.top10[0].memberCount})
                 </span>
               )}
@@ -138,7 +138,7 @@ function Groups(): React.ReactElement {
             <div className="overflow-x-auto">
               <table className="w-full">
                 <thead>
-                  <tr className="border-b border-white/10 text-sm text-gray-400">
+                  <tr className="border-b border-white/10 text-sm text-text-secondary">
                     <th className="p-2 text-right">שם</th>
                     <th className="p-2 text-right">בעלים</th>
                     <th className="p-2 text-right">חברים</th>
@@ -156,11 +156,11 @@ function Groups(): React.ReactElement {
                     >
                       <td className="p-2 font-medium">{g.name}</td>
                       <td className="p-2 text-sm">
-                        {g.ownerDisplayName ?? <span className="text-gray-500">—</span>}
+                        {g.ownerDisplayName ?? <span className="text-text-muted">—</span>}
                       </td>
                       <td className="p-2">{g.memberCount}</td>
                       <td className="p-2 font-mono text-xs">{g.inviteCode}</td>
-                      <td className="p-2 text-sm text-gray-400">{relDate(g.createdAt)}</td>
+                      <td className="p-2 text-sm text-text-muted">{relDate(g.createdAt)}</td>
                       <td className="p-2 text-left">
                         <button
                           aria-label={`מחק קבוצה ${g.name}`}
@@ -197,14 +197,14 @@ function Groups(): React.ReactElement {
                 <h2 className="text-xl font-bold">{detail.group.name}</h2>
                 <button
                   aria-label="סגור"
-                  className="text-gray-400 hover:text-white"
+                  className="text-text-secondary hover:text-text-primary"
                   onClick={() => setDrillId(null)}
                 >
                   <X size={20} />
                 </button>
               </div>
 
-              <div className="text-sm text-gray-400 space-y-1">
+              <div className="text-sm text-text-secondary space-y-1">
                 <div>
                   קוד הזמנה: <span className="font-mono text-white">{detail.group.inviteCode}</span>
                 </div>
@@ -213,7 +213,7 @@ function Groups(): React.ReactElement {
               </div>
 
               <div className="border-t border-white/10 pt-4">
-                <h3 className="text-sm font-semibold mb-2 text-gray-300">חברים</h3>
+                <h3 className="text-sm font-semibold mb-2 text-text-primary">חברים</h3>
                 <ul className="space-y-2">
                   {detail.members.map((m) => (
                     <li key={m.userId} className="flex items-center justify-between p-2 rounded bg-white/5">
@@ -223,10 +223,10 @@ function Groups(): React.ReactElement {
                           {m.role === 'owner' && <span className="mr-2 text-xs text-blue-400">בעלים</span>}
                         </div>
                         {m.homeCity !== null && m.homeCity !== '' && (
-                          <div className="text-xs text-gray-400">{m.homeCity}</div>
+                          <div className="text-xs text-text-muted">{m.homeCity}</div>
                         )}
                       </div>
-                      <div className="text-xs text-gray-500">
+                      <div className="text-xs text-text-muted">
                         {m.notifyGroup ? '🔔' : '🔕'}
                       </div>
                     </li>

--- a/dashboard-ui/src/pages/Groups.tsx
+++ b/dashboard-ui/src/pages/Groups.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { UsersRound, Trash2, X } from 'lucide-react';
+import { UsersRound, Trash2, X, Users } from 'lucide-react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { motion, AnimatePresence } from 'framer-motion';
 import toast from 'react-hot-toast';
@@ -117,7 +117,7 @@ function Groups(): React.ReactElement {
             <div className="text-xl font-semibold mt-1 truncate">
               {stats?.top10[0]?.name ?? '—'}
               {stats?.top10[0] !== undefined && (
-                <span className="text-sm text-text-muted mr-2">
+                <span className="text-sm text-text-muted ms-2">
                   ({stats.top10[0].memberCount})
                 </span>
               )}
@@ -131,7 +131,7 @@ function Groups(): React.ReactElement {
             <Skeleton className="h-64" />
           ) : !list?.groups || list.groups.length === 0 ? (
             <EmptyState
-              icon="👥"
+              icon={<Users size={36} />}
               message="אין קבוצות עדיין. קבוצות נוצרות מהבוט עם /group create."
             />
           ) : (
@@ -220,7 +220,7 @@ function Groups(): React.ReactElement {
                       <div>
                         <div className="font-medium">
                           {m.displayName ?? `משתמש #${m.userId}`}
-                          {m.role === 'owner' && <span className="mr-2 text-xs text-blue-400">בעלים</span>}
+                          {m.role === 'owner' && <span className="ms-2 text-xs text-blue-400">בעלים</span>}
                         </div>
                         {m.homeCity !== null && m.homeCity !== '' && (
                           <div className="text-xs text-text-muted">{m.homeCity}</div>

--- a/dashboard-ui/src/pages/Login.tsx
+++ b/dashboard-ui/src/pages/Login.tsx
@@ -1,6 +1,9 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { ShieldCheck } from 'lucide-react';
 import toast from 'react-hot-toast';
+import { GlassCard } from '../components/ui/GlassCard';
+import { PageTransition } from '../components/ui/PageTransition';
 
 export function Login() {
   const [password, setPassword] = useState('');
@@ -30,30 +33,39 @@ export function Login() {
   };
 
   return (
-    <div className="min-h-screen bg-base flex items-center justify-center">
-      <div className="bg-surface border border-border rounded-2xl p-8 w-full max-w-sm">
-        <div className="text-center mb-8">
-          <div className="text-5xl mb-3">🔴</div>
-          <h1 className="text-xl font-bold text-text-primary">פיקוד העורף — ניהול</h1>
-          <p className="text-text-secondary text-sm mt-1">כניסת מנהל מערכת</p>
-        </div>
-        <form onSubmit={submit} className="space-y-4">
-          <input
-            type="password"
-            value={password}
-            onChange={e => setPassword(e.target.value)}
-            placeholder="סיסמה"
-            className="w-full bg-base border border-border rounded-lg px-4 py-3 text-sm outline-none focus:border-amber transition-colors"
-          />
-          <button
-            type="submit"
-            disabled={loading || !password}
-            className="w-full bg-amber text-black font-bold py-3 rounded-lg hover:bg-amber-dark disabled:opacity-40 transition-colors"
-          >
-            {loading ? 'מתחבר...' : 'כניסה'}
-          </button>
-        </form>
+    <PageTransition>
+      <div className="min-h-dvh bg-base flex items-center justify-center p-4">
+        <GlassCard className="w-full max-w-sm p-8">
+          <div className="text-center mb-8">
+            <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-amber/10 border border-amber/30 mb-4">
+              <ShieldCheck size={32} className="text-amber" />
+            </div>
+            <h1 className="text-xl font-bold text-text-primary">פיקוד העורף — ניהול</h1>
+            <p className="text-text-secondary text-sm mt-1">כניסת מנהל מערכת</p>
+          </div>
+          <form onSubmit={submit} className="space-y-4">
+            <div>
+              <label htmlFor="password" className="sr-only">סיסמה</label>
+              <input
+                id="password"
+                type="password"
+                value={password}
+                onChange={e => setPassword(e.target.value)}
+                placeholder="סיסמה"
+                autoComplete="current-password"
+                className="w-full bg-[var(--color-base)] border border-border rounded-lg px-4 py-3 text-sm outline-none focus:border-amber transition-colors"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={loading || !password}
+              className="w-full bg-amber text-black font-bold py-3 rounded-lg hover:bg-amber-dark disabled:opacity-40 transition-colors"
+            >
+              {loading ? 'מתחבר...' : 'כניסה'}
+            </button>
+          </form>
+        </GlassCard>
       </div>
-    </div>
+    </PageTransition>
   );
 }

--- a/dashboard-ui/src/pages/Operations.tsx
+++ b/dashboard-ui/src/pages/Operations.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Loader2, CheckCircle, Radio } from 'lucide-react';
+import { Loader2, CheckCircle, Radio, Inbox, MessageSquare } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { api } from '../api/client';
 import { ConfirmModal } from '../components/ConfirmModal';
@@ -311,7 +311,7 @@ export function Operations() {
             חלון כפילויות — התראה שנשלחה נשארת &quot;פתוחה&quot; לעדכונים. עדכון פיקוד העורף באותו סוג+ערים יעדכן את ההודעה ולא ישלח חדשה. ניקוי ידני מאפשר קבלת התראה מחדש.
           </p>
           {alertWindow.length === 0 ? (
-            <EmptyState icon="🪟" message="חלון ההתראות ריק" />
+            <EmptyState icon={<Inbox size={36} />} message="חלון ההתראות ריק" />
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full text-sm">
@@ -419,7 +419,7 @@ export function Operations() {
             חוויות שמשתמשים שיתפו מהמקלט — ממתינות לאישור לפני פרסום בערוץ
           </p>
           {pendingStories.length === 0 ? (
-            <EmptyState icon="🏠" message="אין הודעות ממתינות לסקירה" />
+            <EmptyState icon={<MessageSquare size={36} />} message="אין הודעות ממתינות לסקירה" />
           ) : (
             <div className="flex flex-col gap-3">
               {pendingStories.map((story) => (

--- a/dashboard-ui/src/pages/Overview.tsx
+++ b/dashboard-ui/src/pages/Overview.tsx
@@ -230,6 +230,8 @@ export function Overview() {
           </motion.div>
         )}
 
+        <hr className="border-t border-border" />
+
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
           {/* Live Alert Feed */}
           <GlassCard className="p-5">

--- a/dashboard-ui/src/pages/Overview.tsx
+++ b/dashboard-ui/src/pages/Overview.tsx
@@ -137,25 +137,25 @@ function HebrewYAxisTick({ x, y, payload }: { x?: number; y?: number; payload?: 
 export function Overview() {
   const reducedMotion = useReducedMotion();
 
-  const { data: stats, isLoading: statsLoading } = useQuery<OverviewStats>({
+  const { data: stats, isLoading: statsLoading, isError: statsError } = useQuery<OverviewStats>({
     queryKey: ['overview'],
     queryFn: () => api.get('/api/stats/overview'),
     refetchInterval: 30_000,
   });
 
-  const { data: liveAlerts = [] } = useQuery<Alert[]>({
+  const { data: liveAlerts, isLoading: liveAlertsLoading, isError: liveAlertsError } = useQuery<Alert[]>({
     queryKey: ['alerts-live'],
     queryFn: () => api.get('/api/stats/alerts?days=1&limit=10'),
     refetchInterval: 5_000,
   });
 
-  const { data: byCategory = [], isLoading: byCategoryLoading } = useQuery<CategoryDay[]>({
+  const { data: byCategory = [], isLoading: byCategoryLoading, isError: byCategoryError } = useQuery<CategoryDay[]>({
     queryKey: ['alerts-by-category'],
     queryFn: () => api.get('/api/stats/alerts/by-category'),
     refetchInterval: 60_000,
   });
 
-  const { data: topCities = [], isLoading: topCitiesLoading } = useQuery<TopCity[]>({
+  const { data: topCities = [], isLoading: topCitiesLoading, isError: topCitiesError } = useQuery<TopCity[]>({
     queryKey: ['top-cities'],
     queryFn: () => api.get('/api/stats/alerts/top-cities'),
     refetchInterval: 60_000,
@@ -192,6 +192,10 @@ export function Overview() {
         {statsLoading ? (
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
             {Array.from({ length: 4 }).map((_, i) => <Skeleton key={i} className="h-28" />)}
+          </div>
+        ) : statsError ? (
+          <div className="p-4 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-sm text-center">
+            שגיאה בטעינת נתוני KPI — <button onClick={() => window.location.reload()} className="underline">רענן</button>
           </div>
         ) : (
           <motion.div
@@ -233,7 +237,11 @@ export function Overview() {
               <Bell size={14} className="text-amber-400 flex-shrink-0" />
               <span>התראות היום (עדכון חי)</span>
             </h2>
-            {liveAlerts.length === 0 ? (
+            {liveAlertsLoading ? (
+              <Skeleton className="h-40" />
+            ) : liveAlertsError ? (
+              <div className="py-8 text-center text-red-300 text-sm">שגיאה בטעינת התראות</div>
+            ) : !liveAlerts?.length ? (
               <EmptyState icon="🔔" message="אין התראות היום" />
             ) : (
               <div className="space-y-2 max-h-72 overflow-y-auto">
@@ -282,6 +290,8 @@ export function Overview() {
             </h2>
             {topCitiesLoading ? (
               <Skeleton className="h-[220px]" />
+            ) : topCitiesError ? (
+              <div className="h-[220px] flex items-center justify-center text-red-300 text-sm">שגיאה בטעינת ערים</div>
             ) : topCities.length === 0 ? (
               <EmptyState icon="📍" message="אין נתונים" />
             ) : (
@@ -312,6 +322,8 @@ export function Overview() {
           </h2>
           {byCategoryLoading ? (
             <Skeleton className="h-[260px]" />
+          ) : byCategoryError ? (
+            <div className="h-[260px] flex items-center justify-center text-red-300 text-sm">שגיאה בטעינת גרף</div>
           ) : byCategory.length === 0 ? (
             <EmptyState icon="📊" message="אין נתונים לתקופה זו" />
           ) : (

--- a/dashboard-ui/src/pages/Overview.tsx
+++ b/dashboard-ui/src/pages/Overview.tsx
@@ -242,7 +242,7 @@ export function Overview() {
             ) : liveAlertsError ? (
               <div className="py-8 text-center text-red-300 text-sm">שגיאה בטעינת התראות</div>
             ) : !liveAlerts?.length ? (
-              <EmptyState icon="🔔" message="אין התראות היום" />
+              <EmptyState icon={<Bell size={36} />} message="אין התראות היום" />
             ) : (
               <div className="space-y-2 max-h-72 overflow-y-auto">
                 <AnimatePresence initial={false}>
@@ -293,7 +293,7 @@ export function Overview() {
             ) : topCitiesError ? (
               <div className="h-[220px] flex items-center justify-center text-red-300 text-sm">שגיאה בטעינת ערים</div>
             ) : topCities.length === 0 ? (
-              <EmptyState icon="📍" message="אין נתונים" />
+              <EmptyState icon={<MapPin size={36} />} message="אין נתונים" />
             ) : (
               <ResponsiveContainer width="100%" height={220}>
                 <BarChart data={topCities} layout="vertical" margin={{ right: 170, left: 8 }}>
@@ -325,7 +325,7 @@ export function Overview() {
           ) : byCategoryError ? (
             <div className="h-[260px] flex items-center justify-center text-red-300 text-sm">שגיאה בטעינת גרף</div>
           ) : byCategory.length === 0 ? (
-            <EmptyState icon="📊" message="אין נתונים לתקופה זו" />
+            <EmptyState icon={<BarChart2 size={36} />} message="אין נתונים לתקופה זו" />
           ) : (
             <ResponsiveContainer width="100%" height={260}>
               <BarChart data={chartData} margin={{ right: 16, bottom: 8 }}>

--- a/dashboard-ui/src/pages/SafetyCheck.tsx
+++ b/dashboard-ui/src/pages/SafetyCheck.tsx
@@ -66,14 +66,30 @@ function ChartTooltip({ active, payload, label }: { active?: boolean; payload?: 
 
 export function SafetyCheck() {
   const prefersReducedMotion = useReducedMotion();
-  const { data, isLoading } = useQuery<SafetyCheckData>({
+  const { data, isLoading, isError } = useQuery<SafetyCheckData>({
     queryKey: ['safety-check'],
     queryFn: () => api.get<SafetyCheckData>('/api/stats/safety-check'),
     refetchInterval: 30_000,
   });
 
-  if (isLoading || !data) {
+  if (isLoading) {
     return <Skeleton className="h-full min-h-[60vh]" />;
+  }
+
+  if (isError || !data) {
+    return (
+      <PageTransition>
+        <div className="p-8 text-center space-y-2">
+          <p className="text-red-300 text-sm">שגיאה בטעינת נתוני בדיקת שלומות</p>
+          <button
+            onClick={() => window.location.reload()}
+            className="text-xs text-text-muted underline"
+          >
+            רענן דף
+          </button>
+        </div>
+      </PageTransition>
+    );
   }
 
   const { kpis, trend, recentPrompts } = data;

--- a/dashboard-ui/src/pages/Subscribers.tsx
+++ b/dashboard-ui/src/pages/Subscribers.tsx
@@ -284,7 +284,7 @@ export function Subscribers() {
               ))}
             </div>
           ) : users.length === 0 ? (
-            <EmptyState icon="👥" message="לא נמצאו מנויים" />
+            <EmptyState icon={<Users size={36} />} message="לא נמצאו מנויים" />
           ) : (
             <>
               <table className="w-full text-sm">
@@ -470,7 +470,7 @@ export function Subscribers() {
                                               onClick={() =>
                                                 removeCityMutation.mutate({ id: user.chat_id, city })
                                               }
-                                              className="text-text-muted hover:text-red-400 mr-1"
+                                              className="text-text-muted hover:text-red-400 ms-1"
                                               title={`הסר ${city}`}
                                             >
                                               ×

--- a/dashboard-ui/src/pages/Subscribers.tsx
+++ b/dashboard-ui/src/pages/Subscribers.tsx
@@ -10,6 +10,7 @@ import { EmptyState } from '../components/EmptyState';
 import { Skeleton } from '../components/Skeleton';
 import { GlassCard } from '../components/ui/GlassCard';
 import { PageTransition } from '../components/ui/PageTransition';
+import { Pagination } from '../components/Pagination';
 
 interface User {
   chat_id: number;
@@ -287,6 +288,7 @@ export function Subscribers() {
             <EmptyState icon={<Users size={36} />} message="לא נמצאו מנויים" />
           ) : (
             <>
+              <div className="overflow-x-auto">
               <table className="w-full text-sm">
                 <thead>
                   <tr className="border-b border-[var(--color-border)] text-text-muted text-xs">
@@ -534,27 +536,15 @@ export function Subscribers() {
                   ))}
                 </tbody>
               </table>
-
-              {/* Pagination */}
-              <div className="flex items-center justify-between px-4 py-3 border-t border-[var(--color-border)]">
-                <button
-                  disabled={page === 0}
-                  onClick={() => setPage(p => p - 1)}
-                  className="text-text-muted text-xs hover:text-text-primary disabled:opacity-40"
-                >
-                  הקודם →
-                </button>
-                <span className="text-text-muted text-xs">
-                  עמוד {page + 1} · {total} סה״כ
-                </span>
-                <button
-                  disabled={users.length < PAGE_SIZE}
-                  onClick={() => setPage(p => p + 1)}
-                  className="text-text-muted text-xs hover:text-text-primary disabled:opacity-40"
-                >
-                  ← הבא
-                </button>
               </div>
+
+              <Pagination
+                page={page}
+                hasNext={users.length >= PAGE_SIZE}
+                onPrev={() => setPage(p => p - 1)}
+                onNext={() => setPage(p => p + 1)}
+                total={total}
+              />
             </>
           )}
         </GlassCard>

--- a/dashboard-ui/src/pages/TelegramListeners.tsx
+++ b/dashboard-ui/src/pages/TelegramListeners.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { Loader2, Phone, Unplug, MessageCircle } from 'lucide-react';
+import { Loader2, Phone, Unplug, MessageCircle, Radio } from 'lucide-react';
 import { api } from '../api/client';
 import { GlassCard } from '../components/ui/GlassCard';
 import { PageTransition } from '../components/ui/PageTransition';
@@ -480,7 +480,7 @@ export function TelegramListeners() {
             </div>
           ) : !rules || rules.length === 0 ? (
             <div className="py-6">
-              <EmptyState icon="📡" message="אין כללי האזנה עדיין" />
+              <EmptyState icon={<Radio size={36} />} message="אין כללי האזנה עדיין" />
               <p className="text-center text-text-muted text-xs -mt-2">מלא את הטופס למטה כדי להוסיף כלל ראשון</p>
             </div>
           ) : (

--- a/dashboard-ui/src/pages/WhatsApp.tsx
+++ b/dashboard-ui/src/pages/WhatsApp.tsx
@@ -167,7 +167,7 @@ function GroupRow({ group, onUpdate }: { group: WhatsAppGroup; onUpdate: (groupI
         <span className={`text-sm ${group.enabled ? 'font-semibold text-text-primary' : 'text-text-secondary'}`}>
           {group.name}
           {!group.inClient && (
-            <span className="mr-2 text-xs px-1.5 py-0.5 rounded bg-white/5 text-text-muted border border-border">
+            <span className="ms-2 text-xs px-1.5 py-0.5 rounded bg-white/5 text-text-muted border border-border">
               לא בחשבון
             </span>
           )}

--- a/dashboard-ui/src/pages/WhatsAppListeners.tsx
+++ b/dashboard-ui/src/pages/WhatsAppListeners.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
-import { Rss } from 'lucide-react';
+import { Rss, Radio } from 'lucide-react';
 import { api } from '../api/client';
 import { GlassCard } from '../components/ui/GlassCard';
 import { PageTransition } from '../components/ui/PageTransition';
@@ -248,7 +248,7 @@ export function WhatsAppListeners() {
             </div>
           ) : !rules || rules.length === 0 ? (
             <div className="py-6">
-              <EmptyState icon="📡" message="אין כללי האזנה עדיין" />
+              <EmptyState icon={<Radio size={36} />} message="אין כללי האזנה עדיין" />
               <p className="text-center text-text-muted text-xs -mt-2">מלא את הטופס למטה כדי להוסיף כלל ראשון</p>
             </div>
           ) : (

--- a/dashboard-ui/src/pages/whatsapp-listeners/SourceSelector.tsx
+++ b/dashboard-ui/src/pages/whatsapp-listeners/SourceSelector.tsx
@@ -142,7 +142,7 @@ export function SourceSelector({ chats, value, onChange, disabled, whatsappConne
                   }`}
                 >
                   {tab.label}
-                  <span className="mr-1 text-text-muted">({tab.count})</span>
+                  <span className="ms-1 text-text-muted">({tab.count})</span>
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## Summary

Complete UI/UX audit and improvement pass on the admin dashboard (`dashboard-ui/`), split across three focused commits.

### Phase 1 — Accessibility & Critical Fixes
- **C1+C2 — ConfirmModal**: Added `role="dialog"`, `aria-labelledby`/`aria-describedby` via `useId()`, `react-focus-lock` focus trap (handles iOS Safari edge cases), and `AnimatePresence` scale+fade entrance/exit animation
- **C4+M4 — StatusStrip**: Added `aria-live="polite"` + `aria-label` to all three render branches (loading/error/healthy); dynamic `border-top` color (green=healthy, red=error) instead of always-amber
- **C6 — Overview + SafetyCheck**: All 4 `useQuery` calls in Overview now expose `isError` with per-section error UI (each section fails independently). SafetyCheck splits `isLoading` from `isError` so errors show a retry prompt instead of an infinite skeleton
- **H1 — Token cleanup**: Replaced all raw `text-gray-{300,400,500}` with semantic tokens (`text-text-primary` / `text-text-secondary` / `text-text-muted`) in `Groups.tsx`

### Phase 2 — Visual Consistency & UX Patterns
- **H3 — Skeleton shimmer**: CSS keyframe gradient sweep (`skeleton-shimmer` in `index.css`) replaces `animate-pulse`; adds `height`/`width` props
- **H8 — Root max-width**: Page content wrapped in `max-w-[1600px] mx-auto` — sidebar unaffected, content bounded on ultra-wide displays
- **H7 — Login redesign**: `GlassCard` + `PageTransition` + `ShieldCheck` icon; `min-h-dvh`; `sr-only` label + `autocomplete="current-password"`; keeps existing `bg-base` background
- **H10 — RTL logical properties**: Physical `mr-`/`ml-`/`pr-`/`pl-` → logical `ms-`/`me-`/`ps-`/`pe-` across Sidebar, StatusStrip, Groups, Subscribers, WhatsApp, whatsapp-listeners SourceSelector. `border-r/l` intentionally preserved (per RTL design convention)
- **M1 — EmptyState**: `icon` prop widened to `ReactNode` (default: `<Inbox />`); all 12 call sites updated to Lucide JSX
- **M2 — CommandPalette**: PAGES array uses `LucideIcon` components instead of emoji strings

### Phase 3 — Architecture & Polish
- **H4 — Shared Pagination**: Extracted `components/Pagination.tsx`; props: `page`, `onPrev`, `onNext`, `hasNext`, optional `total`. Wired into Alerts (URL-param state) and Subscribers (useState)
- **H6 — AlertCategoryStats**: Progress bar height `h-1.5` → `h-2` for better dark-mode visibility
- **H9 — Subscribers**: Table wrapped in `overflow-x-auto` to prevent layout breakage at narrow viewports
- **M3 — GlassCard hover**: `hoverable` scale `1.01` → `1.015` for more perceptible hover feedback
- **M6 — Overview separator**: `border-t` `<hr>` between KPI grid and charts for visual hierarchy

## Files changed (17)
`dashboard-ui/package.json` · `src/index.css` · `src/layout/Root.tsx` · `src/layout/Sidebar.tsx` · `src/layout/StatusStrip.tsx` · `src/layout/CommandPalette.tsx` · `src/components/ConfirmModal.tsx` · `src/components/EmptyState.tsx` · `src/components/Skeleton.tsx` · `src/components/Pagination.tsx` *(new)* · `src/components/AlertCategoryStats.tsx` · `src/components/ui/GlassCard.tsx` · `src/pages/Login.tsx` · `src/pages/Overview.tsx` · `src/pages/SafetyCheck.tsx` · `src/pages/Groups.tsx` · `src/pages/{Alerts,Subscribers,WhatsApp,WhatsAppListeners,TelegramListeners}.tsx`

## Test plan
- [ ] Open ConfirmModal with VoiceOver/NVDA → announces `role="dialog"` and title
- [ ] Tab inside ConfirmModal → focus stays trapped; closes on cancel/confirm
- [ ] Kill API server, visit Overview → each section (KPIs, live alerts, top cities, chart) shows error UI independently
- [ ] Visit SafetyCheck with API down → shows retry prompt, not skeleton
- [ ] Check StatusStrip with screen reader → `aria-live` region announced on update
- [ ] StatusStrip healthy state → green border-top; error state → red
- [ ] Resize to 1920px+ → content stays within `max-w-[1600px]`
- [ ] Visit `/login` → GlassCard, ShieldCheck icon, PageTransition fade
- [ ] Check Skeleton in dark mode → shimmer gradient visible
- [ ] Open ⌘K → Lucide icons render next to each nav item
- [ ] Empty state for any page → Lucide icon renders, no emoji
- [ ] Subscribers/Alerts pagination → shared component renders correctly in both
- [ ] Resize Subscribers to 375px → table scrolls horizontally

Closes #(none — audit-driven improvement, no issue)